### PR TITLE
Support use of parser and AST in C++ programs

### DIFF
--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -1338,7 +1338,7 @@ static WasmModuleField* append_module_field_and_fixup(
       WasmExportPtr* export_ptr = wasm_append_export_ptr(&module->exports);
       if (!export_ptr)
         goto fail;
-      *export_ptr = &result->wasm_export;
+      *export_ptr = &result->export_;
       break;
     }
     case WASM_MODULE_FIELD_TYPE_FUNC_TYPE: {
@@ -1380,7 +1380,7 @@ static WasmModuleField* append_module_field_and_fixup(
         break;
       case WASM_MODULE_FIELD_TYPE_EXPORT:
         assert(num_exports < module->exports.size);
-        module->exports.data[num_exports++] = &field->wasm_export;
+        module->exports.data[num_exports++] = &field->export_;
         break;
       case WASM_MODULE_FIELD_TYPE_TABLE:
         module->table = &field->table;
@@ -1435,7 +1435,7 @@ static WasmFunc* append_nullary_func(WasmModule* module,
     /* leave the func field, it will be cleaned up later */
     return NULL;
   }
-  WasmExport* export = &export_field->wasm_export;
+  WasmExport* export = &export_field->export_;
   export->var.type = WASM_VAR_TYPE_INDEX;
   export->var.index = func_index;
   export->name = export_name;

--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -1338,7 +1338,7 @@ static WasmModuleField* append_module_field_and_fixup(
       WasmExportPtr* export_ptr = wasm_append_export_ptr(&module->exports);
       if (!export_ptr)
         goto fail;
-      *export_ptr = &result->export;
+      *export_ptr = &result->wasm_export;
       break;
     }
     case WASM_MODULE_FIELD_TYPE_FUNC_TYPE: {
@@ -1380,7 +1380,7 @@ static WasmModuleField* append_module_field_and_fixup(
         break;
       case WASM_MODULE_FIELD_TYPE_EXPORT:
         assert(num_exports < module->exports.size);
-        module->exports.data[num_exports++] = &field->export;
+        module->exports.data[num_exports++] = &field->wasm_export;
         break;
       case WASM_MODULE_FIELD_TYPE_TABLE:
         module->table = &field->table;
@@ -1435,7 +1435,7 @@ static WasmFunc* append_nullary_func(WasmModule* module,
     /* leave the func field, it will be cleaned up later */
     return NULL;
   }
-  WasmExport* export = &export_field->export;
+  WasmExport* export = &export_field->wasm_export;
   export->var.type = WASM_VAR_TYPE_INDEX;
   export->var.index = func_index;
   export->name = export_name;

--- a/src/wasm-check.c
+++ b/src/wasm-check.c
@@ -843,7 +843,7 @@ static WasmResult check_module(WasmCheckContext* ctx, WasmModule* module) {
         result |= check_import(ctx, module, &field->loc, &field->import);
         break;
       case WASM_MODULE_FIELD_TYPE_EXPORT:
-        result |= check_export(ctx, module, &field->wasm_export);
+        result |= check_export(ctx, module, &field->export_);
         break;
       case WASM_MODULE_FIELD_TYPE_TABLE:
         if (seen_table) {

--- a/src/wasm-check.c
+++ b/src/wasm-check.c
@@ -843,7 +843,7 @@ static WasmResult check_module(WasmCheckContext* ctx, WasmModule* module) {
         result |= check_import(ctx, module, &field->loc, &field->import);
         break;
       case WASM_MODULE_FIELD_TYPE_EXPORT:
-        result |= check_export(ctx, module, &field->export);
+        result |= check_export(ctx, module, &field->wasm_export);
         break;
       case WASM_MODULE_FIELD_TYPE_TABLE:
         if (seen_table) {

--- a/src/wasm-common.h
+++ b/src/wasm-common.h
@@ -3,8 +3,12 @@
 
 #ifdef __cplusplus
 #define EXTERN_C extern "C"
+#define EXTERN_C_BEGIN extern "C" {
+#define EXTERN_C_END }
 #else
 #define EXTERN_C
+#define EXTERN_C_BEGIN
+#define EXTERN_C_END
 #endif
 
 #define WARN_UNUSED __attribute__ ((warn_unused_result))

--- a/src/wasm-parser.c
+++ b/src/wasm-parser.c
@@ -3761,7 +3761,7 @@ yyreduce:
       CHECK_ALLOC_NULL(field);
       field->loc = (yylsp[0]);
       field->type = WASM_MODULE_FIELD_TYPE_EXPORT;
-      field->export = (yyvsp[0].export);
+      field->wasm_export = (yyvsp[0].export);
     }
 #line 3767 "src/wasm-parser.c" /* yacc.c:1646  */
     break;
@@ -3855,13 +3855,13 @@ yyreduce:
             break;
           }
           case WASM_MODULE_FIELD_TYPE_EXPORT: {
-            WasmExportPtr export_ptr = &field->export;
+            WasmExportPtr export_ptr = &field->wasm_export;
             CHECK_ALLOC(wasm_append_export_ptr_value(&(yyval.module).exports, &export_ptr));
-            if (field->export.name.start) {
+            if (field->wasm_export.name.start) {
               WasmBinding* binding = wasm_append_binding(&(yyval.module).export_bindings);
               CHECK_ALLOC_NULL(binding);
               binding->loc = field->loc;
-              binding->name = field->export.name;
+              binding->name = field->wasm_export.name;
               binding->index = (yyval.module).exports.size - 1;
             }
             break;

--- a/src/wasm-parser.c
+++ b/src/wasm-parser.c
@@ -3761,7 +3761,7 @@ yyreduce:
       CHECK_ALLOC_NULL(field);
       field->loc = (yylsp[0]);
       field->type = WASM_MODULE_FIELD_TYPE_EXPORT;
-      field->wasm_export = (yyvsp[0].export);
+      field->export_ = (yyvsp[0].export);
     }
 #line 3767 "src/wasm-parser.c" /* yacc.c:1646  */
     break;
@@ -3855,13 +3855,13 @@ yyreduce:
             break;
           }
           case WASM_MODULE_FIELD_TYPE_EXPORT: {
-            WasmExportPtr export_ptr = &field->wasm_export;
+            WasmExportPtr export_ptr = &field->export_;
             CHECK_ALLOC(wasm_append_export_ptr_value(&(yyval.module).exports, &export_ptr));
-            if (field->wasm_export.name.start) {
+            if (field->export_.name.start) {
               WasmBinding* binding = wasm_append_binding(&(yyval.module).export_bindings);
               CHECK_ALLOC_NULL(binding);
               binding->loc = field->loc;
-              binding->name = field->wasm_export.name;
+              binding->name = field->export_.name;
               binding->index = (yyval.module).exports.size - 1;
             }
             break;

--- a/src/wasm-parser.y
+++ b/src/wasm-parser.y
@@ -1207,7 +1207,7 @@ module_fields :
       CHECK_ALLOC_NULL(field);
       field->loc = @2;
       field->type = WASM_MODULE_FIELD_TYPE_EXPORT;
-      field->export = $2;
+      field->wasm_export = $2;
     }
   | module_fields table {
       $$ = $1;
@@ -1278,13 +1278,13 @@ module :
             break;
           }
           case WASM_MODULE_FIELD_TYPE_EXPORT: {
-            WasmExportPtr export_ptr = &field->export;
+            WasmExportPtr export_ptr = &field->wasm_export;
             CHECK_ALLOC(wasm_append_export_ptr_value(&$$.exports, &export_ptr));
-            if (field->export.name.start) {
+            if (field->wasm_export.name.start) {
               WasmBinding* binding = wasm_append_binding(&$$.export_bindings);
               CHECK_ALLOC_NULL(binding);
               binding->loc = field->loc;
-              binding->name = field->export.name;
+              binding->name = field->wasm_export.name;
               binding->index = $$.exports.size - 1;
             }
             break;

--- a/src/wasm-parser.y
+++ b/src/wasm-parser.y
@@ -1207,7 +1207,7 @@ module_fields :
       CHECK_ALLOC_NULL(field);
       field->loc = @2;
       field->type = WASM_MODULE_FIELD_TYPE_EXPORT;
-      field->wasm_export = $2;
+      field->export_ = $2;
     }
   | module_fields table {
       $$ = $1;
@@ -1278,13 +1278,13 @@ module :
             break;
           }
           case WASM_MODULE_FIELD_TYPE_EXPORT: {
-            WasmExportPtr export_ptr = &field->wasm_export;
+            WasmExportPtr export_ptr = &field->export_;
             CHECK_ALLOC(wasm_append_export_ptr_value(&$$.exports, &export_ptr));
-            if (field->wasm_export.name.start) {
+            if (field->export_.name.start) {
               WasmBinding* binding = wasm_append_binding(&$$.export_bindings);
               CHECK_ALLOC_NULL(binding);
               binding->loc = field->loc;
-              binding->name = field->wasm_export.name;
+              binding->name = field->export_.name;
               binding->index = $$.exports.size - 1;
             }
             break;

--- a/src/wasm.c
+++ b/src/wasm.c
@@ -346,7 +346,7 @@ static void wasm_destroy_module_field(WasmModuleField* field) {
       wasm_destroy_import(&field->import);
       break;
     case WASM_MODULE_FIELD_TYPE_EXPORT:
-      wasm_destroy_export(&field->export);
+      wasm_destroy_export(&field->wasm_export);
       break;
     case WASM_MODULE_FIELD_TYPE_TABLE:
       DESTROY_VECTOR_AND_ELEMENTS(field->table, var);

--- a/src/wasm.c
+++ b/src/wasm.c
@@ -346,7 +346,7 @@ static void wasm_destroy_module_field(WasmModuleField* field) {
       wasm_destroy_import(&field->import);
       break;
     case WASM_MODULE_FIELD_TYPE_EXPORT:
-      wasm_destroy_export(&field->wasm_export);
+      wasm_destroy_export(&field->export_);
       break;
     case WASM_MODULE_FIELD_TYPE_TABLE:
       DESTROY_VECTOR_AND_ELEMENTS(field->table, var);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -479,7 +479,7 @@ typedef struct WasmModuleField {
   union {
     WasmFunc func;
     WasmImport import;
-    WasmExport wasm_export;
+    WasmExport export_;
     WasmVarVector table;
     WasmFuncType func_type;
     WasmMemory memory;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -479,7 +479,7 @@ typedef struct WasmModuleField {
   union {
     WasmFunc func;
     WasmImport import;
-    WasmExport export;
+    WasmExport wasm_export;
     WasmVarVector table;
     WasmFuncType func_type;
     WasmMemory memory;
@@ -552,6 +552,7 @@ typedef struct WasmWriteBinaryOptions {
   int log_writes;
 } WasmWriteBinaryOptions;
 
+EXTERN_C_BEGIN
 WasmScanner wasm_new_scanner(const char* filename);
 void wasm_free_scanner(WasmScanner scanner);
 void wasm_error(WasmLocation*, WasmScanner, WasmParser*, const char*, ...);
@@ -602,5 +603,6 @@ WasmResult wasm_extend_type_bindings(WasmTypeBindings* dst,
                                      WasmTypeBindings* src) WARN_UNUSED;
 
 int wasm_func_is_exported(WasmModule* module, WasmFunc* func);
+EXTERN_C_END
 
 #endif /* WASM_H_ */


### PR DESCRIPTION
Rename 'export' field of WasmModuleField because 'export' is a reserved
word in C++ (and regenerate the parser).
Wrap functions declared in wasm.h in extern "C"