### PR TITLE
Rename assert_eq to assert_return

### DIFF
--- a/src/wasm-gen.c
+++ b/src/wasm-gen.c
@@ -987,7 +987,7 @@ static void after_assert_return(WasmType type,
   out_u8_at(&ctx->buf, offset, opcode, "FIXUP assert_return opcode");
 
   char name[256];
-  snprintf(name, 256, "$assert_return_%d", ctx->assert_return_count++);
+  snprintf(name, 256, "$assert_eq_%d", ctx->assert_return_count++);
   append_nullary_function(ctx, name, WASM_TYPE_I32);
 
   ctx->in_assert = 0;

--- a/src/wasm-keywords.gperf
+++ b/src/wasm-keywords.gperf
@@ -7,7 +7,8 @@ struct OpInfo {
   int access;
 };
 %%
-assert_eq, WASM_OP_ASSERT_EQ
+assert_eq, WASM_OP_ASSERT_RETURN
+assert_return, WASM_OP_ASSERT_RETURN
 assert_invalid, WASM_OP_ASSERT_INVALID
 assert_trap, WASM_OP_ASSERT_TRAP
 block, WASM_OP_BLOCK, WASM_OPCODE_EXPR_BLOCK

--- a/src/wasm-keywords.h
+++ b/src/wasm-keywords.h
@@ -39,7 +39,7 @@ struct OpInfo {
   int access;
 };
 
-#define TOTAL_KEYWORDS 180
+#define TOTAL_KEYWORDS 181
 #define MIN_WORD_LENGTH 2
 #define MAX_WORD_LENGTH 19
 #define MIN_HASH_VALUE 16
@@ -139,455 +139,456 @@ in_word_set (str, len)
     {
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 152 "src/wasm-keywords.gperf"
+#line 153 "src/wasm-keywords.gperf"
       {"i64.or", WASM_OP_BINARY, WASM_OPCODE_I64_OR, WASM_TYPE_I64},
       {""},
-#line 137 "src/wasm-keywords.gperf"
+#line 138 "src/wasm-keywords.gperf"
       {"i64.gt_s", WASM_OP_COMPARE, WASM_OPCODE_I64_SGT, WASM_TYPE_I64},
       {""}, {""},
-#line 106 "src/wasm-keywords.gperf"
+#line 107 "src/wasm-keywords.gperf"
       {"i32.or", WASM_OP_BINARY, WASM_OPCODE_I32_OR, WASM_TYPE_I32},
-#line 171 "src/wasm-keywords.gperf"
+#line 172 "src/wasm-keywords.gperf"
       {"if", WASM_OP_IF, WASM_OPCODE_IF},
-#line 92 "src/wasm-keywords.gperf"
+#line 93 "src/wasm-keywords.gperf"
       {"i32.gt_s", WASM_OP_COMPARE, WASM_OPCODE_I32_SGT, WASM_TYPE_I32},
       {""}, {""},
-#line 62 "src/wasm-keywords.gperf"
+#line 63 "src/wasm-keywords.gperf"
       {"f64.gt", WASM_OP_COMPARE, WASM_OPCODE_F64_GT, WASM_TYPE_F64},
       {""},
-#line 135 "src/wasm-keywords.gperf"
+#line 136 "src/wasm-keywords.gperf"
       {"i64.ge_s", WASM_OP_COMPARE, WASM_OPCODE_I64_SGE, WASM_TYPE_I64},
       {""}, {""},
-#line 33 "src/wasm-keywords.gperf"
+#line 34 "src/wasm-keywords.gperf"
       {"f32.gt", WASM_OP_COMPARE, WASM_OPCODE_F32_GT, WASM_TYPE_F32},
       {""},
-#line 90 "src/wasm-keywords.gperf"
+#line 91 "src/wasm-keywords.gperf"
       {"i32.ge_s", WASM_OP_COMPARE, WASM_OPCODE_I32_SGE, WASM_TYPE_I32},
       {""}, {""},
-#line 160 "src/wasm-keywords.gperf"
+#line 161 "src/wasm-keywords.gperf"
       {"i64.store16", WASM_OP_STORE, WASM_OPCODE_I64_STORE_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I16, 5},
       {""}, {""},
-#line 155 "src/wasm-keywords.gperf"
+#line 156 "src/wasm-keywords.gperf"
       {"i64.rem_s", WASM_OP_BINARY, WASM_OPCODE_I64_SREM, WASM_TYPE_I64},
       {""},
-#line 114 "src/wasm-keywords.gperf"
+#line 115 "src/wasm-keywords.gperf"
       {"i32.store16", WASM_OP_STORE, WASM_OPCODE_I32_STORE_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I16, 5},
       {""}, {""},
-#line 109 "src/wasm-keywords.gperf"
+#line 110 "src/wasm-keywords.gperf"
       {"i32.rem_s", WASM_OP_BINARY, WASM_OPCODE_I32_SREM, WASM_TYPE_I32},
       {""},
-#line 61 "src/wasm-keywords.gperf"
+#line 62 "src/wasm-keywords.gperf"
       {"f64.ge", WASM_OP_COMPARE, WASM_OPCODE_F64_GE, WASM_TYPE_F64},
       {""},
-#line 148 "src/wasm-keywords.gperf"
+#line 149 "src/wasm-keywords.gperf"
       {"i64.lt_s", WASM_OP_COMPARE, WASM_OPCODE_I64_SLT, WASM_TYPE_I64},
-#line 163 "src/wasm-keywords.gperf"
+#line 164 "src/wasm-keywords.gperf"
       {"i64.store", WASM_OP_STORE, WASM_OPCODE_I64_STORE_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I64, 7},
-#line 189 "src/wasm-keywords.gperf"
+#line 190 "src/wasm-keywords.gperf"
       {"table", WASM_OP_TABLE},
-#line 32 "src/wasm-keywords.gperf"
+#line 33 "src/wasm-keywords.gperf"
       {"f32.ge", WASM_OP_COMPARE, WASM_OPCODE_F32_GE, WASM_TYPE_F32},
       {""},
-#line 101 "src/wasm-keywords.gperf"
+#line 102 "src/wasm-keywords.gperf"
       {"i32.lt_s", WASM_OP_COMPARE, WASM_OPCODE_I32_SLT, WASM_TYPE_I32},
-#line 116 "src/wasm-keywords.gperf"
+#line 117 "src/wasm-keywords.gperf"
       {"i32.store", WASM_OP_STORE, WASM_OPCODE_I32_STORE_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I32, 6},
       {""},
-#line 65 "src/wasm-keywords.gperf"
+#line 66 "src/wasm-keywords.gperf"
       {"f64.lt", WASM_OP_COMPARE, WASM_OPCODE_F64_LT, WASM_TYPE_F64},
       {""},
-#line 139 "src/wasm-keywords.gperf"
+#line 140 "src/wasm-keywords.gperf"
       {"i64.le_s", WASM_OP_COMPARE, WASM_OPCODE_I64_SLE, WASM_TYPE_I64},
-#line 75 "src/wasm-keywords.gperf"
+#line 76 "src/wasm-keywords.gperf"
       {"f64.store", WASM_OP_STORE, WASM_OPCODE_F64_STORE_I32, WASM_TYPE_F64, WASM_MEM_TYPE_F64, 0},
       {""},
-#line 36 "src/wasm-keywords.gperf"
+#line 37 "src/wasm-keywords.gperf"
       {"f32.lt", WASM_OP_COMPARE, WASM_OPCODE_F32_LT, WASM_TYPE_F32},
       {""},
-#line 94 "src/wasm-keywords.gperf"
+#line 95 "src/wasm-keywords.gperf"
       {"i32.le_s", WASM_OP_COMPARE, WASM_OPCODE_I32_SLE, WASM_TYPE_I32},
-#line 45 "src/wasm-keywords.gperf"
+#line 46 "src/wasm-keywords.gperf"
       {"f32.store", WASM_OP_STORE, WASM_OPCODE_F32_STORE_I32, WASM_TYPE_F32, WASM_MEM_TYPE_F32, 0},
       {""},
-#line 185 "src/wasm-keywords.gperf"
+#line 186 "src/wasm-keywords.gperf"
       {"result", WASM_OP_RESULT},
-#line 105 "src/wasm-keywords.gperf"
+#line 106 "src/wasm-keywords.gperf"
       {"i32.not", WASM_OP_UNARY, WASM_OPCODE_I32_NOT, WASM_TYPE_I32},
-#line 138 "src/wasm-keywords.gperf"
+#line 139 "src/wasm-keywords.gperf"
       {"i64.gt_u", WASM_OP_COMPARE, WASM_OPCODE_I64_UGT, WASM_TYPE_I64},
-#line 60 "src/wasm-keywords.gperf"
+#line 61 "src/wasm-keywords.gperf"
       {"f64.floor", WASM_OP_UNARY, WASM_OPCODE_F64_FLOOR, WASM_TYPE_F64},
       {""}, {""}, {""},
-#line 93 "src/wasm-keywords.gperf"
+#line 94 "src/wasm-keywords.gperf"
       {"i32.gt_u", WASM_OP_COMPARE, WASM_OPCODE_I32_UGT, WASM_TYPE_I32},
-#line 31 "src/wasm-keywords.gperf"
+#line 32 "src/wasm-keywords.gperf"
       {"f32.floor", WASM_OP_UNARY, WASM_OPCODE_F32_FLOOR, WASM_TYPE_F32},
       {""},
-#line 63 "src/wasm-keywords.gperf"
+#line 64 "src/wasm-keywords.gperf"
       {"f64.le", WASM_OP_COMPARE, WASM_OPCODE_F64_LE, WASM_TYPE_F64},
       {""},
-#line 136 "src/wasm-keywords.gperf"
+#line 137 "src/wasm-keywords.gperf"
       {"i64.ge_u", WASM_OP_COMPARE, WASM_OPCODE_I64_UGE, WASM_TYPE_I64},
-#line 128 "src/wasm-keywords.gperf"
+#line 129 "src/wasm-keywords.gperf"
       {"i64.const", WASM_OP_CONST, WASM_OPCODE_I64_CONST, WASM_TYPE_I64},
       {""},
-#line 34 "src/wasm-keywords.gperf"
+#line 35 "src/wasm-keywords.gperf"
       {"f32.le", WASM_OP_COMPARE, WASM_OPCODE_F32_LE, WASM_TYPE_F32},
-#line 70 "src/wasm-keywords.gperf"
+#line 71 "src/wasm-keywords.gperf"
       {"f64.neg", WASM_OP_UNARY, WASM_OPCODE_F64_NEG, WASM_TYPE_F64},
-#line 91 "src/wasm-keywords.gperf"
+#line 92 "src/wasm-keywords.gperf"
       {"i32.ge_u", WASM_OP_COMPARE, WASM_OPCODE_I32_UGE, WASM_TYPE_I32},
-#line 85 "src/wasm-keywords.gperf"
+#line 86 "src/wasm-keywords.gperf"
       {"i32.const", WASM_OP_CONST, WASM_OPCODE_I32_CONST, WASM_TYPE_I32},
       {""},
-#line 151 "src/wasm-keywords.gperf"
+#line 152 "src/wasm-keywords.gperf"
       {"i64.ne", WASM_OP_COMPARE, WASM_OPCODE_I64_NE, WASM_TYPE_I64},
-#line 41 "src/wasm-keywords.gperf"
+#line 42 "src/wasm-keywords.gperf"
       {"f32.neg", WASM_OP_UNARY, WASM_OPCODE_F32_NEG, WASM_TYPE_F32},
       {""},
-#line 52 "src/wasm-keywords.gperf"
+#line 53 "src/wasm-keywords.gperf"
       {"f64.const", WASM_OP_CONST, WASM_OPCODE_F64_CONST, WASM_TYPE_F64},
       {""},
-#line 104 "src/wasm-keywords.gperf"
+#line 105 "src/wasm-keywords.gperf"
       {"i32.ne", WASM_OP_COMPARE, WASM_OPCODE_I32_NE, WASM_TYPE_I32},
       {""}, {""},
-#line 22 "src/wasm-keywords.gperf"
+#line 23 "src/wasm-keywords.gperf"
       {"f32.const", WASM_OP_CONST, WASM_OPCODE_F32_CONST, WASM_TYPE_F32},
-#line 176 "src/wasm-keywords.gperf"
-      {"local", WASM_OP_LOCAL},
-#line 71 "src/wasm-keywords.gperf"
-      {"f64.ne", WASM_OP_COMPARE, WASM_OPCODE_F64_NE, WASM_TYPE_F64},
-#line 170 "src/wasm-keywords.gperf"
-      {"i64.xor", WASM_OP_BINARY, WASM_OPCODE_I64_XOR, WASM_TYPE_I64},
-#line 149 "src/wasm-keywords.gperf"
-      {"i64.lt_u", WASM_OP_COMPARE, WASM_OPCODE_I64_ULT, WASM_TYPE_I64},
 #line 177 "src/wasm-keywords.gperf"
+      {"local", WASM_OP_LOCAL},
+#line 72 "src/wasm-keywords.gperf"
+      {"f64.ne", WASM_OP_COMPARE, WASM_OPCODE_F64_NE, WASM_TYPE_F64},
+#line 171 "src/wasm-keywords.gperf"
+      {"i64.xor", WASM_OP_BINARY, WASM_OPCODE_I64_XOR, WASM_TYPE_I64},
+#line 150 "src/wasm-keywords.gperf"
+      {"i64.lt_u", WASM_OP_COMPARE, WASM_OPCODE_I64_ULT, WASM_TYPE_I64},
+#line 178 "src/wasm-keywords.gperf"
       {"loop", WASM_OP_LOOP, WASM_OPCODE_LOOP},
       {""},
-#line 42 "src/wasm-keywords.gperf"
+#line 43 "src/wasm-keywords.gperf"
       {"f32.ne", WASM_OP_COMPARE, WASM_OPCODE_F32_NE, WASM_TYPE_F32},
-#line 124 "src/wasm-keywords.gperf"
+#line 125 "src/wasm-keywords.gperf"
       {"i32.xor", WASM_OP_BINARY, WASM_OPCODE_I32_XOR, WASM_TYPE_I32},
-#line 102 "src/wasm-keywords.gperf"
+#line 103 "src/wasm-keywords.gperf"
       {"i32.lt_u", WASM_OP_COMPARE, WASM_OPCODE_I32_ULT, WASM_TYPE_I32},
-#line 17 "src/wasm-keywords.gperf"
+#line 18 "src/wasm-keywords.gperf"
       {"call", WASM_OP_CALL, WASM_OPCODE_CALL},
-#line 174 "src/wasm-keywords.gperf"
+#line 175 "src/wasm-keywords.gperf"
       {"label", WASM_OP_LABEL, WASM_OPCODE_INVALID},
-#line 81 "src/wasm-keywords.gperf"
+#line 82 "src/wasm-keywords.gperf"
       {"global", WASM_OP_GLOBAL},
-#line 129 "src/wasm-keywords.gperf"
+#line 130 "src/wasm-keywords.gperf"
       {"i64.ctz", WASM_OP_UNARY, WASM_OPCODE_I64_CTZ, WASM_TYPE_I64},
-#line 140 "src/wasm-keywords.gperf"
+#line 141 "src/wasm-keywords.gperf"
       {"i64.le_u", WASM_OP_COMPARE, WASM_OPCODE_I64_ULE, WASM_TYPE_I64},
       {""}, {""},
-#line 69 "src/wasm-keywords.gperf"
+#line 70 "src/wasm-keywords.gperf"
       {"f64.nearest", WASM_OP_UNARY, WASM_OPCODE_F64_NEAREST, WASM_TYPE_F64},
-#line 86 "src/wasm-keywords.gperf"
+#line 87 "src/wasm-keywords.gperf"
       {"i32.ctz", WASM_OP_UNARY, WASM_OPCODE_I32_CTZ, WASM_TYPE_I32},
-#line 95 "src/wasm-keywords.gperf"
+#line 96 "src/wasm-keywords.gperf"
       {"i32.le_u", WASM_OP_COMPARE, WASM_OPCODE_I32_ULE, WASM_TYPE_I32},
-#line 80 "src/wasm-keywords.gperf"
+#line 81 "src/wasm-keywords.gperf"
       {"get_local", WASM_OP_GET_LOCAL, WASM_OPCODE_GET_LOCAL},
       {""},
-#line 40 "src/wasm-keywords.gperf"
+#line 41 "src/wasm-keywords.gperf"
       {"f32.nearest", WASM_OP_UNARY, WASM_OPCODE_F32_NEAREST, WASM_TYPE_F32},
-#line 143 "src/wasm-keywords.gperf"
+#line 144 "src/wasm-keywords.gperf"
       {"i64.load32_s", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I32, 6},
-#line 181 "src/wasm-keywords.gperf"
+#line 182 "src/wasm-keywords.gperf"
       {"nop", WASM_OP_NOP, WASM_OPCODE_NOP, WASM_TYPE_VOID},
-#line 187 "src/wasm-keywords.gperf"
+#line 188 "src/wasm-keywords.gperf"
       {"set_local", WASM_OP_SET_LOCAL, WASM_OPCODE_SET_LOCAL},
       {""},
-#line 18 "src/wasm-keywords.gperf"
+#line 19 "src/wasm-keywords.gperf"
       {"export", WASM_OP_EXPORT},
       {""},
-#line 51 "src/wasm-keywords.gperf"
+#line 52 "src/wasm-keywords.gperf"
       {"f64.ceil", WASM_OP_UNARY, WASM_OPCODE_F64_CEIL, WASM_TYPE_F64},
       {""}, {""},
-#line 173 "src/wasm-keywords.gperf"
+#line 174 "src/wasm-keywords.gperf"
       {"invoke", WASM_OP_INVOKE},
       {""},
-#line 21 "src/wasm-keywords.gperf"
+#line 22 "src/wasm-keywords.gperf"
       {"f32.ceil", WASM_OP_UNARY, WASM_OPCODE_F32_CEIL, WASM_TYPE_F32},
-#line 79 "src/wasm-keywords.gperf"
+#line 80 "src/wasm-keywords.gperf"
       {"func", WASM_OP_FUNC},
-#line 153 "src/wasm-keywords.gperf"
+#line 154 "src/wasm-keywords.gperf"
       {"i64.popcnt", WASM_OP_UNARY, WASM_OPCODE_I64_POPCNT, WASM_TYPE_I64},
-#line 186 "src/wasm-keywords.gperf"
+#line 187 "src/wasm-keywords.gperf"
       {"return", WASM_OP_RETURN, WASM_OPCODE_RETURN},
-#line 127 "src/wasm-keywords.gperf"
+#line 128 "src/wasm-keywords.gperf"
       {"i64.clz", WASM_OP_UNARY, WASM_OPCODE_I64_CLZ, WASM_TYPE_I64},
-#line 74 "src/wasm-keywords.gperf"
+#line 75 "src/wasm-keywords.gperf"
       {"f64.sqrt", WASM_OP_UNARY, WASM_OPCODE_F64_SQRT, WASM_TYPE_F64},
       {""},
-#line 107 "src/wasm-keywords.gperf"
+#line 108 "src/wasm-keywords.gperf"
       {"i32.popcnt", WASM_OP_UNARY, WASM_OPCODE_I32_POPCNT, WASM_TYPE_I32},
-#line 161 "src/wasm-keywords.gperf"
+#line 162 "src/wasm-keywords.gperf"
       {"i64.store32", WASM_OP_STORE, WASM_OPCODE_I64_STORE_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I32, 6},
-#line 84 "src/wasm-keywords.gperf"
+#line 85 "src/wasm-keywords.gperf"
       {"i32.clz", WASM_OP_UNARY, WASM_OPCODE_I32_CLZ, WASM_TYPE_I32},
-#line 44 "src/wasm-keywords.gperf"
+#line 45 "src/wasm-keywords.gperf"
       {"f32.sqrt", WASM_OP_UNARY, WASM_OPCODE_F32_SQRT, WASM_TYPE_F32},
-#line 156 "src/wasm-keywords.gperf"
+#line 157 "src/wasm-keywords.gperf"
       {"i64.rem_u", WASM_OP_BINARY, WASM_OPCODE_I64_UREM, WASM_TYPE_I64},
       {""}, {""}, {""},
-#line 158 "src/wasm-keywords.gperf"
+#line 159 "src/wasm-keywords.gperf"
       {"i64.shr_s", WASM_OP_BINARY, WASM_OPCODE_I64_SAR, WASM_TYPE_I64},
-#line 110 "src/wasm-keywords.gperf"
+#line 111 "src/wasm-keywords.gperf"
       {"i32.rem_u", WASM_OP_BINARY, WASM_OPCODE_I32_UREM, WASM_TYPE_I32},
       {""}, {""}, {""},
-#line 112 "src/wasm-keywords.gperf"
+#line 113 "src/wasm-keywords.gperf"
       {"i32.shr_s", WASM_OP_BINARY, WASM_OPCODE_I32_SAR, WASM_TYPE_I32},
-#line 78 "src/wasm-keywords.gperf"
+#line 79 "src/wasm-keywords.gperf"
       {"f64.trunc", WASM_OP_UNARY, WASM_OPCODE_F64_TRUNC, WASM_TYPE_F64},
-#line 166 "src/wasm-keywords.gperf"
+#line 167 "src/wasm-keywords.gperf"
       {"i64.trunc_s/f32", WASM_OP_CONVERT, WASM_OPCODE_I64_SCONVERT_F32, WASM_TYPE_I64, WASM_TYPE_F32},
-#line 15 "src/wasm-keywords.gperf"
+#line 16 "src/wasm-keywords.gperf"
       {"call_import", WASM_OP_CALL_IMPORT, WASM_OPCODE_CALL},
       {""}, {""},
-#line 48 "src/wasm-keywords.gperf"
+#line 49 "src/wasm-keywords.gperf"
       {"f32.trunc", WASM_OP_UNARY, WASM_OPCODE_F32_TRUNC, WASM_TYPE_F32},
-#line 119 "src/wasm-keywords.gperf"
+#line 120 "src/wasm-keywords.gperf"
       {"i32.trunc_s/f32", WASM_OP_CONVERT, WASM_OPCODE_I32_SCONVERT_F32, WASM_TYPE_I32, WASM_TYPE_F32},
       {""},
-#line 141 "src/wasm-keywords.gperf"
+#line 142 "src/wasm-keywords.gperf"
       {"i64.load16_s", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I16, 5},
       {""},
-#line 130 "src/wasm-keywords.gperf"
+#line 131 "src/wasm-keywords.gperf"
       {"i64.div_s", WASM_OP_BINARY, WASM_OPCODE_I64_SDIV, WASM_TYPE_I64},
       {""},
-#line 157 "src/wasm-keywords.gperf"
+#line 158 "src/wasm-keywords.gperf"
       {"i64.shl", WASM_OP_BINARY, WASM_OPCODE_I64_SHL, WASM_TYPE_I64},
-#line 96 "src/wasm-keywords.gperf"
+#line 97 "src/wasm-keywords.gperf"
       {"i32.load16_s", WASM_OP_LOAD, WASM_OPCODE_I32_LOAD_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I16, 5},
-#line 184 "src/wasm-keywords.gperf"
+#line 185 "src/wasm-keywords.gperf"
       {"resize_memory", WASM_OP_RESIZE_MEMORY, WASM_OPCODE_RESIZE_MEMORY_I32},
-#line 87 "src/wasm-keywords.gperf"
+#line 88 "src/wasm-keywords.gperf"
       {"i32.div_s", WASM_OP_BINARY, WASM_OPCODE_I32_SDIV, WASM_TYPE_I32},
       {""},
-#line 111 "src/wasm-keywords.gperf"
+#line 112 "src/wasm-keywords.gperf"
       {"i32.shl", WASM_OP_BINARY, WASM_OPCODE_I32_SHL, WASM_TYPE_I32},
-#line 188 "src/wasm-keywords.gperf"
+#line 189 "src/wasm-keywords.gperf"
       {"store_global", WASM_OP_STORE_GLOBAL, WASM_OPCODE_SET_GLOBAL},
       {""}, {""},
-#line 72 "src/wasm-keywords.gperf"
+#line 73 "src/wasm-keywords.gperf"
       {"f64.promote/f32", WASM_OP_CONVERT, WASM_OPCODE_F64_CONVERT_F32, WASM_TYPE_F64, WASM_TYPE_F32},
-#line 12 "src/wasm-keywords.gperf"
+#line 13 "src/wasm-keywords.gperf"
       {"assert_trap", WASM_OP_ASSERT_TRAP},
-#line 58 "src/wasm-keywords.gperf"
+#line 59 "src/wasm-keywords.gperf"
       {"f64.div", WASM_OP_BINARY, WASM_OPCODE_F64_DIV, WASM_TYPE_F64},
       {""},
-#line 108 "src/wasm-keywords.gperf"
+#line 109 "src/wasm-keywords.gperf"
       {"i32.reinterpret/f32", WASM_OP_CONVERT, WASM_OPCODE_I32_REINTERPRET_F32, WASM_TYPE_I32, WASM_TYPE_F32},
-#line 162 "src/wasm-keywords.gperf"
+#line 163 "src/wasm-keywords.gperf"
       {"i64.store8", WASM_OP_STORE, WASM_OPCODE_I64_STORE_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I8, 4},
       {""},
-#line 29 "src/wasm-keywords.gperf"
+#line 30 "src/wasm-keywords.gperf"
       {"f32.div", WASM_OP_BINARY, WASM_OPCODE_F32_DIV, WASM_TYPE_F32},
-#line 147 "src/wasm-keywords.gperf"
+#line 148 "src/wasm-keywords.gperf"
       {"i64.load", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I64, 7},
-#line 182 "src/wasm-keywords.gperf"
+#line 183 "src/wasm-keywords.gperf"
       {"page_size", WASM_OP_PAGE_SIZE, WASM_OPCODE_PAGE_SIZE},
-#line 115 "src/wasm-keywords.gperf"
+#line 116 "src/wasm-keywords.gperf"
       {"i32.store8", WASM_OP_STORE, WASM_OPCODE_I32_STORE_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I8, 4},
       {""}, {""},
-#line 100 "src/wasm-keywords.gperf"
+#line 101 "src/wasm-keywords.gperf"
       {"i32.load", WASM_OP_LOAD, WASM_OPCODE_I32_LOAD_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I32, 6},
-#line 43 "src/wasm-keywords.gperf"
+#line 44 "src/wasm-keywords.gperf"
       {"f32.reinterpret/i32", WASM_OP_CONVERT, WASM_OPCODE_F32_REINTERPRET_I32, WASM_TYPE_F32, WASM_TYPE_I32},
       {""}, {""},
-#line 57 "src/wasm-keywords.gperf"
+#line 58 "src/wasm-keywords.gperf"
       {"f64.copysign", WASM_OP_BINARY, WASM_OPCODE_F64_COPYSIGN, WASM_TYPE_F64},
-#line 64 "src/wasm-keywords.gperf"
+#line 65 "src/wasm-keywords.gperf"
       {"f64.load", WASM_OP_LOAD, WASM_OPCODE_F64_LOAD_I32, WASM_TYPE_F64, WASM_MEM_TYPE_F64, 0},
       {""}, {""},
-#line 145 "src/wasm-keywords.gperf"
+#line 146 "src/wasm-keywords.gperf"
       {"i64.load8_s", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I8, 4},
-#line 27 "src/wasm-keywords.gperf"
+#line 28 "src/wasm-keywords.gperf"
       {"f32.copysign", WASM_OP_BINARY, WASM_OPCODE_F32_COPYSIGN, WASM_TYPE_F32},
-#line 35 "src/wasm-keywords.gperf"
+#line 36 "src/wasm-keywords.gperf"
       {"f32.load", WASM_OP_LOAD, WASM_OPCODE_F32_LOAD_I32, WASM_TYPE_F32, WASM_MEM_TYPE_F32, 0},
       {""}, {""},
-#line 98 "src/wasm-keywords.gperf"
+#line 99 "src/wasm-keywords.gperf"
       {"i32.load8_s", WASM_OP_LOAD, WASM_OPCODE_I32_LOAD_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I8, 4},
-#line 49 "src/wasm-keywords.gperf"
+#line 50 "src/wasm-keywords.gperf"
       {"f64.abs", WASM_OP_UNARY, WASM_OPCODE_F64_ABS, WASM_TYPE_F64},
       {""}, {""},
-#line 168 "src/wasm-keywords.gperf"
+#line 169 "src/wasm-keywords.gperf"
       {"i64.trunc_u/f32", WASM_OP_CONVERT, WASM_OPCODE_I64_UCONVERT_F32, WASM_TYPE_I64, WASM_TYPE_F32},
       {""},
-#line 19 "src/wasm-keywords.gperf"
+#line 20 "src/wasm-keywords.gperf"
       {"f32.abs", WASM_OP_UNARY, WASM_OPCODE_F32_ABS, WASM_TYPE_F32},
       {""},
-#line 165 "src/wasm-keywords.gperf"
+#line 166 "src/wasm-keywords.gperf"
       {"i64.switch", WASM_OP_SWITCH, WASM_OPCODE_INVALID, WASM_TYPE_I64},
-#line 121 "src/wasm-keywords.gperf"
+#line 122 "src/wasm-keywords.gperf"
       {"i32.trunc_u/f32", WASM_OP_CONVERT, WASM_OPCODE_I32_UCONVERT_F32, WASM_TYPE_I32, WASM_TYPE_F32},
       {""},
-#line 126 "src/wasm-keywords.gperf"
+#line 127 "src/wasm-keywords.gperf"
       {"i64.and", WASM_OP_BINARY, WASM_OPCODE_I64_AND, WASM_TYPE_I64},
       {""},
-#line 118 "src/wasm-keywords.gperf"
+#line 119 "src/wasm-keywords.gperf"
       {"i32.switch", WASM_OP_SWITCH, WASM_OPCODE_SWITCH, WASM_TYPE_I32},
-#line 167 "src/wasm-keywords.gperf"
+#line 168 "src/wasm-keywords.gperf"
       {"i64.trunc_s/f64", WASM_OP_CONVERT, WASM_OPCODE_I64_SCONVERT_F64, WASM_TYPE_I64, WASM_TYPE_F64},
       {""},
-#line 83 "src/wasm-keywords.gperf"
+#line 84 "src/wasm-keywords.gperf"
       {"i32.and", WASM_OP_BINARY, WASM_OPCODE_I32_AND, WASM_TYPE_I32},
-      {""},
-#line 77 "src/wasm-keywords.gperf"
+#line 11 "src/wasm-keywords.gperf"
+      {"assert_return", WASM_OP_ASSERT_RETURN},
+#line 78 "src/wasm-keywords.gperf"
       {"f64.switch", WASM_OP_SWITCH, WASM_OPCODE_INVALID, WASM_TYPE_F64},
-#line 120 "src/wasm-keywords.gperf"
+#line 121 "src/wasm-keywords.gperf"
       {"i32.trunc_s/f64", WASM_OP_CONVERT, WASM_OPCODE_I32_SCONVERT_F64, WASM_TYPE_I32, WASM_TYPE_F64},
       {""},
-#line 144 "src/wasm-keywords.gperf"
+#line 145 "src/wasm-keywords.gperf"
       {"i64.load32_u", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I32, 2},
       {""},
-#line 47 "src/wasm-keywords.gperf"
+#line 48 "src/wasm-keywords.gperf"
       {"f32.switch", WASM_OP_SWITCH, WASM_OPCODE_INVALID, WASM_TYPE_F32},
       {""}, {""},
-#line 53 "src/wasm-keywords.gperf"
+#line 54 "src/wasm-keywords.gperf"
       {"f64.convert_s/i32", WASM_OP_CONVERT, WASM_OPCODE_F64_SCONVERT_I32, WASM_TYPE_F64, WASM_TYPE_I32},
       {""}, {""}, {""}, {""},
-#line 23 "src/wasm-keywords.gperf"
+#line 24 "src/wasm-keywords.gperf"
       {"f32.convert_s/i32", WASM_OP_CONVERT, WASM_OPCODE_F32_SCONVERT_I32, WASM_TYPE_F32, WASM_TYPE_I32},
-#line 16 "src/wasm-keywords.gperf"
+#line 17 "src/wasm-keywords.gperf"
       {"call_indirect", WASM_OP_CALL_INDIRECT, WASM_OPCODE_CALL_INDIRECT},
-#line 154 "src/wasm-keywords.gperf"
+#line 155 "src/wasm-keywords.gperf"
       {"i64.reinterpret/f64", WASM_OP_CONVERT, WASM_OPCODE_I64_REINTERPRET_F64, WASM_TYPE_I64, WASM_TYPE_F64},
       {""},
-#line 132 "src/wasm-keywords.gperf"
+#line 133 "src/wasm-keywords.gperf"
       {"i64.eq", WASM_OP_COMPARE, WASM_OPCODE_I64_EQ, WASM_TYPE_I64},
-#line 164 "src/wasm-keywords.gperf"
+#line 165 "src/wasm-keywords.gperf"
       {"i64.sub", WASM_OP_BINARY, WASM_OPCODE_I64_SUB, WASM_TYPE_I64},
       {""}, {""}, {""},
-#line 89 "src/wasm-keywords.gperf"
+#line 90 "src/wasm-keywords.gperf"
       {"i32.eq", WASM_OP_COMPARE, WASM_OPCODE_I32_EQ, WASM_TYPE_I32},
-#line 117 "src/wasm-keywords.gperf"
+#line 118 "src/wasm-keywords.gperf"
       {"i32.sub", WASM_OP_BINARY, WASM_OPCODE_I32_SUB, WASM_TYPE_I32},
       {""},
-#line 73 "src/wasm-keywords.gperf"
+#line 74 "src/wasm-keywords.gperf"
       {"f64.reinterpret/i64", WASM_OP_CONVERT, WASM_OPCODE_F64_REINTERPRET_I64, WASM_TYPE_F64, WASM_TYPE_I64},
       {""},
-#line 59 "src/wasm-keywords.gperf"
+#line 60 "src/wasm-keywords.gperf"
       {"f64.eq", WASM_OP_COMPARE, WASM_OPCODE_F64_EQ, WASM_TYPE_F64},
-#line 76 "src/wasm-keywords.gperf"
+#line 77 "src/wasm-keywords.gperf"
       {"f64.sub", WASM_OP_BINARY, WASM_OPCODE_F64_SUB, WASM_TYPE_F64},
-#line 159 "src/wasm-keywords.gperf"
+#line 160 "src/wasm-keywords.gperf"
       {"i64.shr_u", WASM_OP_BINARY, WASM_OPCODE_I64_SHR, WASM_TYPE_I64},
 #line 10 "src/wasm-keywords.gperf"
-      {"assert_eq", WASM_OP_ASSERT_EQ},
+      {"assert_eq", WASM_OP_ASSERT_RETURN},
       {""},
-#line 30 "src/wasm-keywords.gperf"
+#line 31 "src/wasm-keywords.gperf"
       {"f32.eq", WASM_OP_COMPARE, WASM_OPCODE_F32_EQ, WASM_TYPE_F32},
-#line 46 "src/wasm-keywords.gperf"
+#line 47 "src/wasm-keywords.gperf"
       {"f32.sub", WASM_OP_BINARY, WASM_OPCODE_F32_SUB, WASM_TYPE_F32},
-#line 113 "src/wasm-keywords.gperf"
+#line 114 "src/wasm-keywords.gperf"
       {"i32.shr_u", WASM_OP_BINARY, WASM_OPCODE_I32_SHR, WASM_TYPE_I32},
       {""}, {""}, {""},
-#line 123 "src/wasm-keywords.gperf"
+#line 124 "src/wasm-keywords.gperf"
       {"i32.wrap/i64", WASM_OP_CONVERT, WASM_OPCODE_I32_CONVERT_I64, WASM_TYPE_I32, WASM_TYPE_I64},
       {""}, {""},
-#line 14 "src/wasm-keywords.gperf"
+#line 15 "src/wasm-keywords.gperf"
       {"break", WASM_OP_BREAK, WASM_OPCODE_BREAK},
       {""},
-#line 142 "src/wasm-keywords.gperf"
+#line 143 "src/wasm-keywords.gperf"
       {"i64.load16_u", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I16, 1},
       {""},
-#line 131 "src/wasm-keywords.gperf"
+#line 132 "src/wasm-keywords.gperf"
       {"i64.div_u", WASM_OP_BINARY, WASM_OPCODE_I64_UDIV, WASM_TYPE_I64},
-#line 169 "src/wasm-keywords.gperf"
+#line 170 "src/wasm-keywords.gperf"
       {"i64.trunc_u/f64", WASM_OP_CONVERT, WASM_OPCODE_I64_UCONVERT_F64, WASM_TYPE_I64, WASM_TYPE_F64},
       {""},
-#line 97 "src/wasm-keywords.gperf"
+#line 98 "src/wasm-keywords.gperf"
       {"i32.load16_u", WASM_OP_LOAD, WASM_OPCODE_I32_LOAD_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I16, 1},
       {""},
-#line 88 "src/wasm-keywords.gperf"
+#line 89 "src/wasm-keywords.gperf"
       {"i32.div_u", WASM_OP_BINARY, WASM_OPCODE_I32_UDIV, WASM_TYPE_I32},
-#line 122 "src/wasm-keywords.gperf"
+#line 123 "src/wasm-keywords.gperf"
       {"i32.trunc_u/f64", WASM_OP_CONVERT, WASM_OPCODE_I32_UCONVERT_F64, WASM_TYPE_I32, WASM_TYPE_F64},
       {""}, {""}, {""},
-#line 11 "src/wasm-keywords.gperf"
+#line 12 "src/wasm-keywords.gperf"
       {"assert_invalid", WASM_OP_ASSERT_INVALID},
       {""},
-#line 172 "src/wasm-keywords.gperf"
+#line 173 "src/wasm-keywords.gperf"
       {"import", WASM_OP_IMPORT},
-#line 55 "src/wasm-keywords.gperf"
+#line 56 "src/wasm-keywords.gperf"
       {"f64.convert_u/i32", WASM_OP_CONVERT, WASM_OPCODE_F64_UCONVERT_I32, WASM_TYPE_F64, WASM_TYPE_I32},
       {""}, {""}, {""}, {""},
-#line 25 "src/wasm-keywords.gperf"
+#line 26 "src/wasm-keywords.gperf"
       {"f32.convert_u/i32", WASM_OP_CONVERT, WASM_OPCODE_F32_UCONVERT_I32, WASM_TYPE_F32, WASM_TYPE_I32},
       {""}, {""},
-#line 13 "src/wasm-keywords.gperf"
+#line 14 "src/wasm-keywords.gperf"
       {"block", WASM_OP_BLOCK, WASM_OPCODE_EXPR_BLOCK},
-#line 133 "src/wasm-keywords.gperf"
+#line 134 "src/wasm-keywords.gperf"
       {"i64.extend_s/i32", WASM_OP_CONVERT, WASM_OPCODE_I64_SCONVERT_I32, WASM_TYPE_I64, WASM_TYPE_I32},
-#line 54 "src/wasm-keywords.gperf"
+#line 55 "src/wasm-keywords.gperf"
       {"f64.convert_s/i64", WASM_OP_CONVERT, WASM_OPCODE_F64_SCONVERT_I64, WASM_TYPE_F64, WASM_TYPE_I64},
       {""}, {""}, {""}, {""},
-#line 24 "src/wasm-keywords.gperf"
+#line 25 "src/wasm-keywords.gperf"
       {"f32.convert_s/i64", WASM_OP_CONVERT, WASM_OPCODE_F32_SCONVERT_I64, WASM_TYPE_F32, WASM_TYPE_I64},
       {""}, {""}, {""},
-#line 146 "src/wasm-keywords.gperf"
+#line 147 "src/wasm-keywords.gperf"
       {"i64.load8_u", WASM_OP_LOAD, WASM_OPCODE_I64_LOAD_I32, WASM_TYPE_I64, WASM_MEM_TYPE_I8, 0},
       {""}, {""}, {""}, {""},
-#line 99 "src/wasm-keywords.gperf"
+#line 100 "src/wasm-keywords.gperf"
       {"i32.load8_u", WASM_OP_LOAD, WASM_OPCODE_I32_LOAD_I32, WASM_TYPE_I32, WASM_MEM_TYPE_I8, 0},
-#line 125 "src/wasm-keywords.gperf"
+#line 126 "src/wasm-keywords.gperf"
       {"i64.add", WASM_OP_BINARY, WASM_OPCODE_I64_ADD, WASM_TYPE_I64},
       {""}, {""}, {""}, {""},
-#line 82 "src/wasm-keywords.gperf"
+#line 83 "src/wasm-keywords.gperf"
       {"i32.add", WASM_OP_BINARY, WASM_OPCODE_I32_ADD, WASM_TYPE_I32},
       {""}, {""}, {""}, {""},
-#line 50 "src/wasm-keywords.gperf"
+#line 51 "src/wasm-keywords.gperf"
       {"f64.add", WASM_OP_BINARY, WASM_OPCODE_F64_ADD, WASM_TYPE_F64},
       {""},
-#line 28 "src/wasm-keywords.gperf"
+#line 29 "src/wasm-keywords.gperf"
       {"f32.demote/f64", WASM_OP_CONVERT, WASM_OPCODE_F32_CONVERT_F64, WASM_TYPE_F32, WASM_TYPE_F64},
       {""}, {""},
-#line 20 "src/wasm-keywords.gperf"
+#line 21 "src/wasm-keywords.gperf"
       {"f32.add", WASM_OP_BINARY, WASM_OPCODE_F32_ADD, WASM_TYPE_F32},
       {""}, {""}, {""},
-#line 180 "src/wasm-keywords.gperf"
+#line 181 "src/wasm-keywords.gperf"
       {"module", WASM_OP_MODULE},
-#line 67 "src/wasm-keywords.gperf"
+#line 68 "src/wasm-keywords.gperf"
       {"f64.min", WASM_OP_BINARY, WASM_OPCODE_F64_MIN, WASM_TYPE_F64},
       {""}, {""}, {""}, {""},
-#line 38 "src/wasm-keywords.gperf"
+#line 39 "src/wasm-keywords.gperf"
       {"f32.min", WASM_OP_BINARY, WASM_OPCODE_F32_MIN, WASM_TYPE_F32},
       {""}, {""}, {""},
-#line 175 "src/wasm-keywords.gperf"
+#line 176 "src/wasm-keywords.gperf"
       {"load_global", WASM_OP_LOAD_GLOBAL, WASM_OPCODE_GET_GLOBAL},
       {""}, {""}, {""}, {""},
-#line 134 "src/wasm-keywords.gperf"
+#line 135 "src/wasm-keywords.gperf"
       {"i64.extend_u/i32", WASM_OP_CONVERT, WASM_OPCODE_I64_UCONVERT_I32, WASM_TYPE_I64, WASM_TYPE_I32},
-#line 56 "src/wasm-keywords.gperf"
+#line 57 "src/wasm-keywords.gperf"
       {"f64.convert_u/i64", WASM_OP_CONVERT, WASM_OPCODE_F64_UCONVERT_I64, WASM_TYPE_F64, WASM_TYPE_I64},
       {""}, {""}, {""},
-#line 179 "src/wasm-keywords.gperf"
+#line 180 "src/wasm-keywords.gperf"
       {"memory", WASM_OP_MEMORY},
-#line 26 "src/wasm-keywords.gperf"
+#line 27 "src/wasm-keywords.gperf"
       {"f32.convert_u/i64", WASM_OP_CONVERT, WASM_OPCODE_F32_UCONVERT_I64, WASM_TYPE_F32, WASM_TYPE_I64},
       {""}, {""}, {""},
-#line 178 "src/wasm-keywords.gperf"
+#line 179 "src/wasm-keywords.gperf"
       {"memory_size", WASM_OP_MEMORY_SIZE, WASM_OPCODE_INVALID},
-#line 150 "src/wasm-keywords.gperf"
+#line 151 "src/wasm-keywords.gperf"
       {"i64.mul", WASM_OP_BINARY, WASM_OPCODE_I64_MUL, WASM_TYPE_I64},
       {""}, {""}, {""}, {""},
-#line 103 "src/wasm-keywords.gperf"
+#line 104 "src/wasm-keywords.gperf"
       {"i32.mul", WASM_OP_BINARY, WASM_OPCODE_I32_MUL, WASM_TYPE_I32},
       {""}, {""}, {""}, {""},
-#line 68 "src/wasm-keywords.gperf"
+#line 69 "src/wasm-keywords.gperf"
       {"f64.mul", WASM_OP_BINARY, WASM_OPCODE_F64_MUL, WASM_TYPE_F64},
       {""}, {""}, {""}, {""},
-#line 39 "src/wasm-keywords.gperf"
+#line 40 "src/wasm-keywords.gperf"
       {"f32.mul", WASM_OP_BINARY, WASM_OPCODE_F32_MUL, WASM_TYPE_F32},
       {""}, {""}, {""}, {""},
-#line 66 "src/wasm-keywords.gperf"
+#line 67 "src/wasm-keywords.gperf"
       {"f64.max", WASM_OP_BINARY, WASM_OPCODE_F64_MAX, WASM_TYPE_F64},
       {""}, {""}, {""}, {""},
-#line 37 "src/wasm-keywords.gperf"
+#line 38 "src/wasm-keywords.gperf"
       {"f32.max", WASM_OP_BINARY, WASM_OPCODE_F32_MAX, WASM_TYPE_F32},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -613,7 +614,7 @@ in_word_set (str, len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 183 "src/wasm-keywords.gperf"
+#line 184 "src/wasm-keywords.gperf"
       {"param", WASM_OP_PARAM}
     };
 

--- a/src/wasm-parse.c
+++ b/src/wasm-parse.c
@@ -35,7 +35,7 @@ typedef enum WasmMemType {
 
 typedef enum WasmOpType {
   WASM_OP_NONE,
-  WASM_OP_ASSERT_EQ,
+  WASM_OP_ASSERT_RETURN,
   WASM_OP_ASSERT_INVALID,
   WASM_OP_ASSERT_TRAP,
   WASM_OP_BINARY,
@@ -2041,16 +2041,16 @@ int wasm_parse_file(WasmSource* source, WasmParserCallbacks* callbacks) {
         break;
       }
 
-      case WASM_OP_ASSERT_EQ: {
+      case WASM_OP_ASSERT_RETURN: {
         if (!seen_module)
           FATAL_AT(parser, t.range.start,
-                   "assert_eq must occur after a module definition\n");
+                   "assert_return must occur after a module definition\n");
 
         expect_open(parser, read_token(parser));
         expect_atom_op(parser, read_token(parser), WASM_OP_INVOKE, "invoke");
 
         WasmParserCookie cookie =
-            CALLBACK(parser, before_assert_eq, (parser->user_data));
+            CALLBACK(parser, before_assert_return, (parser->user_data));
 
         WasmFunction dummy_function = {};
         WasmType left_type = parse_invoke(parser, &module);
@@ -2058,7 +2058,7 @@ int wasm_parse_file(WasmSource* source, WasmParserCallbacks* callbacks) {
             parse_expr(parser, &module, &dummy_function, NULL);
         check_type(parser, parser->tokenizer.loc, right_type, left_type, "");
 
-        CALLBACK(parser, after_assert_eq,
+        CALLBACK(parser, after_assert_return,
                  (left_type, cookie, parser->user_data));
         expect_close(parser, read_token(parser));
         break;

--- a/src/wasm-parse.h
+++ b/src/wasm-parse.h
@@ -84,10 +84,10 @@ typedef struct WasmParserCallbacks {
   void (*before_unary)(enum WasmOpcode opcode, void* user_data);
 
   /* used in spec repo tests */
-  WasmParserCookie (*before_assert_eq)(void* user_data);
-  void (*after_assert_eq)(WasmType type,
-                          WasmParserCookie cookie,
-                          void* user_data);
+  WasmParserCookie (*before_assert_return)(void* user_data);
+  void (*after_assert_return)(WasmType type,
+                              WasmParserCookie cookie,
+                              void* user_data);
   void (*before_assert_trap)(void* user_data);
   void (*after_assert_trap)(void* user_data);
   WasmParserCookie (*before_invoke)(const char* invoke_name,

--- a/test/assert/assert-after-module.txt
+++ b/test/assert/assert-after-module.txt
@@ -2,4 +2,4 @@
 (module
   (export "f" 0)
   (func (result i32) (return (i32.const 0))))
-(assert_eq (invoke "f") (i32.const 0))
+(assert_return (invoke "f") (i32.const 0))

--- a/test/assert/assertreturn.txt
+++ b/test/assert/assertreturn.txt
@@ -5,10 +5,10 @@
   (func $bar (param f32) (result f32) (get_local 0))
   (export "bar" $bar))
 
-(assert_eq (invoke "foo") (i32.const 0))
-(assert_eq (invoke "bar" (f32.const 0)) (f32.const 0))
+(assert_return (invoke "foo") (i32.const 0))
+(assert_return (invoke "bar" (f32.const 0)) (f32.const 0))
 ;; ok to use more complex exprs
-(assert_eq
+(assert_return
   (invoke "bar"
     (f32.add (f32.const 1) (f32.const 10)))
   (f32.const 11))

--- a/test/assert/bad-assert-before-module.txt
+++ b/test/assert/bad-assert-before-module.txt
@@ -1,5 +1,5 @@
 # FLAGS: --multi-module
 # ERROR: 1
-(assert_eq (invoke "f") (i32.const 0))
+(assert_return (invoke "f") (i32.const 0))
 # STDERR:
-assert/bad-assert-before-module.txt:3:2: assert_eq must occur after a module definition
+assert/bad-assert-before-module.txt:3:2: assert_return must occur after a module definition

--- a/test/assert/bad-asserteq-too-few.txt
+++ b/test/assert/bad-asserteq-too-few.txt
@@ -1,8 +1,0 @@
-# ERROR: 1
-# FLAGS: --multi-module
-(module
-  (func $foo (param i32) (result i32) (get_local 0))
-  (export "foo" $foo))
-(assert_eq (invoke "foo") (i32.const 0))
-# STDERR:
-assert/bad-asserteq-too-few.txt:6:25: too few arguments to function. got 0, expected 1

--- a/test/assert/bad-asserteq-too-many.txt
+++ b/test/assert/bad-asserteq-too-many.txt
@@ -1,8 +1,0 @@
-# ERROR: 1
-# FLAGS: --multi-module
-(module
-  (func $foo (result i32) (i32.const 0))
-  (export "foo" $foo))
-(assert_eq (invoke "foo" (i32.const 0)) (i32.const 0))
-# STDERR:
-assert/bad-asserteq-too-many.txt:6:26: too many arguments to function. got 1, expected 0

--- a/test/assert/bad-asserteq-unknown-function.txt
+++ b/test/assert/bad-asserteq-unknown-function.txt
@@ -1,6 +1,0 @@
-# ERROR: 1
-# FLAGS: --multi-module
-(module)
-(assert_eq (invoke "foo") (i32.const 0))
-# STDERR:
-assert/bad-asserteq-unknown-function.txt:4:20: unknown function export "foo"

--- a/test/assert/bad-assertreturn-too-few.txt
+++ b/test/assert/bad-assertreturn-too-few.txt
@@ -1,0 +1,8 @@
+# ERROR: 1
+# FLAGS: --multi-module
+(module
+  (func $foo (param i32) (result i32) (get_local 0))
+  (export "foo" $foo))
+(assert_return (invoke "foo") (i32.const 0))
+# STDERR:
+assert/bad-assertreturn-too-few.txt:6:29: too few arguments to function. got 0, expected 1

--- a/test/assert/bad-assertreturn-too-many.txt
+++ b/test/assert/bad-assertreturn-too-many.txt
@@ -1,0 +1,8 @@
+# ERROR: 1
+# FLAGS: --multi-module
+(module
+  (func $foo (result i32) (i32.const 0))
+  (export "foo" $foo))
+(assert_return (invoke "foo" (i32.const 0)) (i32.const 0))
+# STDERR:
+assert/bad-assertreturn-too-many.txt:6:30: too many arguments to function. got 1, expected 0

--- a/test/assert/bad-assertreturn-unknown-function.txt
+++ b/test/assert/bad-assertreturn-unknown-function.txt
@@ -1,0 +1,6 @@
+# ERROR: 1
+# FLAGS: --multi-module
+(module)
+(assert_return (invoke "foo") (i32.const 0))
+# STDERR:
+assert/bad-assertreturn-unknown-function.txt:4:24: unknown function export "foo"


### PR DESCRIPTION
This matches recent changes in the spec repo. I left assert_eq as an
alias for assert_return to accomodate existing tests for now (although
the semantics for FP compares are subtly different), but renamed the
enums and event names to assert_return. I also left the d8
and spec tests alone for now.