### PR TITLE
Tables can include imports and their index space includes imports.

### DIFF
--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -1276,8 +1276,14 @@ static void write_module(WasmWriteContext* ctx, WasmModule* module) {
     out_leb128(ws, module->table->size, "num function table entries");
     for (i = 0; i < module->table->size; ++i) {
       int index = wasm_get_func_index_by_var(module, &module->table->data[i]);
-      assert(index >= 0 && index < module->funcs.size);
-      out_u16(ws, index + module->imports.size, "function table entry");
+      if (index >= 0) {
+        assert(index >= 0 && index < module->funcs.size);
+        out_u16(ws, index + module->imports.size, "function table entry, function");
+      } else {
+        index = wasm_get_import_index_by_var(module, &module->table->data[i]);
+        assert(index >= 0 && index < module->imports.size);
+        out_u16(ws, index, "function table entry, import");
+      }
     }
   }
 

--- a/src/wasm-check.c
+++ b/src/wasm-check.c
@@ -147,6 +147,22 @@ static WasmResult check_import_var(WasmCheckContext* ctx,
   return WASM_OK;
 }
 
+static WasmResult check_import_or_func_var(WasmCheckContext* ctx,
+                                           WasmModule* module,
+                                           WasmVar* var) {
+  int index = wasm_get_index_from_var(&module->import_bindings, var);
+  if (index >= 0 && index < module->imports.size)
+    return WASM_OK;
+
+  index = wasm_get_index_from_var(&module->func_bindings, var);
+  if (index >= 0 && index < module->funcs.size)
+    return WASM_OK;
+
+  print_error(ctx, &var->loc, "import or function variable out of range (max %d)",
+              module->funcs.size);
+  return WASM_ERROR;
+}
+
 static WasmResult check_func_type_var(WasmCheckContext* ctx,
                                       WasmModule* module,
                                       WasmVar* var,
@@ -781,7 +797,7 @@ static WasmResult check_table(WasmCheckContext* ctx,
   WasmResult result = WASM_OK;
   int i;
   for (i = 0; i < table->size; ++i)
-    result |= check_func_var(ctx, module, &table->data[i], NULL);
+    result |= check_import_or_func_var(ctx, module, &table->data[i]);
   return result;
 }
 

--- a/test/d8/table.txt
+++ b/test/d8/table.txt
@@ -1,0 +1,15 @@
+;;; EXE: test/run-d8.py
+(module
+  (type $i_v (func (param i32)))
+  (import $print_i32 "stdio" "print" (param i32))
+  (import $print_i32_i32 "stdio" "print" (param i32 i32))
+  (func $test (result i32)
+    (call_indirect $i_v (i32.const 0) (i32.const 400))
+    (return (i32.const 1)))
+  (export "test" $test)
+  (table $print_i32)
+)
+(;; STDOUT ;;;
+400
+test() = 1
+;;; STDOUT ;;)

--- a/test/dump/callindirect-after-import.txt
+++ b/test/dump/callindirect-after-import.txt
@@ -55,7 +55,7 @@
 000001b: 0900                                       ; FIXUP func body size
 0000026: 05                                         ; WASM_SECTION_FUNCTION_TABLE
 0000027: 01                                         ; num function table entries
-0000028: 0100                                       ; function table entry
+0000028: 0100                                       ; function table entry, function
 000002a: 06                                         ; WASM_SECTION_END
 ; import 0
 000000e: 2b00 0000                                  ; FIXUP import name offset

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -26,7 +26,7 @@
 000000a: 0600                                       ; FIXUP func body size
 0000012: 05                                         ; WASM_SECTION_FUNCTION_TABLE
 0000013: 01                                         ; num function table entries
-0000014: 0000                                       ; function table entry
+0000014: 0000                                       ; function table entry, function
 0000016: 06                                         ; WASM_SECTION_END
 ;; dump
 0000000: 0101 0100 0102 0100 0000 0600 1300 0900  

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -41,10 +41,10 @@
 000001a: 0900                                       ; FIXUP func body size
 0000025: 05                                         ; WASM_SECTION_FUNCTION_TABLE
 0000026: 04                                         ; num function table entries
-0000027: 0000                                       ; function table entry
-0000029: 0000                                       ; function table entry
-000002b: 0100                                       ; function table entry
-000002d: 0200                                       ; function table entry
+0000027: 0000                                       ; function table entry, function
+0000029: 0000                                       ; function table entry, function
+000002b: 0100                                       ; function table entry, function
+000002d: 0200                                       ; function table entry, function
 000002f: 06                                         ; WASM_SECTION_END
 ;; dump
 0000000: 0103 0100 0102 0001 0200 0402 0300 0000  

--- a/test/parse/module/bad-table-invalid.txt
+++ b/test/parse/module/bad-table-invalid.txt
@@ -2,5 +2,5 @@
 (module
   (table 0))
 (;; STDERR ;;;
-parse/module/bad-table-invalid.txt:3:10: function variable out of range (max 0)
+parse/module/bad-table-invalid.txt:3:10: import or function variable out of range (max 0)
 ;;; STDERR ;;)


### PR DESCRIPTION
If I understand the following issue correctly then the sexpr-wasm-prototype has a bug in the generation of tables, see https://github.com/WebAssembly/binaryen/pull/115 This is an attempt to correct this issue, and includes a small example test.