### PR TITLE
Make after_export parser callback pass a WasmExport* instead of just int

### DIFF
--- a/src/wasm-gen.c
+++ b/src/wasm-gen.c
@@ -338,10 +338,10 @@ static void after_function(WasmModule* module,
 static void before_export(WasmModule* module, void* user_data) {}
 
 static void after_export(WasmModule* module,
-                         int function_index,
+                         WasmExport* export,
                          void* user_data) {
   Context* ctx = user_data;
-  WasmFunction* exported = &module->functions.data[function_index];
+  WasmFunction* exported = &module->functions.data[export->index];
   out_u8_at(ctx->buf, exported->offset + FUNCTION_EXPORTED_OFFSET, 1,
             "FIXUP func exported");
 }

--- a/src/wasm-parse.c
+++ b/src/wasm-parse.c
@@ -1490,7 +1490,7 @@ static void parse_module(WasmParser* parser, WasmTokenizer* tokenizer) {
         export->index = index;
 
         expect_close(read_token(tokenizer));
-        parser->after_export(&module, index, parser->user_data);
+        parser->after_export(&module, export, parser->user_data);
         break;
       }
 

--- a/src/wasm-parse.h
+++ b/src/wasm-parse.h
@@ -28,7 +28,7 @@ typedef struct WasmParser {
                          void* user_data);
   void (*before_export)(struct WasmModule* m, void* user_data);
   void (*after_export)(struct WasmModule* m,
-                       int function_index,
+                       struct WasmExport* e,
                        void* user_data);
 
   void (*before_binary)(enum WasmOpcode opcode, void* user_data);


### PR DESCRIPTION
This allows getting the export name without having to get the module and
peek at the back of the export vector.