### PR TITLE
Accept duplicate block labels.

### DIFF
--- a/src/wasm-check.c
+++ b/src/wasm-check.c
@@ -301,12 +301,6 @@ static WasmResult push_label(WasmCheckContext* ctx,
                              WasmType expected_type,
                              const char* desc) {
   WasmResult result = WASM_OK;
-  if (label->start && find_label_by_name(ctx->top_label, label)) {
-    print_error(ctx, loc, "redefinition of label \"%.*s\"", label->length,
-                label->start);
-    /* add it anyway */
-    result = WASM_ERROR;
-  }
   node->label = label;
   node->next = ctx->top_label;
   node->expected_type = expected_type;

--- a/test/typecheck/label-redefinition.txt
+++ b/test/typecheck/label-redefinition.txt
@@ -1,0 +1,7 @@
+(module
+  (func (result i32)
+    (block $l1
+      (i32.add (block $l1
+		 (i32.const 2))
+	       (block $l1
+		 (br $l1 (i32.const 3)))))))


### PR DESCRIPTION
The ml-proto allows duplicate block labels. This is noted as convenient in the discussions https://github.com/WebAssembly/spec/issues/210 as is supports 'locality and compositionality'. Perhaps something to consider for sexp-wasm.