### PR TITLE
Pass exported function to after_export callback

### DIFF
--- a/src/wasm-parse.c
+++ b/src/wasm-parse.c
@@ -2341,8 +2341,10 @@ static void parse_module(WasmParser* parser, WasmModule* module) {
         }
 
         expect_close(parser, read_token(parser));
+        parser->info.function = function;
         CALLBACK_COOKIE(parser, after_export, cookie,
                         (&parser->info, export_name));
+        parser->info.function = NULL;
         break;
       }
 


### PR DESCRIPTION
The callback isn't very useful with just the name