### PR TITLE
binary format has magic and version number

### DIFF
--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -947,6 +947,9 @@ static void write_module(WasmWriteContext* ctx, WasmModule* module) {
   int i;
   WasmWriterState* ws = &ctx->writer_state;
   ctx->writer_state.offset = 0;
+  out_u32(ws, WASM_BINARY_MAGIC, "WASM_BINARY_MAGIC");
+  out_u32(ws, WASM_BINARY_VERSION, "WASM_BINARY_VERSION");
+
   size_t segments_offset = 0;
   if (module->memory) {
     out_u8(ws, WASM_BINARY_SECTION_MEMORY, "WASM_BINARY_SECTION_MEMORY");

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -19,6 +19,9 @@
 
 #include <stdint.h>
 
+#define WASM_BINARY_MAGIC 0x6d736100
+#define WASM_BINARY_VERSION 0x0a
+
 typedef enum WasmBinarySectionType {
   WASM_BINARY_SECTION_MEMORY = 0,
   WASM_BINARY_SECTION_SIGNATURES = 1,

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -6,49 +6,52 @@
     (i32.add (get_local 0) (get_local 1)))
   (export "f" $f))
 (;; STDOUT ;;;
-0000000: 03                                         ; WASM_BINARY_SECTION_GLOBALS
-0000001: 01                                         ; num globals
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 03                                         ; WASM_BINARY_SECTION_GLOBALS
+0000009: 01                                         ; num globals
 ; global header 0
-0000002: 0000 0000                                  ; global name offset
-0000006: 04                                         ; global mem type
-0000007: 00                                         ; export global
-0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000009: 01                                         ; num signatures
+000000a: 0000 0000                                  ; global name offset
+000000e: 04                                         ; global mem type
+000000f: 00                                         ; export global
+0000010: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000011: 01                                         ; num signatures
 ; signature 0
-000000a: 02                                         ; num params
-000000b: 01                                         ; result_type
-000000c: 01                                         ; param type
-000000d: 01                                         ; param type
-000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-000000f: 01                                         ; num functions
+0000012: 02                                         ; num params
+0000013: 01                                         ; result_type
+0000014: 01                                         ; param type
+0000015: 01                                         ; param type
+0000016: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000017: 01                                         ; num functions
 ; function 0
-0000010: 00                                         ; func flags
-0000011: 0000                                       ; func signature index
-0000013: 0000                                       ; func body size
-0000015: 11                                         ; OPCODE_STORE_GLOBAL
-0000016: 00                                         ; global index
-0000017: 40                                         ; OPCODE_I32_ADD
-0000018: 10                                         ; OPCODE_LOAD_GLOBAL
-0000019: 00                                         ; global index
-000001a: 09                                         ; OPCODE_I8_CONST
-000001b: 01                                         ; u8 literal
-000001c: 40                                         ; OPCODE_I32_ADD
-000001d: 0e                                         ; OPCODE_GET_LOCAL
-000001e: 00                                         ; remapped local index
-000001f: 0e                                         ; OPCODE_GET_LOCAL
-0000020: 01                                         ; remapped local index
-0000013: 0c00                                       ; FIXUP func body size
-0000021: 09                                         ; WASM_BINARY_SECTION_EXPORTS
-0000022: 01                                         ; num exports
-0000023: 0000                                       ; export func index
-0000025: 0000 0000                                  ; export name offset
-0000029: 06                                         ; WASM_BINARY_SECTION_END
+0000018: 00                                         ; func flags
+0000019: 0000                                       ; func signature index
+000001b: 0000                                       ; func body size
+000001d: 11                                         ; OPCODE_STORE_GLOBAL
+000001e: 00                                         ; global index
+000001f: 40                                         ; OPCODE_I32_ADD
+0000020: 10                                         ; OPCODE_LOAD_GLOBAL
+0000021: 00                                         ; global index
+0000022: 09                                         ; OPCODE_I8_CONST
+0000023: 01                                         ; u8 literal
+0000024: 40                                         ; OPCODE_I32_ADD
+0000025: 0e                                         ; OPCODE_GET_LOCAL
+0000026: 00                                         ; remapped local index
+0000027: 0e                                         ; OPCODE_GET_LOCAL
+0000028: 01                                         ; remapped local index
+000001b: 0c00                                       ; FIXUP func body size
+0000029: 09                                         ; WASM_BINARY_SECTION_EXPORTS
+000002a: 01                                         ; num exports
+000002b: 0000                                       ; export func index
+000002d: 0000 0000                                  ; export name offset
+0000031: 06                                         ; WASM_BINARY_SECTION_END
 ; export 0
-0000025: 2a00 0000                                  ; FIXUP func name offset
-000002a: 66                                         ; export name
-000002b: 00                                         ; \0
+000002d: 3200 0000                                  ; FIXUP func name offset
+0000032: 66                                         ; export name
+0000033: 00                                         ; \0
 ;; dump
-0000000: 0301 0000 0000 0400 0101 0201 0101 0201  
-0000010: 0000 000c 0011 0040 1000 0901 400e 000e  
-0000020: 0109 0100 002a 0000 0006 6600            
+0000000: 0061 736d 0a00 0000 0301 0000 0000 0400  
+0000010: 0101 0201 0101 0201 0000 000c 0011 0040  
+0000020: 1000 0901 400e 000e 0109 0100 0032 0000  
+0000030: 0006 6600                                
 ;;; STDOUT ;;)

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -92,38 +92,32 @@
 ))
 
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 40                                         ; OPCODE_I32_ADD
-000000c: 41                                         ; OPCODE_I32_SUB
-000000d: 42                                         ; OPCODE_I32_MUL
-000000e: 43                                         ; OPCODE_I32_DIV_S
-000000f: 44                                         ; OPCODE_I32_DIV_U
-0000010: 45                                         ; OPCODE_I32_REM_S
-0000011: 46                                         ; OPCODE_I32_REM_U
-0000012: 47                                         ; OPCODE_I32_AND
-0000013: 48                                         ; OPCODE_I32_OR
-0000014: 49                                         ; OPCODE_I32_XOR
-0000015: 4a                                         ; OPCODE_I32_SHL
-0000016: 4b                                         ; OPCODE_I32_SHR_U
-0000017: 4c                                         ; OPCODE_I32_SHR_S
-0000018: 09                                         ; OPCODE_I8_CONST
-0000019: 00                                         ; u8 literal
-000001a: 09                                         ; OPCODE_I8_CONST
-000001b: 00                                         ; u8 literal
-000001c: 09                                         ; OPCODE_I8_CONST
-000001d: 00                                         ; u8 literal
-000001e: 09                                         ; OPCODE_I8_CONST
-000001f: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 40                                         ; OPCODE_I32_ADD
+0000014: 41                                         ; OPCODE_I32_SUB
+0000015: 42                                         ; OPCODE_I32_MUL
+0000016: 43                                         ; OPCODE_I32_DIV_S
+0000017: 44                                         ; OPCODE_I32_DIV_U
+0000018: 45                                         ; OPCODE_I32_REM_S
+0000019: 46                                         ; OPCODE_I32_REM_U
+000001a: 47                                         ; OPCODE_I32_AND
+000001b: 48                                         ; OPCODE_I32_OR
+000001c: 49                                         ; OPCODE_I32_XOR
+000001d: 4a                                         ; OPCODE_I32_SHL
+000001e: 4b                                         ; OPCODE_I32_SHR_U
+000001f: 4c                                         ; OPCODE_I32_SHR_S
 0000020: 09                                         ; OPCODE_I8_CONST
 0000021: 00                                         ; u8 literal
 0000022: 09                                         ; OPCODE_I8_CONST
@@ -144,114 +138,123 @@
 0000031: 00                                         ; u8 literal
 0000032: 09                                         ; OPCODE_I8_CONST
 0000033: 00                                         ; u8 literal
-0000034: 5b                                         ; OPCODE_I64_ADD
-0000035: 5c                                         ; OPCODE_I64_SUB
-0000036: 5d                                         ; OPCODE_I64_MUL
-0000037: 5e                                         ; OPCODE_I64_DIV_S
-0000038: 5f                                         ; OPCODE_I64_DIV_U
-0000039: 60                                         ; OPCODE_I64_REM_S
-000003a: 61                                         ; OPCODE_I64_REM_U
-000003b: 62                                         ; OPCODE_I64_AND
-000003c: 63                                         ; OPCODE_I64_OR
-000003d: 64                                         ; OPCODE_I64_XOR
-000003e: 65                                         ; OPCODE_I64_SHL
-000003f: 66                                         ; OPCODE_I64_SHR_U
-0000040: 67                                         ; OPCODE_I64_SHR_S
-0000041: 0b                                         ; OPCODE_I64_CONST
-0000042: 0000 0000 0000 0000                        ; u64 literal
-000004a: 0b                                         ; OPCODE_I64_CONST
-000004b: 0000 0000 0000 0000                        ; u64 literal
-0000053: 0b                                         ; OPCODE_I64_CONST
-0000054: 0000 0000 0000 0000                        ; u64 literal
-000005c: 0b                                         ; OPCODE_I64_CONST
-000005d: 0000 0000 0000 0000                        ; u64 literal
-0000065: 0b                                         ; OPCODE_I64_CONST
-0000066: 0000 0000 0000 0000                        ; u64 literal
-000006e: 0b                                         ; OPCODE_I64_CONST
-000006f: 0000 0000 0000 0000                        ; u64 literal
-0000077: 0b                                         ; OPCODE_I64_CONST
-0000078: 0000 0000 0000 0000                        ; u64 literal
-0000080: 0b                                         ; OPCODE_I64_CONST
-0000081: 0000 0000 0000 0000                        ; u64 literal
-0000089: 0b                                         ; OPCODE_I64_CONST
-000008a: 0000 0000 0000 0000                        ; u64 literal
-0000092: 0b                                         ; OPCODE_I64_CONST
-0000093: 0000 0000 0000 0000                        ; u64 literal
-000009b: 0b                                         ; OPCODE_I64_CONST
-000009c: 0000 0000 0000 0000                        ; u64 literal
-00000a4: 0b                                         ; OPCODE_I64_CONST
-00000a5: 0000 0000 0000 0000                        ; u64 literal
-00000ad: 0b                                         ; OPCODE_I64_CONST
-00000ae: 0000 0000 0000 0000                        ; u64 literal
-00000b6: 0b                                         ; OPCODE_I64_CONST
-00000b7: 0000 0000 0000 0000                        ; u64 literal
-00000bf: 75                                         ; OPCODE_F32_ADD
-00000c0: 76                                         ; OPCODE_F32_SUB
-00000c1: 77                                         ; OPCODE_F32_MUL
-00000c2: 78                                         ; OPCODE_F32_DIV
-00000c3: 79                                         ; OPCODE_F32_MIN
-00000c4: 7a                                         ; OPCODE_F32_MAX
-00000c5: 7d                                         ; OPCODE_F32_COPYSIGN
-00000c6: 0d                                         ; OPCODE_F32_CONST
-00000c7: 0000 0000                                  ; f32 literal
-00000cb: 0d                                         ; OPCODE_F32_CONST
-00000cc: 0000 0000                                  ; f32 literal
-00000d0: 0d                                         ; OPCODE_F32_CONST
-00000d1: 0000 0000                                  ; f32 literal
-00000d5: 0d                                         ; OPCODE_F32_CONST
-00000d6: 0000 0000                                  ; f32 literal
-00000da: 0d                                         ; OPCODE_F32_CONST
-00000db: 0000 0000                                  ; f32 literal
-00000df: 0d                                         ; OPCODE_F32_CONST
-00000e0: 0000 0000                                  ; f32 literal
-00000e4: 0d                                         ; OPCODE_F32_CONST
-00000e5: 0000 0000                                  ; f32 literal
-00000e9: 0d                                         ; OPCODE_F32_CONST
-00000ea: 0000 0000                                  ; f32 literal
-00000ee: 89                                         ; OPCODE_F64_ADD
-00000ef: 8a                                         ; OPCODE_F64_SUB
-00000f0: 8b                                         ; OPCODE_F64_MUL
-00000f1: 8c                                         ; OPCODE_F64_DIV
-00000f2: 8d                                         ; OPCODE_F64_MIN
-00000f3: 8e                                         ; OPCODE_F64_MAX
-00000f4: 91                                         ; OPCODE_F64_COPYSIGN
-00000f5: 0c                                         ; OPCODE_F64_CONST
-00000f6: 0000 0000 0000 0000                        ; f64 literal
-00000fe: 0c                                         ; OPCODE_F64_CONST
-00000ff: 0000 0000 0000 0000                        ; f64 literal
-0000107: 0c                                         ; OPCODE_F64_CONST
-0000108: 0000 0000 0000 0000                        ; f64 literal
-0000110: 0c                                         ; OPCODE_F64_CONST
-0000111: 0000 0000 0000 0000                        ; f64 literal
-0000119: 0c                                         ; OPCODE_F64_CONST
-000011a: 0000 0000 0000 0000                        ; f64 literal
-0000122: 0c                                         ; OPCODE_F64_CONST
-0000123: 0000 0000 0000 0000                        ; f64 literal
-000012b: 0c                                         ; OPCODE_F64_CONST
-000012c: 0000 0000 0000 0000                        ; f64 literal
-0000134: 0c                                         ; OPCODE_F64_CONST
-0000135: 0000 0000 0000 0000                        ; f64 literal
-0000009: 3201                                       ; FIXUP func body size
-000013d: 06                                         ; WASM_BINARY_SECTION_END
+0000034: 09                                         ; OPCODE_I8_CONST
+0000035: 00                                         ; u8 literal
+0000036: 09                                         ; OPCODE_I8_CONST
+0000037: 00                                         ; u8 literal
+0000038: 09                                         ; OPCODE_I8_CONST
+0000039: 00                                         ; u8 literal
+000003a: 09                                         ; OPCODE_I8_CONST
+000003b: 00                                         ; u8 literal
+000003c: 5b                                         ; OPCODE_I64_ADD
+000003d: 5c                                         ; OPCODE_I64_SUB
+000003e: 5d                                         ; OPCODE_I64_MUL
+000003f: 5e                                         ; OPCODE_I64_DIV_S
+0000040: 5f                                         ; OPCODE_I64_DIV_U
+0000041: 60                                         ; OPCODE_I64_REM_S
+0000042: 61                                         ; OPCODE_I64_REM_U
+0000043: 62                                         ; OPCODE_I64_AND
+0000044: 63                                         ; OPCODE_I64_OR
+0000045: 64                                         ; OPCODE_I64_XOR
+0000046: 65                                         ; OPCODE_I64_SHL
+0000047: 66                                         ; OPCODE_I64_SHR_U
+0000048: 67                                         ; OPCODE_I64_SHR_S
+0000049: 0b                                         ; OPCODE_I64_CONST
+000004a: 0000 0000 0000 0000                        ; u64 literal
+0000052: 0b                                         ; OPCODE_I64_CONST
+0000053: 0000 0000 0000 0000                        ; u64 literal
+000005b: 0b                                         ; OPCODE_I64_CONST
+000005c: 0000 0000 0000 0000                        ; u64 literal
+0000064: 0b                                         ; OPCODE_I64_CONST
+0000065: 0000 0000 0000 0000                        ; u64 literal
+000006d: 0b                                         ; OPCODE_I64_CONST
+000006e: 0000 0000 0000 0000                        ; u64 literal
+0000076: 0b                                         ; OPCODE_I64_CONST
+0000077: 0000 0000 0000 0000                        ; u64 literal
+000007f: 0b                                         ; OPCODE_I64_CONST
+0000080: 0000 0000 0000 0000                        ; u64 literal
+0000088: 0b                                         ; OPCODE_I64_CONST
+0000089: 0000 0000 0000 0000                        ; u64 literal
+0000091: 0b                                         ; OPCODE_I64_CONST
+0000092: 0000 0000 0000 0000                        ; u64 literal
+000009a: 0b                                         ; OPCODE_I64_CONST
+000009b: 0000 0000 0000 0000                        ; u64 literal
+00000a3: 0b                                         ; OPCODE_I64_CONST
+00000a4: 0000 0000 0000 0000                        ; u64 literal
+00000ac: 0b                                         ; OPCODE_I64_CONST
+00000ad: 0000 0000 0000 0000                        ; u64 literal
+00000b5: 0b                                         ; OPCODE_I64_CONST
+00000b6: 0000 0000 0000 0000                        ; u64 literal
+00000be: 0b                                         ; OPCODE_I64_CONST
+00000bf: 0000 0000 0000 0000                        ; u64 literal
+00000c7: 75                                         ; OPCODE_F32_ADD
+00000c8: 76                                         ; OPCODE_F32_SUB
+00000c9: 77                                         ; OPCODE_F32_MUL
+00000ca: 78                                         ; OPCODE_F32_DIV
+00000cb: 79                                         ; OPCODE_F32_MIN
+00000cc: 7a                                         ; OPCODE_F32_MAX
+00000cd: 7d                                         ; OPCODE_F32_COPYSIGN
+00000ce: 0d                                         ; OPCODE_F32_CONST
+00000cf: 0000 0000                                  ; f32 literal
+00000d3: 0d                                         ; OPCODE_F32_CONST
+00000d4: 0000 0000                                  ; f32 literal
+00000d8: 0d                                         ; OPCODE_F32_CONST
+00000d9: 0000 0000                                  ; f32 literal
+00000dd: 0d                                         ; OPCODE_F32_CONST
+00000de: 0000 0000                                  ; f32 literal
+00000e2: 0d                                         ; OPCODE_F32_CONST
+00000e3: 0000 0000                                  ; f32 literal
+00000e7: 0d                                         ; OPCODE_F32_CONST
+00000e8: 0000 0000                                  ; f32 literal
+00000ec: 0d                                         ; OPCODE_F32_CONST
+00000ed: 0000 0000                                  ; f32 literal
+00000f1: 0d                                         ; OPCODE_F32_CONST
+00000f2: 0000 0000                                  ; f32 literal
+00000f6: 89                                         ; OPCODE_F64_ADD
+00000f7: 8a                                         ; OPCODE_F64_SUB
+00000f8: 8b                                         ; OPCODE_F64_MUL
+00000f9: 8c                                         ; OPCODE_F64_DIV
+00000fa: 8d                                         ; OPCODE_F64_MIN
+00000fb: 8e                                         ; OPCODE_F64_MAX
+00000fc: 91                                         ; OPCODE_F64_COPYSIGN
+00000fd: 0c                                         ; OPCODE_F64_CONST
+00000fe: 0000 0000 0000 0000                        ; f64 literal
+0000106: 0c                                         ; OPCODE_F64_CONST
+0000107: 0000 0000 0000 0000                        ; f64 literal
+000010f: 0c                                         ; OPCODE_F64_CONST
+0000110: 0000 0000 0000 0000                        ; f64 literal
+0000118: 0c                                         ; OPCODE_F64_CONST
+0000119: 0000 0000 0000 0000                        ; f64 literal
+0000121: 0c                                         ; OPCODE_F64_CONST
+0000122: 0000 0000 0000 0000                        ; f64 literal
+000012a: 0c                                         ; OPCODE_F64_CONST
+000012b: 0000 0000 0000 0000                        ; f64 literal
+0000133: 0c                                         ; OPCODE_F64_CONST
+0000134: 0000 0000 0000 0000                        ; f64 literal
+000013c: 0c                                         ; OPCODE_F64_CONST
+000013d: 0000 0000 0000 0000                        ; f64 literal
+0000011: 3201                                       ; FIXUP func body size
+0000145: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0032 0140 4142 4344  
-0000010: 4546 4748 494a 4b4c 0900 0900 0900 0900  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0032 0140 4142 4344 4546 4748 494a 4b4c  
 0000020: 0900 0900 0900 0900 0900 0900 0900 0900  
-0000030: 0900 0900 5b5c 5d5e 5f60 6162 6364 6566  
-0000040: 670b 0000 0000 0000 0000 0b00 0000 0000  
-0000050: 0000 000b 0000 0000 0000 0000 0b00 0000  
-0000060: 0000 0000 000b 0000 0000 0000 0000 0b00  
-0000070: 0000 0000 0000 000b 0000 0000 0000 0000  
-0000080: 0b00 0000 0000 0000 000b 0000 0000 0000  
-0000090: 0000 0b00 0000 0000 0000 000b 0000 0000  
-00000a0: 0000 0000 0b00 0000 0000 0000 000b 0000  
-00000b0: 0000 0000 0000 0b00 0000 0000 0000 0075  
-00000c0: 7677 7879 7a7d 0d00 0000 000d 0000 0000  
-00000d0: 0d00 0000 000d 0000 0000 0d00 0000 000d  
-00000e0: 0000 0000 0d00 0000 000d 0000 0000 898a  
-00000f0: 8b8c 8d8e 910c 0000 0000 0000 0000 0c00  
-0000100: 0000 0000 0000 000c 0000 0000 0000 0000  
-0000110: 0c00 0000 0000 0000 000c 0000 0000 0000  
-0000120: 0000 0c00 0000 0000 0000 000c 0000 0000  
-0000130: 0000 0000 0c00 0000 0000 0000 0006       
+0000030: 0900 0900 0900 0900 0900 0900 5b5c 5d5e  
+0000040: 5f60 6162 6364 6566 670b 0000 0000 0000  
+0000050: 0000 0b00 0000 0000 0000 000b 0000 0000  
+0000060: 0000 0000 0b00 0000 0000 0000 000b 0000  
+0000070: 0000 0000 0000 0b00 0000 0000 0000 000b  
+0000080: 0000 0000 0000 0000 0b00 0000 0000 0000  
+0000090: 000b 0000 0000 0000 0000 0b00 0000 0000  
+00000a0: 0000 000b 0000 0000 0000 0000 0b00 0000  
+00000b0: 0000 0000 000b 0000 0000 0000 0000 0b00  
+00000c0: 0000 0000 0000 0075 7677 7879 7a7d 0d00  
+00000d0: 0000 000d 0000 0000 0d00 0000 000d 0000  
+00000e0: 0000 0d00 0000 000d 0000 0000 0d00 0000  
+00000f0: 000d 0000 0000 898a 8b8c 8d8e 910c 0000  
+0000100: 0000 0000 0000 0c00 0000 0000 0000 000c  
+0000110: 0000 0000 0000 0000 0c00 0000 0000 0000  
+0000120: 000c 0000 0000 0000 0000 0c00 0000 0000  
+0000130: 0000 000c 0000 0000 0000 0000 0c00 0000  
+0000140: 0000 0000 0006                           
 ;;; STDOUT ;;)

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -47,29 +47,23 @@
       (br 0)     ;; also depth 1
 )))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 02                                         ; num expressions (byte 1)
-000000d: 01                                         ; OPCODE_BLOCK
-000000e: ff                                         ; num expressions (byte 0)
-000000f: 00                                         ; OPCODE_NOP
-0000010: 00                                         ; OPCODE_NOP
-0000011: 00                                         ; OPCODE_NOP
-0000012: 00                                         ; OPCODE_NOP
-0000013: 00                                         ; OPCODE_NOP
-0000014: 00                                         ; OPCODE_NOP
-0000015: 00                                         ; OPCODE_NOP
-0000016: 00                                         ; OPCODE_NOP
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 01                                         ; OPCODE_BLOCK
+0000014: 02                                         ; num expressions (byte 1)
+0000015: 01                                         ; OPCODE_BLOCK
+0000016: ff                                         ; num expressions (byte 0)
 0000017: 00                                         ; OPCODE_NOP
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
@@ -317,20 +311,28 @@
 000010b: 00                                         ; OPCODE_NOP
 000010c: 00                                         ; OPCODE_NOP
 000010d: 00                                         ; OPCODE_NOP
-000010e: 01                                         ; OPCODE_BLOCK
-000010f: 03                                         ; num expressions (byte 0)
+000010e: 00                                         ; OPCODE_NOP
+000010f: 00                                         ; OPCODE_NOP
 0000110: 00                                         ; OPCODE_NOP
-0000111: 06                                         ; OPCODE_BR
-0000112: 01                                         ; break depth
+0000111: 00                                         ; OPCODE_NOP
+0000112: 00                                         ; OPCODE_NOP
 0000113: 00                                         ; OPCODE_NOP
-0000114: 06                                         ; OPCODE_BR
-0000115: 01                                         ; break depth
-0000116: 00                                         ; OPCODE_NOP
-0000009: 0c01                                       ; FIXUP func body size
-0000117: 06                                         ; WASM_BINARY_SECTION_END
+0000114: 00                                         ; OPCODE_NOP
+0000115: 00                                         ; OPCODE_NOP
+0000116: 01                                         ; OPCODE_BLOCK
+0000117: 03                                         ; num expressions (byte 0)
+0000118: 00                                         ; OPCODE_NOP
+0000119: 06                                         ; OPCODE_BR
+000011a: 01                                         ; break depth
+000011b: 00                                         ; OPCODE_NOP
+000011c: 06                                         ; OPCODE_BR
+000011d: 01                                         ; break depth
+000011e: 00                                         ; OPCODE_NOP
+0000011: 0c01                                       ; FIXUP func body size
+000011f: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 000c 0101 0201 ff00  
-0000010: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 000c 0101 0201 ff00 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -345,6 +347,6 @@
 00000d0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000100: 0000 0000 0000 0000 0000 0000 0000 0103  
-0000110: 0006 0100 0601 0006                      
+0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000110: 0000 0000 0000 0103 0006 0100 0601 0006  
 ;;; STDOUT ;;)

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -45,29 +45,23 @@
       ;; 257
       (nop))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 02                                         ; num expressions (byte 1)
-000000d: 01                                         ; OPCODE_BLOCK
-000000e: ff                                         ; num expressions (byte 0)
-000000f: 00                                         ; OPCODE_NOP
-0000010: 00                                         ; OPCODE_NOP
-0000011: 00                                         ; OPCODE_NOP
-0000012: 00                                         ; OPCODE_NOP
-0000013: 00                                         ; OPCODE_NOP
-0000014: 00                                         ; OPCODE_NOP
-0000015: 00                                         ; OPCODE_NOP
-0000016: 00                                         ; OPCODE_NOP
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 01                                         ; OPCODE_BLOCK
+0000014: 02                                         ; num expressions (byte 1)
+0000015: 01                                         ; OPCODE_BLOCK
+0000016: ff                                         ; num expressions (byte 0)
 0000017: 00                                         ; OPCODE_NOP
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
@@ -315,15 +309,23 @@
 000010b: 00                                         ; OPCODE_NOP
 000010c: 00                                         ; OPCODE_NOP
 000010d: 00                                         ; OPCODE_NOP
-000010e: 01                                         ; OPCODE_BLOCK
-000010f: 02                                         ; num expressions (byte 0)
+000010e: 00                                         ; OPCODE_NOP
+000010f: 00                                         ; OPCODE_NOP
 0000110: 00                                         ; OPCODE_NOP
 0000111: 00                                         ; OPCODE_NOP
-0000009: 0701                                       ; FIXUP func body size
-0000112: 06                                         ; WASM_BINARY_SECTION_END
+0000112: 00                                         ; OPCODE_NOP
+0000113: 00                                         ; OPCODE_NOP
+0000114: 00                                         ; OPCODE_NOP
+0000115: 00                                         ; OPCODE_NOP
+0000116: 01                                         ; OPCODE_BLOCK
+0000117: 02                                         ; num expressions (byte 0)
+0000118: 00                                         ; OPCODE_NOP
+0000119: 00                                         ; OPCODE_NOP
+0000011: 0701                                       ; FIXUP func body size
+000011a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0007 0101 0201 ff00  
-0000010: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0007 0101 0201 ff00 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -338,6 +340,6 @@
 00000d0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000100: 0000 0000 0000 0000 0000 0000 0000 0102  
-0000110: 0000 06                                  
+0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000110: 0000 0000 0000 0102 0000 06              
 ;;; STDOUT ;;)

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -10,37 +10,40 @@
     (block
       (i32.const 1))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 02                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 02                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
 ; signature 1
-0000004: 00                                         ; num params
-0000005: 01                                         ; result_type
-0000006: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000007: 02                                         ; num functions
+000000c: 00                                         ; num params
+000000d: 01                                         ; result_type
+000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000f: 02                                         ; num functions
 ; function 0
-0000008: 00                                         ; func flags
-0000009: 0000                                       ; func signature index
-000000b: 0000                                       ; func body size
-000000d: 01                                         ; OPCODE_BLOCK
-000000e: 03                                         ; num expressions
-000000f: 00                                         ; OPCODE_NOP
-0000010: 00                                         ; OPCODE_NOP
-0000011: 00                                         ; OPCODE_NOP
-000000b: 0500                                       ; FIXUP func body size
+0000010: 00                                         ; func flags
+0000011: 0000                                       ; func signature index
+0000013: 0000                                       ; func body size
+0000015: 01                                         ; OPCODE_BLOCK
+0000016: 03                                         ; num expressions
+0000017: 00                                         ; OPCODE_NOP
+0000018: 00                                         ; OPCODE_NOP
+0000019: 00                                         ; OPCODE_NOP
+0000013: 0500                                       ; FIXUP func body size
 ; function 1
-0000012: 00                                         ; func flags
-0000013: 0100                                       ; func signature index
-0000015: 0000                                       ; func body size
-0000017: 01                                         ; OPCODE_BLOCK
-0000018: 01                                         ; num expressions
-0000019: 09                                         ; OPCODE_I8_CONST
-000001a: 01                                         ; u8 literal
-0000015: 0400                                       ; FIXUP func body size
-000001b: 06                                         ; WASM_BINARY_SECTION_END
+000001a: 00                                         ; func flags
+000001b: 0100                                       ; func signature index
+000001d: 0000                                       ; func body size
+000001f: 01                                         ; OPCODE_BLOCK
+0000020: 01                                         ; num expressions
+0000021: 09                                         ; OPCODE_I8_CONST
+0000022: 01                                         ; u8 literal
+000001d: 0400                                       ; FIXUP func body size
+0000023: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0102 0000 0001 0202 0000 0005 0001 0300  
-0000010: 0000 0001 0004 0001 0109 0106            
+0000000: 0061 736d 0a00 0000 0102 0000 0001 0202  
+0000010: 0000 0005 0001 0300 0000 0001 0004 0001  
+0000020: 0109 0106                                
 ;;; STDOUT ;;)

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -9,36 +9,39 @@
             (br $inner)
             (br $outer)))))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 01                                         ; num expressions
-000000d: 02                                         ; OPCODE_LOOP
-000000e: 01                                         ; num expressions
-000000f: 01                                         ; OPCODE_BLOCK
-0000010: 02                                         ; num expressions
-0000011: 09                                         ; OPCODE_I8_CONST
-0000012: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
 0000013: 01                                         ; OPCODE_BLOCK
-0000014: 02                                         ; num expressions
-0000015: 06                                         ; OPCODE_BR
-0000016: 00                                         ; break depth
-0000017: 00                                         ; OPCODE_NOP
-0000018: 06                                         ; OPCODE_BR
-0000019: 04                                         ; break depth
-000001a: 00                                         ; OPCODE_NOP
-0000009: 1000                                       ; FIXUP func body size
-000001b: 06                                         ; WASM_BINARY_SECTION_END
+0000014: 01                                         ; num expressions
+0000015: 02                                         ; OPCODE_LOOP
+0000016: 01                                         ; num expressions
+0000017: 01                                         ; OPCODE_BLOCK
+0000018: 02                                         ; num expressions
+0000019: 09                                         ; OPCODE_I8_CONST
+000001a: 00                                         ; u8 literal
+000001b: 01                                         ; OPCODE_BLOCK
+000001c: 02                                         ; num expressions
+000001d: 06                                         ; OPCODE_BR
+000001e: 00                                         ; break depth
+000001f: 00                                         ; OPCODE_NOP
+0000020: 06                                         ; OPCODE_BR
+0000021: 04                                         ; break depth
+0000022: 00                                         ; OPCODE_NOP
+0000011: 1000                                       ; FIXUP func body size
+0000023: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0010 0001 0102 0101  
-0000010: 0209 0001 0206 0000 0604 0006            
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0010 0001 0102 0101 0209 0001 0206 0000  
+0000020: 0604 0006                                
 ;;; STDOUT ;;)

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -12,46 +12,48 @@
             (br 2)
             (br 3)))))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 01                                         ; num expressions
-000000d: 02                                         ; OPCODE_LOOP
-000000e: 01                                         ; num expressions
-000000f: 01                                         ; OPCODE_BLOCK
-0000010: 02                                         ; num expressions
-0000011: 09                                         ; OPCODE_I8_CONST
-0000012: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
 0000013: 01                                         ; OPCODE_BLOCK
-0000014: 05                                         ; num expressions
-0000015: 06                                         ; OPCODE_BR
-0000016: 00                                         ; break depth
-0000017: 00                                         ; OPCODE_NOP
-0000018: 06                                         ; OPCODE_BR
-0000019: 00                                         ; break depth
-000001a: 00                                         ; OPCODE_NOP
-000001b: 06                                         ; OPCODE_BR
-000001c: 01                                         ; break depth
-000001d: 00                                         ; OPCODE_NOP
-000001e: 06                                         ; OPCODE_BR
-000001f: 02                                         ; break depth
-0000020: 00                                         ; OPCODE_NOP
-0000021: 06                                         ; OPCODE_BR
-0000022: 03                                         ; break depth
-0000023: 00                                         ; OPCODE_NOP
-0000009: 1900                                       ; FIXUP func body size
-0000024: 06                                         ; WASM_BINARY_SECTION_END
+0000014: 01                                         ; num expressions
+0000015: 02                                         ; OPCODE_LOOP
+0000016: 01                                         ; num expressions
+0000017: 01                                         ; OPCODE_BLOCK
+0000018: 02                                         ; num expressions
+0000019: 09                                         ; OPCODE_I8_CONST
+000001a: 00                                         ; u8 literal
+000001b: 01                                         ; OPCODE_BLOCK
+000001c: 05                                         ; num expressions
+000001d: 06                                         ; OPCODE_BR
+000001e: 00                                         ; break depth
+000001f: 00                                         ; OPCODE_NOP
+0000020: 06                                         ; OPCODE_BR
+0000021: 00                                         ; break depth
+0000022: 00                                         ; OPCODE_NOP
+0000023: 06                                         ; OPCODE_BR
+0000024: 01                                         ; break depth
+0000025: 00                                         ; OPCODE_NOP
+0000026: 06                                         ; OPCODE_BR
+0000027: 02                                         ; break depth
+0000028: 00                                         ; OPCODE_NOP
+0000029: 06                                         ; OPCODE_BR
+000002a: 03                                         ; break depth
+000002b: 00                                         ; OPCODE_NOP
+0000011: 1900                                       ; FIXUP func body size
+000002c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0019 0001 0102 0101  
-0000010: 0209 0001 0506 0000 0600 0006 0100 0602  
-0000020: 0006 0300 06                             
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0019 0001 0102 0101 0209 0001 0506 0000  
+0000020: 0600 0006 0100 0602 0006 0300 06         
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -8,37 +8,40 @@
         (br $exit (i32.const 4)))
       (i32.const 5))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 01                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 01                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 03                                         ; num expressions
-000000d: 03                                         ; OPCODE_IF
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 01                                         ; u8 literal
-0000010: 06                                         ; OPCODE_BR
-0000011: 00                                         ; break depth
-0000012: 00                                         ; OPCODE_NOP
-0000013: 03                                         ; OPCODE_IF
-0000014: 09                                         ; OPCODE_I8_CONST
-0000015: 03                                         ; u8 literal
-0000016: 06                                         ; OPCODE_BR
-0000017: 01                                         ; break depth
-0000018: 09                                         ; OPCODE_I8_CONST
-0000019: 04                                         ; u8 literal
-000001a: 09                                         ; OPCODE_I8_CONST
-000001b: 05                                         ; u8 literal
-0000009: 1100                                       ; FIXUP func body size
-000001c: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 03                                         ; num expressions
+0000015: 03                                         ; OPCODE_IF
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 01                                         ; u8 literal
+0000018: 06                                         ; OPCODE_BR
+0000019: 00                                         ; break depth
+000001a: 00                                         ; OPCODE_NOP
+000001b: 03                                         ; OPCODE_IF
+000001c: 09                                         ; OPCODE_I8_CONST
+000001d: 03                                         ; u8 literal
+000001e: 06                                         ; OPCODE_BR
+000001f: 01                                         ; break depth
+0000020: 09                                         ; OPCODE_I8_CONST
+0000021: 04                                         ; u8 literal
+0000022: 09                                         ; OPCODE_I8_CONST
+0000023: 05                                         ; u8 literal
+0000011: 1100                                       ; FIXUP func body size
+0000024: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0001 0201 0000 0011 0002 0303 0901  
-0000010: 0600 0003 0903 0601 0904 0905 06         
+0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
+0000010: 0011 0002 0303 0901 0600 0003 0903 0601  
+0000020: 0904 0905 06                             
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -7,34 +7,37 @@
       (if (i32.const 2)
         (br $cont)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 02                                         ; num expressions
-000000d: 03                                         ; OPCODE_IF
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 01                                         ; u8 literal
-0000010: 06                                         ; OPCODE_BR
-0000011: 01                                         ; break depth
-0000012: 00                                         ; OPCODE_NOP
-0000013: 03                                         ; OPCODE_IF
-0000014: 09                                         ; OPCODE_I8_CONST
-0000015: 02                                         ; u8 literal
-0000016: 06                                         ; OPCODE_BR
-0000017: 00                                         ; break depth
-0000018: 00                                         ; OPCODE_NOP
-0000009: 0e00                                       ; FIXUP func body size
-0000019: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 02                                         ; num expressions
+0000015: 03                                         ; OPCODE_IF
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 01                                         ; u8 literal
+0000018: 06                                         ; OPCODE_BR
+0000019: 01                                         ; break depth
+000001a: 00                                         ; OPCODE_NOP
+000001b: 03                                         ; OPCODE_IF
+000001c: 09                                         ; OPCODE_I8_CONST
+000001d: 02                                         ; u8 literal
+000001e: 06                                         ; OPCODE_BR
+000001f: 00                                         ; break depth
+0000020: 00                                         ; OPCODE_NOP
+0000011: 0e00                                       ; FIXUP func body size
+0000021: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 000e 0002 0203 0901  
-0000010: 0601 0003 0902 0600 0006                 
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 000e 0002 0203 0901 0601 0003 0902 0600  
+0000020: 0006                                     
 ;;; STDOUT ;;)

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -5,28 +5,30 @@
       (if (i32.const 1)
         (br $cont)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 01                                         ; num expressions
-000000d: 03                                         ; OPCODE_IF
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 01                                         ; u8 literal
-0000010: 06                                         ; OPCODE_BR
-0000011: 00                                         ; break depth
-0000012: 00                                         ; OPCODE_NOP
-0000009: 0800                                       ; FIXUP func body size
-0000013: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 01                                         ; num expressions
+0000015: 03                                         ; OPCODE_IF
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 01                                         ; u8 literal
+0000018: 06                                         ; OPCODE_BR
+0000019: 00                                         ; break depth
+000001a: 00                                         ; OPCODE_NOP
+0000011: 0800                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0008 0002 0103 0901  
-0000010: 0600 0006                                
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0008 0002 0103 0901 0600 0006            
 ;;; STDOUT ;;)

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -4,27 +4,29 @@
     (loop $cont
       (br_if $cont (i32.const 0)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 01                                         ; num expressions
-000000d: 07                                         ; OPCODE_BR_IF
-000000e: 00                                         ; break depth
-000000f: 00                                         ; OPCODE_NOP
-0000010: 09                                         ; OPCODE_I8_CONST
-0000011: 00                                         ; u8 literal
-0000009: 0700                                       ; FIXUP func body size
-0000012: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 01                                         ; num expressions
+0000015: 07                                         ; OPCODE_BR_IF
+0000016: 00                                         ; break depth
+0000017: 00                                         ; OPCODE_NOP
+0000018: 09                                         ; OPCODE_I8_CONST
+0000019: 00                                         ; u8 literal
+0000011: 0700                                       ; FIXUP func body size
+000001a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0007 0002 0107 0000  
-0000010: 0900 06                                  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0007 0002 0107 0000 0900 06              
 ;;; STDOUT ;;)

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -4,27 +4,29 @@
     (block $foo
       (br_if $foo (i32.const 1)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 01                                         ; num expressions
-000000d: 07                                         ; OPCODE_BR_IF
-000000e: 00                                         ; break depth
-000000f: 00                                         ; OPCODE_NOP
-0000010: 09                                         ; OPCODE_I8_CONST
-0000011: 01                                         ; u8 literal
-0000009: 0700                                       ; FIXUP func body size
-0000012: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 01                                         ; OPCODE_BLOCK
+0000014: 01                                         ; num expressions
+0000015: 07                                         ; OPCODE_BR_IF
+0000016: 00                                         ; break depth
+0000017: 00                                         ; OPCODE_NOP
+0000018: 09                                         ; OPCODE_I8_CONST
+0000019: 01                                         ; u8 literal
+0000011: 0700                                       ; FIXUP func body size
+000001a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0007 0001 0107 0000  
-0000010: 0901 06                                  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0007 0001 0107 0000 0901 06              
 ;;; STDOUT ;;)

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -3,25 +3,27 @@
   (func (param i32)
     (call 0 (i32.const 1))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 01                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000006: 01                                         ; num functions
+000000a: 01                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000e: 01                                         ; num functions
 ; function 0
-0000007: 00                                         ; func flags
-0000008: 0000                                       ; func signature index
-000000a: 0000                                       ; func body size
-000000c: 12                                         ; OPCODE_CALL_FUNCTION
-000000d: 00                                         ; func index
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 01                                         ; u8 literal
-000000a: 0400                                       ; FIXUP func body size
-0000010: 06                                         ; WASM_BINARY_SECTION_END
+000000f: 00                                         ; func flags
+0000010: 0000                                       ; func signature index
+0000012: 0000                                       ; func body size
+0000014: 12                                         ; OPCODE_CALL_FUNCTION
+0000015: 00                                         ; func index
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 01                                         ; u8 literal
+0000012: 0400                                       ; FIXUP func body size
+0000018: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0100 0102 0100 0000 0400 1200 0901  
-0000010: 06                                       
+0000000: 0061 736d 0a00 0000 0101 0100 0102 0100  
+0000010: 0000 0400 1200 0901 06                   
 ;;; STDOUT ;;)

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -10,47 +10,50 @@
     ;; first.
     (call 0)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 02                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 02                                         ; num signatures
 ; signature 0
-0000002: 02                                         ; num params
-0000003: 01                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 03                                         ; param type
+000000a: 02                                         ; num params
+000000b: 01                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 03                                         ; param type
 ; signature 1
-0000006: 00                                         ; num params
-0000007: 01                                         ; result_type
-0000008: 08                                         ; WASM_BINARY_SECTION_IMPORTS
-0000009: 01                                         ; num imports
+000000e: 00                                         ; num params
+000000f: 01                                         ; result_type
+0000010: 08                                         ; WASM_BINARY_SECTION_IMPORTS
+0000011: 01                                         ; num imports
 ; import header 0
-000000a: 0000                                       ; import signature index
-000000c: 0000 0000                                  ; import module name offset
-0000010: 0000 0000                                  ; import function name offset
-0000014: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000015: 01                                         ; num functions
+0000012: 0000                                       ; import signature index
+0000014: 0000 0000                                  ; import module name offset
+0000018: 0000 0000                                  ; import function name offset
+000001c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000001d: 01                                         ; num functions
 ; function 0
-0000016: 00                                         ; func flags
-0000017: 0100                                       ; func signature index
-0000019: 0000                                       ; func body size
-000001b: 1f                                         ; OPCODE_CALL_IMPORT
-000001c: 00                                         ; import index
-000001d: 09                                         ; OPCODE_I8_CONST
-000001e: 01                                         ; u8 literal
-000001f: 0d                                         ; OPCODE_F32_CONST
-0000020: 0000 0040                                  ; f32 literal
-0000024: 12                                         ; OPCODE_CALL_FUNCTION
-0000025: 00                                         ; func index
-0000019: 0b00                                       ; FIXUP func body size
-0000026: 06                                         ; WASM_BINARY_SECTION_END
+000001e: 00                                         ; func flags
+000001f: 0100                                       ; func signature index
+0000021: 0000                                       ; func body size
+0000023: 1f                                         ; OPCODE_CALL_IMPORT
+0000024: 00                                         ; import index
+0000025: 09                                         ; OPCODE_I8_CONST
+0000026: 01                                         ; u8 literal
+0000027: 0d                                         ; OPCODE_F32_CONST
+0000028: 0000 0040                                  ; f32 literal
+000002c: 12                                         ; OPCODE_CALL_FUNCTION
+000002d: 00                                         ; func index
+0000021: 0b00                                       ; FIXUP func body size
+000002e: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-000000c: 2700 0000                                  ; FIXUP import module name offset
-0000027: 666f 6f                                    ; import module name
-000002a: 00                                         ; \0
-0000010: 2b00 0000                                  ; FIXUP import function name offset
-000002b: 6261 72                                    ; import function name
-000002e: 00                                         ; \0
+0000014: 2f00 0000                                  ; FIXUP import module name offset
+000002f: 666f 6f                                    ; import module name
+0000032: 00                                         ; \0
+0000018: 3300 0000                                  ; FIXUP import function name offset
+0000033: 6261 72                                    ; import function name
+0000036: 00                                         ; \0
 ;; dump
-0000000: 0102 0201 0103 0001 0801 0000 2700 0000  
-0000010: 2b00 0000 0201 0001 000b 001f 0009 010d  
-0000020: 0000 0040 1200 0666 6f6f 0062 6172 00    
+0000000: 0061 736d 0a00 0000 0102 0201 0103 0001  
+0000010: 0801 0000 2f00 0000 3300 0000 0201 0001  
+0000020: 000b 001f 0009 010d 0000 0040 1200 0666  
+0000030: 6f6f 0062 6172 00                        
 ;;; STDOUT ;;)

--- a/test/dump/callindirect-after-import.txt
+++ b/test/dump/callindirect-after-import.txt
@@ -18,57 +18,59 @@
   ;; should be function 1.
   (table $indirect))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 03                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 03                                         ; num signatures
 ; signature 0
-0000002: 01                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 03                                         ; param type
+000000a: 01                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 03                                         ; param type
 ; signature 1
-0000005: 00                                         ; num params
-0000006: 01                                         ; result_type
+000000d: 00                                         ; num params
+000000e: 01                                         ; result_type
 ; signature 2
-0000007: 00                                         ; num params
-0000008: 00                                         ; result_type
-0000009: 08                                         ; WASM_BINARY_SECTION_IMPORTS
-000000a: 01                                         ; num imports
+000000f: 00                                         ; num params
+0000010: 00                                         ; result_type
+0000011: 08                                         ; WASM_BINARY_SECTION_IMPORTS
+0000012: 01                                         ; num imports
 ; import header 0
-000000b: 0100                                       ; import signature index
-000000d: 0000 0000                                  ; import module name offset
-0000011: 0000 0000                                  ; import function name offset
-0000015: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000016: 02                                         ; num functions
+0000013: 0100                                       ; import signature index
+0000015: 0000 0000                                  ; import module name offset
+0000019: 0000 0000                                  ; import function name offset
+000001d: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000001e: 02                                         ; num functions
 ; function 0
-0000017: 00                                         ; func flags
-0000018: 0000                                       ; func signature index
-000001a: 0000                                       ; func body size
-000001c: 00                                         ; OPCODE_NOP
-000001a: 0100                                       ; FIXUP func body size
+000001f: 00                                         ; func flags
+0000020: 0000                                       ; func signature index
+0000022: 0000                                       ; func body size
+0000024: 00                                         ; OPCODE_NOP
+0000022: 0100                                       ; FIXUP func body size
 ; function 1
-000001d: 00                                         ; func flags
-000001e: 0200                                       ; func signature index
-0000020: 0000                                       ; func body size
-0000022: 13                                         ; OPCODE_CALL_INDIRECT
-0000023: 00                                         ; signature index
-0000024: 09                                         ; OPCODE_I8_CONST
-0000025: 00                                         ; u8 literal
-0000026: 0d                                         ; OPCODE_F32_CONST
-0000027: 0000 803f                                  ; f32 literal
-0000020: 0900                                       ; FIXUP func body size
-000002b: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-000002c: 01                                         ; num function table entries
-000002d: 0000                                       ; function table entry
-000002f: 06                                         ; WASM_BINARY_SECTION_END
+0000025: 00                                         ; func flags
+0000026: 0200                                       ; func signature index
+0000028: 0000                                       ; func body size
+000002a: 13                                         ; OPCODE_CALL_INDIRECT
+000002b: 00                                         ; signature index
+000002c: 09                                         ; OPCODE_I8_CONST
+000002d: 00                                         ; u8 literal
+000002e: 0d                                         ; OPCODE_F32_CONST
+000002f: 0000 803f                                  ; f32 literal
+0000028: 0900                                       ; FIXUP func body size
+0000033: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+0000034: 01                                         ; num function table entries
+0000035: 0000                                       ; function table entry
+0000037: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-000000d: 3000 0000                                  ; FIXUP import module name offset
-0000030: 666f 6f                                    ; import module name
-0000033: 00                                         ; \0
-0000011: 3400 0000                                  ; FIXUP import function name offset
-0000034: 6261 72                                    ; import function name
-0000037: 00                                         ; \0
+0000015: 3800 0000                                  ; FIXUP import module name offset
+0000038: 666f 6f                                    ; import module name
+000003b: 00                                         ; \0
+0000019: 3c00 0000                                  ; FIXUP import function name offset
+000003c: 6261 72                                    ; import function name
+000003f: 00                                         ; \0
 ;; dump
-0000000: 0103 0100 0300 0100 0008 0101 0030 0000  
-0000010: 0034 0000 0002 0200 0000 0100 0000 0200  
-0000020: 0900 1300 0900 0d00 0080 3f05 0100 0006  
-0000030: 666f 6f00 6261 7200                      
+0000000: 0061 736d 0a00 0000 0103 0100 0300 0100  
+0000010: 0008 0101 0038 0000 003c 0000 0002 0200  
+0000020: 0000 0100 0000 0200 0900 1300 0900 0d00  
+0000030: 0080 3f05 0100 0006 666f 6f00 6261 7200  
 ;;; STDOUT ;;)

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -5,30 +5,32 @@
     (call_indirect $t (i32.const 0) (i32.const 0)))
   (table $f))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 01                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000006: 01                                         ; num functions
+000000a: 01                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000e: 01                                         ; num functions
 ; function 0
-0000007: 00                                         ; func flags
-0000008: 0000                                       ; func signature index
-000000a: 0000                                       ; func body size
-000000c: 13                                         ; OPCODE_CALL_INDIRECT
-000000d: 00                                         ; signature index
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 00                                         ; u8 literal
-0000010: 09                                         ; OPCODE_I8_CONST
-0000011: 00                                         ; u8 literal
-000000a: 0600                                       ; FIXUP func body size
-0000012: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-0000013: 01                                         ; num function table entries
-0000014: 0000                                       ; function table entry
-0000016: 06                                         ; WASM_BINARY_SECTION_END
+000000f: 00                                         ; func flags
+0000010: 0000                                       ; func signature index
+0000012: 0000                                       ; func body size
+0000014: 13                                         ; OPCODE_CALL_INDIRECT
+0000015: 00                                         ; signature index
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 00                                         ; u8 literal
+0000018: 09                                         ; OPCODE_I8_CONST
+0000019: 00                                         ; u8 literal
+0000012: 0600                                       ; FIXUP func body size
+000001a: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+000001b: 01                                         ; num function table entries
+000001c: 0000                                       ; function table entry
+000001e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0100 0102 0100 0000 0600 1300 0900  
-0000010: 0900 0501 0000 06                        
+0000000: 0061 736d 0a00 0000 0101 0100 0102 0100  
+0000010: 0000 0600 1300 0900 0900 0501 0000 06    
 ;;; STDOUT ;;)

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -7,33 +7,36 @@
     (f64.reinterpret/i64 (i64.const 0))
     (i64.reinterpret/f64 (f64.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: ad                                         ; OPCODE_F32_REINTERPRET_I32
-000000c: 09                                         ; OPCODE_I8_CONST
-000000d: 00                                         ; u8 literal
-000000e: b4                                         ; OPCODE_I32_REINTERPRET_F32
-000000f: 0d                                         ; OPCODE_F32_CONST
-0000010: 0000 0000                                  ; f32 literal
-0000014: b3                                         ; OPCODE_F64_REINTERPRET_I64
-0000015: 0b                                         ; OPCODE_I64_CONST
-0000016: 0000 0000 0000 0000                        ; u64 literal
-000001e: b5                                         ; OPCODE_I64_REINTERPRET_F64
-000001f: 0c                                         ; OPCODE_F64_CONST
-0000020: 0000 0000 0000 0000                        ; f64 literal
-0000009: 1d00                                       ; FIXUP func body size
-0000028: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: ad                                         ; OPCODE_F32_REINTERPRET_I32
+0000014: 09                                         ; OPCODE_I8_CONST
+0000015: 00                                         ; u8 literal
+0000016: b4                                         ; OPCODE_I32_REINTERPRET_F32
+0000017: 0d                                         ; OPCODE_F32_CONST
+0000018: 0000 0000                                  ; f32 literal
+000001c: b3                                         ; OPCODE_F64_REINTERPRET_I64
+000001d: 0b                                         ; OPCODE_I64_CONST
+000001e: 0000 0000 0000 0000                        ; u64 literal
+0000026: b5                                         ; OPCODE_I64_REINTERPRET_F64
+0000027: 0c                                         ; OPCODE_F64_CONST
+0000028: 0000 0000 0000 0000                        ; f64 literal
+0000011: 1d00                                       ; FIXUP func body size
+0000030: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 001d 00ad 0900 b40d  
-0000010: 0000 0000 b30b 0000 0000 0000 0000 b50c  
-0000020: 0000 0000 0000 0000 06                   
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 001d 00ad 0900 b40d 0000 0000 b30b 0000  
+0000020: 0000 0000 0000 b50c 0000 0000 0000 0000  
+0000030: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -50,35 +50,29 @@
     (f64.gt (f64.const 0) (f64.const 0))
     (f64.ge (f64.const 0) (f64.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 4d                                         ; OPCODE_I32_EQ
-000000c: 4e                                         ; OPCODE_I32_NE
-000000d: 4f                                         ; OPCODE_I32_LT_S
-000000e: 51                                         ; OPCODE_I32_LT_U
-000000f: 50                                         ; OPCODE_I32_LE_S
-0000010: 52                                         ; OPCODE_I32_LE_U
-0000011: 53                                         ; OPCODE_I32_GT_S
-0000012: 55                                         ; OPCODE_I32_GT_U
-0000013: 54                                         ; OPCODE_I32_GE_S
-0000014: 56                                         ; OPCODE_I32_GE_U
-0000015: 09                                         ; OPCODE_I8_CONST
-0000016: 00                                         ; u8 literal
-0000017: 09                                         ; OPCODE_I8_CONST
-0000018: 00                                         ; u8 literal
-0000019: 09                                         ; OPCODE_I8_CONST
-000001a: 00                                         ; u8 literal
-000001b: 09                                         ; OPCODE_I8_CONST
-000001c: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 4d                                         ; OPCODE_I32_EQ
+0000014: 4e                                         ; OPCODE_I32_NE
+0000015: 4f                                         ; OPCODE_I32_LT_S
+0000016: 51                                         ; OPCODE_I32_LT_U
+0000017: 50                                         ; OPCODE_I32_LE_S
+0000018: 52                                         ; OPCODE_I32_LE_U
+0000019: 53                                         ; OPCODE_I32_GT_S
+000001a: 55                                         ; OPCODE_I32_GT_U
+000001b: 54                                         ; OPCODE_I32_GE_S
+000001c: 56                                         ; OPCODE_I32_GE_U
 000001d: 09                                         ; OPCODE_I8_CONST
 000001e: 00                                         ; u8 literal
 000001f: 09                                         ; OPCODE_I8_CONST
@@ -93,143 +87,152 @@
 0000028: 00                                         ; u8 literal
 0000029: 09                                         ; OPCODE_I8_CONST
 000002a: 00                                         ; u8 literal
-000002b: 68                                         ; OPCODE_I64_EQ
-000002c: 0b                                         ; OPCODE_I64_CONST
-000002d: 0000 0000 0000 0000                        ; u64 literal
-0000035: 0b                                         ; OPCODE_I64_CONST
-0000036: 0000 0000 0000 0000                        ; u64 literal
-000003e: 69                                         ; OPCODE_I64_NE
-000003f: 0b                                         ; OPCODE_I64_CONST
-0000040: 0000 0000 0000 0000                        ; u64 literal
-0000048: 0b                                         ; OPCODE_I64_CONST
-0000049: 0000 0000 0000 0000                        ; u64 literal
-0000051: 6a                                         ; OPCODE_I64_LT_S
-0000052: 0b                                         ; OPCODE_I64_CONST
-0000053: 0000 0000 0000 0000                        ; u64 literal
-000005b: 0b                                         ; OPCODE_I64_CONST
-000005c: 0000 0000 0000 0000                        ; u64 literal
-0000064: 6c                                         ; OPCODE_I64_LT_U
-0000065: 0b                                         ; OPCODE_I64_CONST
-0000066: 0000 0000 0000 0000                        ; u64 literal
-000006e: 0b                                         ; OPCODE_I64_CONST
-000006f: 0000 0000 0000 0000                        ; u64 literal
-0000077: 6b                                         ; OPCODE_I64_LE_S
-0000078: 0b                                         ; OPCODE_I64_CONST
-0000079: 0000 0000 0000 0000                        ; u64 literal
-0000081: 0b                                         ; OPCODE_I64_CONST
-0000082: 0000 0000 0000 0000                        ; u64 literal
-000008a: 6d                                         ; OPCODE_I64_LE_U
-000008b: 0b                                         ; OPCODE_I64_CONST
-000008c: 0000 0000 0000 0000                        ; u64 literal
-0000094: 0b                                         ; OPCODE_I64_CONST
-0000095: 0000 0000 0000 0000                        ; u64 literal
-000009d: 6e                                         ; OPCODE_I64_GT_S
-000009e: 0b                                         ; OPCODE_I64_CONST
-000009f: 0000 0000 0000 0000                        ; u64 literal
-00000a7: 0b                                         ; OPCODE_I64_CONST
-00000a8: 0000 0000 0000 0000                        ; u64 literal
-00000b0: 70                                         ; OPCODE_I64_GT_U
-00000b1: 0b                                         ; OPCODE_I64_CONST
-00000b2: 0000 0000 0000 0000                        ; u64 literal
-00000ba: 0b                                         ; OPCODE_I64_CONST
-00000bb: 0000 0000 0000 0000                        ; u64 literal
-00000c3: 6f                                         ; OPCODE_I64_GE_S
-00000c4: 0b                                         ; OPCODE_I64_CONST
-00000c5: 0000 0000 0000 0000                        ; u64 literal
-00000cd: 0b                                         ; OPCODE_I64_CONST
-00000ce: 0000 0000 0000 0000                        ; u64 literal
-00000d6: 71                                         ; OPCODE_I64_GE_U
-00000d7: 0b                                         ; OPCODE_I64_CONST
-00000d8: 0000 0000 0000 0000                        ; u64 literal
-00000e0: 0b                                         ; OPCODE_I64_CONST
-00000e1: 0000 0000 0000 0000                        ; u64 literal
-00000e9: 83                                         ; OPCODE_F32_EQ
-00000ea: 0d                                         ; OPCODE_F32_CONST
-00000eb: 0000 0000                                  ; f32 literal
-00000ef: 0d                                         ; OPCODE_F32_CONST
-00000f0: 0000 0000                                  ; f32 literal
-00000f4: 84                                         ; OPCODE_F32_NE
-00000f5: 0d                                         ; OPCODE_F32_CONST
-00000f6: 0000 0000                                  ; f32 literal
-00000fa: 0d                                         ; OPCODE_F32_CONST
-00000fb: 0000 0000                                  ; f32 literal
-00000ff: 85                                         ; OPCODE_F32_LT
-0000100: 0d                                         ; OPCODE_F32_CONST
-0000101: 0000 0000                                  ; f32 literal
-0000105: 0d                                         ; OPCODE_F32_CONST
-0000106: 0000 0000                                  ; f32 literal
-000010a: 86                                         ; OPCODE_F32_LE
-000010b: 0d                                         ; OPCODE_F32_CONST
-000010c: 0000 0000                                  ; f32 literal
-0000110: 0d                                         ; OPCODE_F32_CONST
-0000111: 0000 0000                                  ; f32 literal
-0000115: 87                                         ; OPCODE_F32_GT
-0000116: 0d                                         ; OPCODE_F32_CONST
-0000117: 0000 0000                                  ; f32 literal
-000011b: 0d                                         ; OPCODE_F32_CONST
-000011c: 0000 0000                                  ; f32 literal
-0000120: 88                                         ; OPCODE_F32_GE
-0000121: 0d                                         ; OPCODE_F32_CONST
-0000122: 0000 0000                                  ; f32 literal
-0000126: 0d                                         ; OPCODE_F32_CONST
-0000127: 0000 0000                                  ; f32 literal
-000012b: 97                                         ; OPCODE_F64_EQ
-000012c: 0c                                         ; OPCODE_F64_CONST
-000012d: 0000 0000 0000 0000                        ; f64 literal
-0000135: 0c                                         ; OPCODE_F64_CONST
-0000136: 0000 0000 0000 0000                        ; f64 literal
-000013e: 98                                         ; OPCODE_F64_NE
-000013f: 0c                                         ; OPCODE_F64_CONST
-0000140: 0000 0000 0000 0000                        ; f64 literal
-0000148: 0c                                         ; OPCODE_F64_CONST
-0000149: 0000 0000 0000 0000                        ; f64 literal
-0000151: 99                                         ; OPCODE_F64_LT
-0000152: 0c                                         ; OPCODE_F64_CONST
-0000153: 0000 0000 0000 0000                        ; f64 literal
-000015b: 0c                                         ; OPCODE_F64_CONST
-000015c: 0000 0000 0000 0000                        ; f64 literal
-0000164: 9a                                         ; OPCODE_F64_LE
-0000165: 0c                                         ; OPCODE_F64_CONST
-0000166: 0000 0000 0000 0000                        ; f64 literal
-000016e: 0c                                         ; OPCODE_F64_CONST
-000016f: 0000 0000 0000 0000                        ; f64 literal
-0000177: 9b                                         ; OPCODE_F64_GT
-0000178: 0c                                         ; OPCODE_F64_CONST
-0000179: 0000 0000 0000 0000                        ; f64 literal
-0000181: 0c                                         ; OPCODE_F64_CONST
-0000182: 0000 0000 0000 0000                        ; f64 literal
-000018a: 9c                                         ; OPCODE_F64_GE
-000018b: 0c                                         ; OPCODE_F64_CONST
-000018c: 0000 0000 0000 0000                        ; f64 literal
-0000194: 0c                                         ; OPCODE_F64_CONST
-0000195: 0000 0000 0000 0000                        ; f64 literal
-0000009: 9201                                       ; FIXUP func body size
-000019d: 06                                         ; WASM_BINARY_SECTION_END
+000002b: 09                                         ; OPCODE_I8_CONST
+000002c: 00                                         ; u8 literal
+000002d: 09                                         ; OPCODE_I8_CONST
+000002e: 00                                         ; u8 literal
+000002f: 09                                         ; OPCODE_I8_CONST
+0000030: 00                                         ; u8 literal
+0000031: 09                                         ; OPCODE_I8_CONST
+0000032: 00                                         ; u8 literal
+0000033: 68                                         ; OPCODE_I64_EQ
+0000034: 0b                                         ; OPCODE_I64_CONST
+0000035: 0000 0000 0000 0000                        ; u64 literal
+000003d: 0b                                         ; OPCODE_I64_CONST
+000003e: 0000 0000 0000 0000                        ; u64 literal
+0000046: 69                                         ; OPCODE_I64_NE
+0000047: 0b                                         ; OPCODE_I64_CONST
+0000048: 0000 0000 0000 0000                        ; u64 literal
+0000050: 0b                                         ; OPCODE_I64_CONST
+0000051: 0000 0000 0000 0000                        ; u64 literal
+0000059: 6a                                         ; OPCODE_I64_LT_S
+000005a: 0b                                         ; OPCODE_I64_CONST
+000005b: 0000 0000 0000 0000                        ; u64 literal
+0000063: 0b                                         ; OPCODE_I64_CONST
+0000064: 0000 0000 0000 0000                        ; u64 literal
+000006c: 6c                                         ; OPCODE_I64_LT_U
+000006d: 0b                                         ; OPCODE_I64_CONST
+000006e: 0000 0000 0000 0000                        ; u64 literal
+0000076: 0b                                         ; OPCODE_I64_CONST
+0000077: 0000 0000 0000 0000                        ; u64 literal
+000007f: 6b                                         ; OPCODE_I64_LE_S
+0000080: 0b                                         ; OPCODE_I64_CONST
+0000081: 0000 0000 0000 0000                        ; u64 literal
+0000089: 0b                                         ; OPCODE_I64_CONST
+000008a: 0000 0000 0000 0000                        ; u64 literal
+0000092: 6d                                         ; OPCODE_I64_LE_U
+0000093: 0b                                         ; OPCODE_I64_CONST
+0000094: 0000 0000 0000 0000                        ; u64 literal
+000009c: 0b                                         ; OPCODE_I64_CONST
+000009d: 0000 0000 0000 0000                        ; u64 literal
+00000a5: 6e                                         ; OPCODE_I64_GT_S
+00000a6: 0b                                         ; OPCODE_I64_CONST
+00000a7: 0000 0000 0000 0000                        ; u64 literal
+00000af: 0b                                         ; OPCODE_I64_CONST
+00000b0: 0000 0000 0000 0000                        ; u64 literal
+00000b8: 70                                         ; OPCODE_I64_GT_U
+00000b9: 0b                                         ; OPCODE_I64_CONST
+00000ba: 0000 0000 0000 0000                        ; u64 literal
+00000c2: 0b                                         ; OPCODE_I64_CONST
+00000c3: 0000 0000 0000 0000                        ; u64 literal
+00000cb: 6f                                         ; OPCODE_I64_GE_S
+00000cc: 0b                                         ; OPCODE_I64_CONST
+00000cd: 0000 0000 0000 0000                        ; u64 literal
+00000d5: 0b                                         ; OPCODE_I64_CONST
+00000d6: 0000 0000 0000 0000                        ; u64 literal
+00000de: 71                                         ; OPCODE_I64_GE_U
+00000df: 0b                                         ; OPCODE_I64_CONST
+00000e0: 0000 0000 0000 0000                        ; u64 literal
+00000e8: 0b                                         ; OPCODE_I64_CONST
+00000e9: 0000 0000 0000 0000                        ; u64 literal
+00000f1: 83                                         ; OPCODE_F32_EQ
+00000f2: 0d                                         ; OPCODE_F32_CONST
+00000f3: 0000 0000                                  ; f32 literal
+00000f7: 0d                                         ; OPCODE_F32_CONST
+00000f8: 0000 0000                                  ; f32 literal
+00000fc: 84                                         ; OPCODE_F32_NE
+00000fd: 0d                                         ; OPCODE_F32_CONST
+00000fe: 0000 0000                                  ; f32 literal
+0000102: 0d                                         ; OPCODE_F32_CONST
+0000103: 0000 0000                                  ; f32 literal
+0000107: 85                                         ; OPCODE_F32_LT
+0000108: 0d                                         ; OPCODE_F32_CONST
+0000109: 0000 0000                                  ; f32 literal
+000010d: 0d                                         ; OPCODE_F32_CONST
+000010e: 0000 0000                                  ; f32 literal
+0000112: 86                                         ; OPCODE_F32_LE
+0000113: 0d                                         ; OPCODE_F32_CONST
+0000114: 0000 0000                                  ; f32 literal
+0000118: 0d                                         ; OPCODE_F32_CONST
+0000119: 0000 0000                                  ; f32 literal
+000011d: 87                                         ; OPCODE_F32_GT
+000011e: 0d                                         ; OPCODE_F32_CONST
+000011f: 0000 0000                                  ; f32 literal
+0000123: 0d                                         ; OPCODE_F32_CONST
+0000124: 0000 0000                                  ; f32 literal
+0000128: 88                                         ; OPCODE_F32_GE
+0000129: 0d                                         ; OPCODE_F32_CONST
+000012a: 0000 0000                                  ; f32 literal
+000012e: 0d                                         ; OPCODE_F32_CONST
+000012f: 0000 0000                                  ; f32 literal
+0000133: 97                                         ; OPCODE_F64_EQ
+0000134: 0c                                         ; OPCODE_F64_CONST
+0000135: 0000 0000 0000 0000                        ; f64 literal
+000013d: 0c                                         ; OPCODE_F64_CONST
+000013e: 0000 0000 0000 0000                        ; f64 literal
+0000146: 98                                         ; OPCODE_F64_NE
+0000147: 0c                                         ; OPCODE_F64_CONST
+0000148: 0000 0000 0000 0000                        ; f64 literal
+0000150: 0c                                         ; OPCODE_F64_CONST
+0000151: 0000 0000 0000 0000                        ; f64 literal
+0000159: 99                                         ; OPCODE_F64_LT
+000015a: 0c                                         ; OPCODE_F64_CONST
+000015b: 0000 0000 0000 0000                        ; f64 literal
+0000163: 0c                                         ; OPCODE_F64_CONST
+0000164: 0000 0000 0000 0000                        ; f64 literal
+000016c: 9a                                         ; OPCODE_F64_LE
+000016d: 0c                                         ; OPCODE_F64_CONST
+000016e: 0000 0000 0000 0000                        ; f64 literal
+0000176: 0c                                         ; OPCODE_F64_CONST
+0000177: 0000 0000 0000 0000                        ; f64 literal
+000017f: 9b                                         ; OPCODE_F64_GT
+0000180: 0c                                         ; OPCODE_F64_CONST
+0000181: 0000 0000 0000 0000                        ; f64 literal
+0000189: 0c                                         ; OPCODE_F64_CONST
+000018a: 0000 0000 0000 0000                        ; f64 literal
+0000192: 9c                                         ; OPCODE_F64_GE
+0000193: 0c                                         ; OPCODE_F64_CONST
+0000194: 0000 0000 0000 0000                        ; f64 literal
+000019c: 0c                                         ; OPCODE_F64_CONST
+000019d: 0000 0000 0000 0000                        ; f64 literal
+0000011: 9201                                       ; FIXUP func body size
+00001a5: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0092 014d 4e4f 5150  
-0000010: 5253 5554 5609 0009 0009 0009 0009 0009  
-0000020: 0009 0009 0009 0009 0009 0068 0b00 0000  
-0000030: 0000 0000 000b 0000 0000 0000 0000 690b  
-0000040: 0000 0000 0000 0000 0b00 0000 0000 0000  
-0000050: 006a 0b00 0000 0000 0000 000b 0000 0000  
-0000060: 0000 0000 6c0b 0000 0000 0000 0000 0b00  
-0000070: 0000 0000 0000 006b 0b00 0000 0000 0000  
-0000080: 000b 0000 0000 0000 0000 6d0b 0000 0000  
-0000090: 0000 0000 0b00 0000 0000 0000 006e 0b00  
-00000a0: 0000 0000 0000 000b 0000 0000 0000 0000  
-00000b0: 700b 0000 0000 0000 0000 0b00 0000 0000  
-00000c0: 0000 006f 0b00 0000 0000 0000 000b 0000  
-00000d0: 0000 0000 0000 710b 0000 0000 0000 0000  
-00000e0: 0b00 0000 0000 0000 0083 0d00 0000 000d  
-00000f0: 0000 0000 840d 0000 0000 0d00 0000 0085  
-0000100: 0d00 0000 000d 0000 0000 860d 0000 0000  
-0000110: 0d00 0000 0087 0d00 0000 000d 0000 0000  
-0000120: 880d 0000 0000 0d00 0000 0097 0c00 0000  
-0000130: 0000 0000 000c 0000 0000 0000 0000 980c  
-0000140: 0000 0000 0000 0000 0c00 0000 0000 0000  
-0000150: 0099 0c00 0000 0000 0000 000c 0000 0000  
-0000160: 0000 0000 9a0c 0000 0000 0000 0000 0c00  
-0000170: 0000 0000 0000 009b 0c00 0000 0000 0000  
-0000180: 000c 0000 0000 0000 0000 9c0c 0000 0000  
-0000190: 0000 0000 0c00 0000 0000 0000 0006       
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0092 014d 4e4f 5150 5253 5554 5609 0009  
+0000020: 0009 0009 0009 0009 0009 0009 0009 0009  
+0000030: 0009 0068 0b00 0000 0000 0000 000b 0000  
+0000040: 0000 0000 0000 690b 0000 0000 0000 0000  
+0000050: 0b00 0000 0000 0000 006a 0b00 0000 0000  
+0000060: 0000 000b 0000 0000 0000 0000 6c0b 0000  
+0000070: 0000 0000 0000 0b00 0000 0000 0000 006b  
+0000080: 0b00 0000 0000 0000 000b 0000 0000 0000  
+0000090: 0000 6d0b 0000 0000 0000 0000 0b00 0000  
+00000a0: 0000 0000 006e 0b00 0000 0000 0000 000b  
+00000b0: 0000 0000 0000 0000 700b 0000 0000 0000  
+00000c0: 0000 0b00 0000 0000 0000 006f 0b00 0000  
+00000d0: 0000 0000 000b 0000 0000 0000 0000 710b  
+00000e0: 0000 0000 0000 0000 0b00 0000 0000 0000  
+00000f0: 0083 0d00 0000 000d 0000 0000 840d 0000  
+0000100: 0000 0d00 0000 0085 0d00 0000 000d 0000  
+0000110: 0000 860d 0000 0000 0d00 0000 0087 0d00  
+0000120: 0000 000d 0000 0000 880d 0000 0000 0d00  
+0000130: 0000 0097 0c00 0000 0000 0000 000c 0000  
+0000140: 0000 0000 0000 980c 0000 0000 0000 0000  
+0000150: 0c00 0000 0000 0000 0099 0c00 0000 0000  
+0000160: 0000 000c 0000 0000 0000 0000 9a0c 0000  
+0000170: 0000 0000 0000 0c00 0000 0000 0000 009b  
+0000180: 0c00 0000 0000 0000 000c 0000 0000 0000  
+0000190: 0000 9c0c 0000 0000 0000 0000 0c00 0000  
+00001a0: 0000 0000 0006                           
 ;;; STDOUT ;;)

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -43,111 +43,114 @@
     (f64.const -0x1p-1)
     (f64.const 0x1.921fb54442d18p+2)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 09                                         ; OPCODE_I8_CONST
-000000c: 00                                         ; u8 literal
-000000d: 0a                                         ; OPCODE_I32_CONST
-000000e: 0000 0080                                  ; u32 literal
-0000012: 09                                         ; OPCODE_I8_CONST
-0000013: ff                                         ; u8 literal
-0000014: 0a                                         ; OPCODE_I32_CONST
-0000015: 0000 0080                                  ; u32 literal
-0000019: 09                                         ; OPCODE_I8_CONST
-000001a: ff                                         ; u8 literal
-000001b: 0b                                         ; OPCODE_I64_CONST
-000001c: 0000 0000 0000 0000                        ; u64 literal
-0000024: 0b                                         ; OPCODE_I64_CONST
-0000025: 0000 0000 0000 0080                        ; u64 literal
-000002d: 0b                                         ; OPCODE_I64_CONST
-000002e: ffff ffff ffff ffff                        ; u64 literal
-0000036: 0b                                         ; OPCODE_I64_CONST
-0000037: 0000 0000 0000 0080                        ; u64 literal
-000003f: 0b                                         ; OPCODE_I64_CONST
-0000040: ffff ffff ffff ffff                        ; u64 literal
-0000048: 0d                                         ; OPCODE_F32_CONST
-0000049: 0000 0000                                  ; f32 literal
-000004d: 0d                                         ; OPCODE_F32_CONST
-000004e: 1668 a965                                  ; f32 literal
-0000052: 0d                                         ; OPCODE_F32_CONST
-0000053: 4020 4f37                                  ; f32 literal
-0000057: 0d                                         ; OPCODE_F32_CONST
-0000058: 0000 c07f                                  ; f32 literal
-000005c: 0d                                         ; OPCODE_F32_CONST
-000005d: 0000 c0ff                                  ; f32 literal
-0000061: 0d                                         ; OPCODE_F32_CONST
-0000062: 0000 c07f                                  ; f32 literal
-0000066: 0d                                         ; OPCODE_F32_CONST
-0000067: bc0a 807f                                  ; f32 literal
-000006b: 0d                                         ; OPCODE_F32_CONST
-000006c: bc0a 80ff                                  ; f32 literal
-0000070: 0d                                         ; OPCODE_F32_CONST
-0000071: bc0a 807f                                  ; f32 literal
-0000075: 0d                                         ; OPCODE_F32_CONST
-0000076: 0000 807f                                  ; f32 literal
-000007a: 0d                                         ; OPCODE_F32_CONST
-000007b: 0000 80ff                                  ; f32 literal
-000007f: 0d                                         ; OPCODE_F32_CONST
-0000080: 0000 807f                                  ; f32 literal
-0000084: 0d                                         ; OPCODE_F32_CONST
-0000085: 0000 00bf                                  ; f32 literal
-0000089: 0d                                         ; OPCODE_F32_CONST
-000008a: db0f c940                                  ; f32 literal
-000008e: 0c                                         ; OPCODE_F64_CONST
-000008f: 0000 0000 0000 0000                        ; f64 literal
-0000097: 0c                                         ; OPCODE_F64_CONST
-0000098: b856 0e3c dd9a efbf                        ; f64 literal
-00000a0: 0c                                         ; OPCODE_F64_CONST
-00000a1: 182d 4454 fb21 1940                        ; f64 literal
-00000a9: 0c                                         ; OPCODE_F64_CONST
-00000aa: 0000 0000 0000 f87f                        ; f64 literal
-00000b2: 0c                                         ; OPCODE_F64_CONST
-00000b3: 0000 0000 0000 f8ff                        ; f64 literal
-00000bb: 0c                                         ; OPCODE_F64_CONST
-00000bc: 0000 0000 0000 f87f                        ; f64 literal
-00000c4: 0c                                         ; OPCODE_F64_CONST
-00000c5: bc0a 0000 0000 f07f                        ; f64 literal
-00000cd: 0c                                         ; OPCODE_F64_CONST
-00000ce: bc0a 0000 0000 f0ff                        ; f64 literal
-00000d6: 0c                                         ; OPCODE_F64_CONST
-00000d7: bc0a 0000 0000 f07f                        ; f64 literal
-00000df: 0c                                         ; OPCODE_F64_CONST
-00000e0: 0000 0000 0000 f07f                        ; f64 literal
-00000e8: 0c                                         ; OPCODE_F64_CONST
-00000e9: 0000 0000 0000 f0ff                        ; f64 literal
-00000f1: 0c                                         ; OPCODE_F64_CONST
-00000f2: 0000 0000 0000 f07f                        ; f64 literal
-00000fa: 0c                                         ; OPCODE_F64_CONST
-00000fb: 0000 0000 0000 e0bf                        ; f64 literal
-0000103: 0c                                         ; OPCODE_F64_CONST
-0000104: 182d 4454 fb21 1940                        ; f64 literal
-0000009: 0101                                       ; FIXUP func body size
-000010c: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 09                                         ; OPCODE_I8_CONST
+0000014: 00                                         ; u8 literal
+0000015: 0a                                         ; OPCODE_I32_CONST
+0000016: 0000 0080                                  ; u32 literal
+000001a: 09                                         ; OPCODE_I8_CONST
+000001b: ff                                         ; u8 literal
+000001c: 0a                                         ; OPCODE_I32_CONST
+000001d: 0000 0080                                  ; u32 literal
+0000021: 09                                         ; OPCODE_I8_CONST
+0000022: ff                                         ; u8 literal
+0000023: 0b                                         ; OPCODE_I64_CONST
+0000024: 0000 0000 0000 0000                        ; u64 literal
+000002c: 0b                                         ; OPCODE_I64_CONST
+000002d: 0000 0000 0000 0080                        ; u64 literal
+0000035: 0b                                         ; OPCODE_I64_CONST
+0000036: ffff ffff ffff ffff                        ; u64 literal
+000003e: 0b                                         ; OPCODE_I64_CONST
+000003f: 0000 0000 0000 0080                        ; u64 literal
+0000047: 0b                                         ; OPCODE_I64_CONST
+0000048: ffff ffff ffff ffff                        ; u64 literal
+0000050: 0d                                         ; OPCODE_F32_CONST
+0000051: 0000 0000                                  ; f32 literal
+0000055: 0d                                         ; OPCODE_F32_CONST
+0000056: 1668 a965                                  ; f32 literal
+000005a: 0d                                         ; OPCODE_F32_CONST
+000005b: 4020 4f37                                  ; f32 literal
+000005f: 0d                                         ; OPCODE_F32_CONST
+0000060: 0000 c07f                                  ; f32 literal
+0000064: 0d                                         ; OPCODE_F32_CONST
+0000065: 0000 c0ff                                  ; f32 literal
+0000069: 0d                                         ; OPCODE_F32_CONST
+000006a: 0000 c07f                                  ; f32 literal
+000006e: 0d                                         ; OPCODE_F32_CONST
+000006f: bc0a 807f                                  ; f32 literal
+0000073: 0d                                         ; OPCODE_F32_CONST
+0000074: bc0a 80ff                                  ; f32 literal
+0000078: 0d                                         ; OPCODE_F32_CONST
+0000079: bc0a 807f                                  ; f32 literal
+000007d: 0d                                         ; OPCODE_F32_CONST
+000007e: 0000 807f                                  ; f32 literal
+0000082: 0d                                         ; OPCODE_F32_CONST
+0000083: 0000 80ff                                  ; f32 literal
+0000087: 0d                                         ; OPCODE_F32_CONST
+0000088: 0000 807f                                  ; f32 literal
+000008c: 0d                                         ; OPCODE_F32_CONST
+000008d: 0000 00bf                                  ; f32 literal
+0000091: 0d                                         ; OPCODE_F32_CONST
+0000092: db0f c940                                  ; f32 literal
+0000096: 0c                                         ; OPCODE_F64_CONST
+0000097: 0000 0000 0000 0000                        ; f64 literal
+000009f: 0c                                         ; OPCODE_F64_CONST
+00000a0: b856 0e3c dd9a efbf                        ; f64 literal
+00000a8: 0c                                         ; OPCODE_F64_CONST
+00000a9: 182d 4454 fb21 1940                        ; f64 literal
+00000b1: 0c                                         ; OPCODE_F64_CONST
+00000b2: 0000 0000 0000 f87f                        ; f64 literal
+00000ba: 0c                                         ; OPCODE_F64_CONST
+00000bb: 0000 0000 0000 f8ff                        ; f64 literal
+00000c3: 0c                                         ; OPCODE_F64_CONST
+00000c4: 0000 0000 0000 f87f                        ; f64 literal
+00000cc: 0c                                         ; OPCODE_F64_CONST
+00000cd: bc0a 0000 0000 f07f                        ; f64 literal
+00000d5: 0c                                         ; OPCODE_F64_CONST
+00000d6: bc0a 0000 0000 f0ff                        ; f64 literal
+00000de: 0c                                         ; OPCODE_F64_CONST
+00000df: bc0a 0000 0000 f07f                        ; f64 literal
+00000e7: 0c                                         ; OPCODE_F64_CONST
+00000e8: 0000 0000 0000 f07f                        ; f64 literal
+00000f0: 0c                                         ; OPCODE_F64_CONST
+00000f1: 0000 0000 0000 f0ff                        ; f64 literal
+00000f9: 0c                                         ; OPCODE_F64_CONST
+00000fa: 0000 0000 0000 f07f                        ; f64 literal
+0000102: 0c                                         ; OPCODE_F64_CONST
+0000103: 0000 0000 0000 e0bf                        ; f64 literal
+000010b: 0c                                         ; OPCODE_F64_CONST
+000010c: 182d 4454 fb21 1940                        ; f64 literal
+0000011: 0101                                       ; FIXUP func body size
+0000114: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0001 0109 000a 0000  
-0000010: 0080 09ff 0a00 0000 8009 ff0b 0000 0000  
-0000020: 0000 0000 0b00 0000 0000 0000 800b ffff  
-0000030: ffff ffff ffff 0b00 0000 0000 0000 800b  
-0000040: ffff ffff ffff ffff 0d00 0000 000d 1668  
-0000050: a965 0d40 204f 370d 0000 c07f 0d00 00c0  
-0000060: ff0d 0000 c07f 0dbc 0a80 7f0d bc0a 80ff  
-0000070: 0dbc 0a80 7f0d 0000 807f 0d00 0080 ff0d  
-0000080: 0000 807f 0d00 0000 bf0d db0f c940 0c00  
-0000090: 0000 0000 0000 000c b856 0e3c dd9a efbf  
-00000a0: 0c18 2d44 54fb 2119 400c 0000 0000 0000  
-00000b0: f87f 0c00 0000 0000 00f8 ff0c 0000 0000  
-00000c0: 0000 f87f 0cbc 0a00 0000 00f0 7f0c bc0a  
-00000d0: 0000 0000 f0ff 0cbc 0a00 0000 00f0 7f0c  
-00000e0: 0000 0000 0000 f07f 0c00 0000 0000 00f0  
-00000f0: ff0c 0000 0000 0000 f07f 0c00 0000 0000  
-0000100: 00e0 bf0c 182d 4454 fb21 1940 06         
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0001 0109 000a 0000 0080 09ff 0a00 0000  
+0000020: 8009 ff0b 0000 0000 0000 0000 0b00 0000  
+0000030: 0000 0000 800b ffff ffff ffff ffff 0b00  
+0000040: 0000 0000 0000 800b ffff ffff ffff ffff  
+0000050: 0d00 0000 000d 1668 a965 0d40 204f 370d  
+0000060: 0000 c07f 0d00 00c0 ff0d 0000 c07f 0dbc  
+0000070: 0a80 7f0d bc0a 80ff 0dbc 0a80 7f0d 0000  
+0000080: 807f 0d00 0080 ff0d 0000 807f 0d00 0000  
+0000090: bf0d db0f c940 0c00 0000 0000 0000 000c  
+00000a0: b856 0e3c dd9a efbf 0c18 2d44 54fb 2119  
+00000b0: 400c 0000 0000 0000 f87f 0c00 0000 0000  
+00000c0: 00f8 ff0c 0000 0000 0000 f87f 0cbc 0a00  
+00000d0: 0000 00f0 7f0c bc0a 0000 0000 f0ff 0cbc  
+00000e0: 0a00 0000 00f0 7f0c 0000 0000 0000 f07f  
+00000f0: 0c00 0000 0000 00f0 ff0c 0000 0000 0000  
+0000100: f07f 0c00 0000 0000 00e0 bf0c 182d 4454  
+0000110: fb21 1940 06                             
 ;;; STDOUT ;;)

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -25,48 +25,51 @@
     (f32.demote/f64
       (f64.promote/f32 (f32.const 0)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: a1                                         ; OPCODE_I32_CONVERT_I64
-000000c: a7                                         ; OPCODE_I64_UCONVERT_I32
-000000d: 9d                                         ; OPCODE_I32_SCONVERT_F32
-000000e: a8                                         ; OPCODE_F32_SCONVERT_I32
-000000f: 9f                                         ; OPCODE_I32_UCONVERT_F32
-0000010: a9                                         ; OPCODE_F32_UCONVERT_I32
-0000011: 9e                                         ; OPCODE_I32_SCONVERT_F64
-0000012: ae                                         ; OPCODE_F64_SCONVERT_I32
-0000013: a0                                         ; OPCODE_I32_UCONVERT_F64
-0000014: af                                         ; OPCODE_F64_UCONVERT_I32
-0000015: 09                                         ; OPCODE_I8_CONST
-0000016: 00                                         ; u8 literal
-0000017: a2                                         ; OPCODE_I64_SCONVERT_F32
-0000018: aa                                         ; OPCODE_F32_SCONVERT_I64
-0000019: a4                                         ; OPCODE_I64_UCONVERT_F32
-000001a: ab                                         ; OPCODE_F32_UCONVERT_I64
-000001b: a3                                         ; OPCODE_I64_SCONVERT_F64
-000001c: b0                                         ; OPCODE_F64_SCONVERT_I64
-000001d: a5                                         ; OPCODE_I64_UCONVERT_F64
-000001e: b1                                         ; OPCODE_F64_UCONVERT_I64
-000001f: a6                                         ; OPCODE_I64_SCONVERT_I32
-0000020: 09                                         ; OPCODE_I8_CONST
-0000021: 00                                         ; u8 literal
-0000022: ac                                         ; OPCODE_F32_CONVERT_F64
-0000023: b2                                         ; OPCODE_F64_CONVERT_F32
-0000024: 0d                                         ; OPCODE_F32_CONST
-0000025: 0000 0000                                  ; f32 literal
-0000009: 1e00                                       ; FIXUP func body size
-0000029: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: a1                                         ; OPCODE_I32_CONVERT_I64
+0000014: a7                                         ; OPCODE_I64_UCONVERT_I32
+0000015: 9d                                         ; OPCODE_I32_SCONVERT_F32
+0000016: a8                                         ; OPCODE_F32_SCONVERT_I32
+0000017: 9f                                         ; OPCODE_I32_UCONVERT_F32
+0000018: a9                                         ; OPCODE_F32_UCONVERT_I32
+0000019: 9e                                         ; OPCODE_I32_SCONVERT_F64
+000001a: ae                                         ; OPCODE_F64_SCONVERT_I32
+000001b: a0                                         ; OPCODE_I32_UCONVERT_F64
+000001c: af                                         ; OPCODE_F64_UCONVERT_I32
+000001d: 09                                         ; OPCODE_I8_CONST
+000001e: 00                                         ; u8 literal
+000001f: a2                                         ; OPCODE_I64_SCONVERT_F32
+0000020: aa                                         ; OPCODE_F32_SCONVERT_I64
+0000021: a4                                         ; OPCODE_I64_UCONVERT_F32
+0000022: ab                                         ; OPCODE_F32_UCONVERT_I64
+0000023: a3                                         ; OPCODE_I64_SCONVERT_F64
+0000024: b0                                         ; OPCODE_F64_SCONVERT_I64
+0000025: a5                                         ; OPCODE_I64_UCONVERT_F64
+0000026: b1                                         ; OPCODE_F64_UCONVERT_I64
+0000027: a6                                         ; OPCODE_I64_SCONVERT_I32
+0000028: 09                                         ; OPCODE_I8_CONST
+0000029: 00                                         ; u8 literal
+000002a: ac                                         ; OPCODE_F32_CONVERT_F64
+000002b: b2                                         ; OPCODE_F64_CONVERT_F32
+000002c: 0d                                         ; OPCODE_F32_CONST
+000002d: 0000 0000                                  ; f32 literal
+0000011: 1e00                                       ; FIXUP func body size
+0000031: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 001e 00a1 a79d a89f  
-0000010: a99e aea0 af09 00a2 aaa4 aba3 b0a5 b1a6  
-0000020: 0900 acb2 0d00 0000 0006                 
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 001e 00a1 a79d a89f a99e aea0 af09 00a2  
+0000020: aaa4 aba3 b0a5 b1a6 0900 acb2 0d00 0000  
+0000030: 0006                                     
 ;;; STDOUT ;;)

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -4,37 +4,40 @@
   (func (param i32) (result i64) (i64.const 0))
   (import "foo" "bar" (param i32) (result i64)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 01                                         ; num params
-0000003: 02                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 08                                         ; WASM_BINARY_SECTION_IMPORTS
-0000006: 01                                         ; num imports
+000000a: 01                                         ; num params
+000000b: 02                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 08                                         ; WASM_BINARY_SECTION_IMPORTS
+000000e: 01                                         ; num imports
 ; import header 0
-0000007: 0000                                       ; import signature index
-0000009: 0000 0000                                  ; import module name offset
-000000d: 0000 0000                                  ; import function name offset
-0000011: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000012: 01                                         ; num functions
+000000f: 0000                                       ; import signature index
+0000011: 0000 0000                                  ; import module name offset
+0000015: 0000 0000                                  ; import function name offset
+0000019: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000001a: 01                                         ; num functions
 ; function 0
-0000013: 00                                         ; func flags
-0000014: 0000                                       ; func signature index
-0000016: 0000                                       ; func body size
-0000018: 0b                                         ; OPCODE_I64_CONST
-0000019: 0000 0000 0000 0000                        ; u64 literal
-0000016: 0900                                       ; FIXUP func body size
-0000021: 06                                         ; WASM_BINARY_SECTION_END
+000001b: 00                                         ; func flags
+000001c: 0000                                       ; func signature index
+000001e: 0000                                       ; func body size
+0000020: 0b                                         ; OPCODE_I64_CONST
+0000021: 0000 0000 0000 0000                        ; u64 literal
+000001e: 0900                                       ; FIXUP func body size
+0000029: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-0000009: 2200 0000                                  ; FIXUP import module name offset
-0000022: 666f 6f                                    ; import module name
-0000025: 00                                         ; \0
-000000d: 2600 0000                                  ; FIXUP import function name offset
-0000026: 6261 72                                    ; import function name
-0000029: 00                                         ; \0
+0000011: 2a00 0000                                  ; FIXUP import module name offset
+000002a: 666f 6f                                    ; import module name
+000002d: 00                                         ; \0
+0000015: 2e00 0000                                  ; FIXUP import function name offset
+000002e: 6261 72                                    ; import function name
+0000031: 00                                         ; \0
 ;; dump
-0000000: 0101 0102 0108 0100 0022 0000 0026 0000  
-0000010: 0002 0100 0000 0900 0b00 0000 0000 0000  
-0000020: 0006 666f 6f00 6261 7200                 
+0000000: 0061 736d 0a00 0000 0101 0102 0108 0100  
+0000010: 002a 0000 002e 0000 0002 0100 0000 0900  
+0000020: 0b00 0000 0000 0000 0006 666f 6f00 6261  
+0000030: 7200                                     
 ;;; STDOUT ;;)

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -4,35 +4,38 @@
   (export "a" 0)
   (export "b" 0))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 00                                         ; OPCODE_NOP
-0000009: 0100                                       ; FIXUP func body size
-000000c: 09                                         ; WASM_BINARY_SECTION_EXPORTS
-000000d: 02                                         ; num exports
-000000e: 0000                                       ; export func index
-0000010: 0000 0000                                  ; export name offset
-0000014: 0000                                       ; export func index
-0000016: 0000 0000                                  ; export name offset
-000001a: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 00                                         ; OPCODE_NOP
+0000011: 0100                                       ; FIXUP func body size
+0000014: 09                                         ; WASM_BINARY_SECTION_EXPORTS
+0000015: 02                                         ; num exports
+0000016: 0000                                       ; export func index
+0000018: 0000 0000                                  ; export name offset
+000001c: 0000                                       ; export func index
+000001e: 0000 0000                                  ; export name offset
+0000022: 06                                         ; WASM_BINARY_SECTION_END
 ; export 0
-0000010: 1b00 0000                                  ; FIXUP func name offset
-000001b: 61                                         ; export name
-000001c: 00                                         ; \0
+0000018: 2300 0000                                  ; FIXUP func name offset
+0000023: 61                                         ; export name
+0000024: 00                                         ; \0
 ; export 1
-0000016: 1d00 0000                                  ; FIXUP func name offset
-000001d: 62                                         ; export name
-000001e: 00                                         ; \0
+000001e: 2500 0000                                  ; FIXUP func name offset
+0000025: 62                                         ; export name
+0000026: 00                                         ; \0
 ;; dump
-0000000: 0101 0000 0201 0000 0001 0000 0902 0000  
-0000010: 1b00 0000 0000 1d00 0000 0661 0062 00    
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0001 0000 0902 0000 2300 0000 0000 2500  
+0000020: 0000 0661 0062 00                        
 ;;; STDOUT ;;)

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -4,26 +4,28 @@
     (block
       (br 0 (i32.const 1)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 01                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 01                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 01                                         ; num expressions
-000000d: 06                                         ; OPCODE_BR
-000000e: 00                                         ; break depth
-000000f: 09                                         ; OPCODE_I8_CONST
-0000010: 01                                         ; u8 literal
-0000009: 0600                                       ; FIXUP func body size
-0000011: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 01                                         ; OPCODE_BLOCK
+0000014: 01                                         ; num expressions
+0000015: 06                                         ; OPCODE_BR
+0000016: 00                                         ; break depth
+0000017: 09                                         ; OPCODE_I8_CONST
+0000018: 01                                         ; u8 literal
+0000011: 0600                                       ; FIXUP func body size
+0000019: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0001 0201 0000 0006 0001 0106 0009  
-0000010: 0106                                     
+0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
+0000010: 0006 0001 0106 0009 0106                 
 ;;; STDOUT ;;)

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -5,30 +5,32 @@
       (br_if $exit (i32.const 42) (i32.const 0))
       (i32.const 29))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 01                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 01                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 01                                         ; OPCODE_BLOCK
-000000c: 02                                         ; num expressions
-000000d: 07                                         ; OPCODE_BR_IF
-000000e: 00                                         ; break depth
-000000f: 09                                         ; OPCODE_I8_CONST
-0000010: 2a                                         ; u8 literal
-0000011: 09                                         ; OPCODE_I8_CONST
-0000012: 00                                         ; u8 literal
-0000013: 09                                         ; OPCODE_I8_CONST
-0000014: 1d                                         ; u8 literal
-0000009: 0a00                                       ; FIXUP func body size
-0000015: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 01                                         ; OPCODE_BLOCK
+0000014: 02                                         ; num expressions
+0000015: 07                                         ; OPCODE_BR_IF
+0000016: 00                                         ; break depth
+0000017: 09                                         ; OPCODE_I8_CONST
+0000018: 2a                                         ; u8 literal
+0000019: 09                                         ; OPCODE_I8_CONST
+000001a: 00                                         ; u8 literal
+000001b: 09                                         ; OPCODE_I8_CONST
+000001c: 1d                                         ; u8 literal
+0000011: 0a00                                       ; FIXUP func body size
+000001d: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0001 0201 0000 000a 0001 0207 0009  
-0000010: 2a09 0009 1d06                           
+0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
+0000010: 000a 0001 0207 0009 2a09 0009 1d06       
 ;;; STDOUT ;;)

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -3,28 +3,30 @@
   (func)
   (export "foo" 0))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-0000009: 0000                                       ; FIXUP func body size
-000000b: 09                                         ; WASM_BINARY_SECTION_EXPORTS
-000000c: 01                                         ; num exports
-000000d: 0000                                       ; export func index
-000000f: 0000 0000                                  ; export name offset
-0000013: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000011: 0000                                       ; FIXUP func body size
+0000013: 09                                         ; WASM_BINARY_SECTION_EXPORTS
+0000014: 01                                         ; num exports
+0000015: 0000                                       ; export func index
+0000017: 0000 0000                                  ; export name offset
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ; export 0
-000000f: 1400 0000                                  ; FIXUP func name offset
-0000014: 666f 6f                                    ; export name
-0000017: 00                                         ; \0
+0000017: 1c00 0000                                  ; FIXUP func name offset
+000001c: 666f 6f                                    ; export name
+000001f: 00                                         ; \0
 ;; dump
-0000000: 0101 0000 0201 0000 0000 0009 0100 0014  
-0000010: 0000 0006 666f 6f00                      
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0000 0009 0100 001c 0000 0006 666f 6f00  
 ;;; STDOUT ;;)

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -4,30 +4,32 @@
   (func)
   (func))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 03                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 03                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-0000009: 0000                                       ; FIXUP func body size
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000011: 0000                                       ; FIXUP func body size
 ; function 1
-000000b: 00                                         ; func flags
-000000c: 0000                                       ; func signature index
-000000e: 0000                                       ; func body size
-000000e: 0000                                       ; FIXUP func body size
+0000013: 00                                         ; func flags
+0000014: 0000                                       ; func signature index
+0000016: 0000                                       ; func body size
+0000016: 0000                                       ; FIXUP func body size
 ; function 2
-0000010: 00                                         ; func flags
-0000011: 0000                                       ; func signature index
-0000013: 0000                                       ; func body size
-0000013: 0000                                       ; FIXUP func body size
-0000015: 06                                         ; WASM_BINARY_SECTION_END
+0000018: 00                                         ; func flags
+0000019: 0000                                       ; func signature index
+000001b: 0000                                       ; func body size
+000001b: 0000                                       ; FIXUP func body size
+000001d: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0203 0000 0000 0000 0000 0000  
-0000010: 0000 0000 0006                           
+0000000: 0061 736d 0a00 0000 0101 0000 0203 0000  
+0000010: 0000 0000 0000 0000 0000 0000 0006       
 ;;; STDOUT ;;)

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -2,19 +2,22 @@
 (module
   (func $my-func))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-0000009: 0000                                       ; FIXUP func body size
-000000b: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000011: 0000                                       ; FIXUP func body size
+0000013: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0000 0006            
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0000 0006                                
 ;;; STDOUT ;;)

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -13,39 +13,41 @@
     (get_local 4)
     (get_local 5)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 02                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 03                                         ; param type
-0000006: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000007: 01                                         ; num functions
+000000a: 02                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 03                                         ; param type
+000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000f: 01                                         ; num functions
 ; function 0
-0000008: 04                                         ; func flags
-0000009: 0000                                       ; func signature index
-000000b: 0100                                       ; num local i32
-000000d: 0100                                       ; num local i64
-000000f: 0200                                       ; num local f32
-0000011: 0000                                       ; num local f64
-0000013: 0000                                       ; func body size
-0000015: 0e                                         ; OPCODE_GET_LOCAL
-0000016: 00                                         ; remapped local index
-0000017: 0e                                         ; OPCODE_GET_LOCAL
-0000018: 01                                         ; remapped local index
-0000019: 0e                                         ; OPCODE_GET_LOCAL
-000001a: 03                                         ; remapped local index
-000001b: 0e                                         ; OPCODE_GET_LOCAL
-000001c: 04                                         ; remapped local index
+0000010: 04                                         ; func flags
+0000011: 0000                                       ; func signature index
+0000013: 0100                                       ; num local i32
+0000015: 0100                                       ; num local i64
+0000017: 0200                                       ; num local f32
+0000019: 0000                                       ; num local f64
+000001b: 0000                                       ; func body size
 000001d: 0e                                         ; OPCODE_GET_LOCAL
-000001e: 02                                         ; remapped local index
+000001e: 00                                         ; remapped local index
 000001f: 0e                                         ; OPCODE_GET_LOCAL
-0000020: 05                                         ; remapped local index
-0000013: 0c00                                       ; FIXUP func body size
-0000021: 06                                         ; WASM_BINARY_SECTION_END
+0000020: 01                                         ; remapped local index
+0000021: 0e                                         ; OPCODE_GET_LOCAL
+0000022: 03                                         ; remapped local index
+0000023: 0e                                         ; OPCODE_GET_LOCAL
+0000024: 04                                         ; remapped local index
+0000025: 0e                                         ; OPCODE_GET_LOCAL
+0000026: 02                                         ; remapped local index
+0000027: 0e                                         ; OPCODE_GET_LOCAL
+0000028: 05                                         ; remapped local index
+000001b: 0c00                                       ; FIXUP func body size
+0000029: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0200 0103 0201 0400 0001 0001 0002  
-0000010: 0000 000c 000e 000e 010e 030e 040e 020e  
-0000020: 0506                                     
+0000000: 0061 736d 0a00 0000 0101 0200 0103 0201  
+0000010: 0400 0001 0001 0002 0000 000c 000e 000e  
+0000020: 010e 030e 040e 020e 0506                 
 ;;; STDOUT ;;)

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -15,41 +15,43 @@
     (get_local 6)
     (get_local 7)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 04                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0200                                       ; num local i32
-000000b: 0200                                       ; num local i64
-000000d: 0200                                       ; num local f32
-000000f: 0200                                       ; num local f64
-0000011: 0000                                       ; func body size
-0000013: 0e                                         ; OPCODE_GET_LOCAL
-0000014: 06                                         ; remapped local index
-0000015: 0e                                         ; OPCODE_GET_LOCAL
-0000016: 04                                         ; remapped local index
-0000017: 0e                                         ; OPCODE_GET_LOCAL
-0000018: 02                                         ; remapped local index
-0000019: 0e                                         ; OPCODE_GET_LOCAL
-000001a: 00                                         ; remapped local index
+000000e: 04                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0200                                       ; num local i32
+0000013: 0200                                       ; num local i64
+0000015: 0200                                       ; num local f32
+0000017: 0200                                       ; num local f64
+0000019: 0000                                       ; func body size
 000001b: 0e                                         ; OPCODE_GET_LOCAL
-000001c: 01                                         ; remapped local index
+000001c: 06                                         ; remapped local index
 000001d: 0e                                         ; OPCODE_GET_LOCAL
-000001e: 05                                         ; remapped local index
+000001e: 04                                         ; remapped local index
 000001f: 0e                                         ; OPCODE_GET_LOCAL
-0000020: 07                                         ; remapped local index
+0000020: 02                                         ; remapped local index
 0000021: 0e                                         ; OPCODE_GET_LOCAL
-0000022: 03                                         ; remapped local index
-0000011: 1000                                       ; FIXUP func body size
-0000023: 06                                         ; WASM_BINARY_SECTION_END
+0000022: 00                                         ; remapped local index
+0000023: 0e                                         ; OPCODE_GET_LOCAL
+0000024: 01                                         ; remapped local index
+0000025: 0e                                         ; OPCODE_GET_LOCAL
+0000026: 05                                         ; remapped local index
+0000027: 0e                                         ; OPCODE_GET_LOCAL
+0000028: 07                                         ; remapped local index
+0000029: 0e                                         ; OPCODE_GET_LOCAL
+000002a: 03                                         ; remapped local index
+0000019: 1000                                       ; FIXUP func body size
+000002b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0400 0002 0002 0002 0002  
-0000010: 0010 000e 060e 040e 020e 000e 010e 050e  
-0000020: 070e 0306                                
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0400  
+0000010: 0002 0002 0002 0002 0010 000e 060e 040e  
+0000020: 020e 000e 010e 050e 070e 0306            
 ;;; STDOUT ;;)

--- a/test/dump/global-multi.txt
+++ b/test/dump/global-multi.txt
@@ -2,26 +2,29 @@
 (module
   (global i32 i64 f32 f64))
 (;; STDOUT ;;;
-0000000: 03                                         ; WASM_BINARY_SECTION_GLOBALS
-0000001: 04                                         ; num globals
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 03                                         ; WASM_BINARY_SECTION_GLOBALS
+0000009: 04                                         ; num globals
 ; global header 0
-0000002: 0000 0000                                  ; global name offset
-0000006: 04                                         ; global mem type
-0000007: 00                                         ; export global
+000000a: 0000 0000                                  ; global name offset
+000000e: 04                                         ; global mem type
+000000f: 00                                         ; export global
 ; global header 1
-0000008: 0000 0000                                  ; global name offset
-000000c: 06                                         ; global mem type
-000000d: 00                                         ; export global
+0000010: 0000 0000                                  ; global name offset
+0000014: 06                                         ; global mem type
+0000015: 00                                         ; export global
 ; global header 2
-000000e: 0000 0000                                  ; global name offset
-0000012: 08                                         ; global mem type
-0000013: 00                                         ; export global
+0000016: 0000 0000                                  ; global name offset
+000001a: 08                                         ; global mem type
+000001b: 00                                         ; export global
 ; global header 3
-0000014: 0000 0000                                  ; global name offset
-0000018: 09                                         ; global mem type
-0000019: 00                                         ; export global
-000001a: 06                                         ; WASM_BINARY_SECTION_END
+000001c: 0000 0000                                  ; global name offset
+0000020: 09                                         ; global mem type
+0000021: 00                                         ; export global
+0000022: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0304 0000 0000 0400 0000 0000 0600 0000  
-0000010: 0000 0800 0000 0000 0900 06              
+0000000: 0061 736d 0a00 0000 0304 0000 0000 0400  
+0000010: 0000 0000 0600 0000 0000 0800 0000 0000  
+0000020: 0900 06                                  
 ;;; STDOUT ;;)

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -4,28 +4,30 @@
   (func (param i32)
     (grow_memory (get_local 0))))
 (;; STDOUT ;;;
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 08                                         ; min mem size log 2
-0000002: 0a                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000005: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 08                                         ; min mem size log 2
+000000a: 0a                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+000000d: 01                                         ; num signatures
 ; signature 0
-0000006: 01                                         ; num params
-0000007: 00                                         ; result_type
-0000008: 01                                         ; param type
-0000009: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-000000a: 01                                         ; num functions
+000000e: 01                                         ; num params
+000000f: 00                                         ; result_type
+0000010: 01                                         ; param type
+0000011: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000012: 01                                         ; num functions
 ; function 0
-000000b: 00                                         ; func flags
-000000c: 0000                                       ; func signature index
-000000e: 0000                                       ; func body size
-0000010: 39                                         ; OPCODE_GROW_MEMORY
-0000011: 0e                                         ; OPCODE_GET_LOCAL
-0000012: 00                                         ; remapped local index
-000000e: 0300                                       ; FIXUP func body size
-0000013: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; func flags
+0000014: 0000                                       ; func signature index
+0000016: 0000                                       ; func body size
+0000018: 39                                         ; OPCODE_GROW_MEMORY
+0000019: 0e                                         ; OPCODE_GET_LOCAL
+000001a: 00                                         ; remapped local index
+0000016: 0300                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0008 0a01 0101 0100 0102 0100 0000 0300  
-0000010: 390e 0006                                
+0000000: 0061 736d 0a00 0000 0008 0a01 0101 0100  
+0000010: 0102 0100 0000 0300 390e 0006            
 ;;; STDOUT ;;)

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -6,42 +6,44 @@
   (func
     (if_else (i32.const 1) (return) (return))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 02                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 02                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 03                                         ; OPCODE_IF
-000000c: 09                                         ; OPCODE_I8_CONST
-000000d: 01                                         ; u8 literal
-000000e: 00                                         ; OPCODE_NOP
-000000f: 04                                         ; OPCODE_IF_THEN
-0000010: 09                                         ; OPCODE_I8_CONST
-0000011: 00                                         ; u8 literal
-0000012: 0d                                         ; OPCODE_F32_CONST
-0000013: 0000 803f                                  ; f32 literal
-0000017: 0d                                         ; OPCODE_F32_CONST
-0000018: 0000 0040                                  ; f32 literal
-0000009: 1100                                       ; FIXUP func body size
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 03                                         ; OPCODE_IF
+0000014: 09                                         ; OPCODE_I8_CONST
+0000015: 01                                         ; u8 literal
+0000016: 00                                         ; OPCODE_NOP
+0000017: 04                                         ; OPCODE_IF_THEN
+0000018: 09                                         ; OPCODE_I8_CONST
+0000019: 00                                         ; u8 literal
+000001a: 0d                                         ; OPCODE_F32_CONST
+000001b: 0000 803f                                  ; f32 literal
+000001f: 0d                                         ; OPCODE_F32_CONST
+0000020: 0000 0040                                  ; f32 literal
+0000011: 1100                                       ; FIXUP func body size
 ; function 1
-000001c: 00                                         ; func flags
-000001d: 0000                                       ; func signature index
-000001f: 0000                                       ; func body size
-0000021: 04                                         ; OPCODE_IF_THEN
-0000022: 09                                         ; OPCODE_I8_CONST
-0000023: 01                                         ; u8 literal
-0000024: 14                                         ; OPCODE_RETURN
-0000025: 14                                         ; OPCODE_RETURN
-000001f: 0500                                       ; FIXUP func body size
-0000026: 06                                         ; WASM_BINARY_SECTION_END
+0000024: 00                                         ; func flags
+0000025: 0000                                       ; func signature index
+0000027: 0000                                       ; func body size
+0000029: 04                                         ; OPCODE_IF_THEN
+000002a: 09                                         ; OPCODE_I8_CONST
+000002b: 01                                         ; u8 literal
+000002c: 14                                         ; OPCODE_RETURN
+000002d: 14                                         ; OPCODE_RETURN
+0000027: 0500                                       ; FIXUP func body size
+000002e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0202 0000 0011 0003 0901 0004  
-0000010: 0900 0d00 0080 3f0d 0000 0040 0000 0005  
-0000020: 0004 0901 1414 06                        
+0000000: 0061 736d 0a00 0000 0101 0000 0202 0000  
+0000010: 0011 0003 0901 0004 0900 0d00 0080 3f0d  
+0000020: 0000 0040 0000 0005 0004 0901 1414 06    
 ;;; STDOUT ;;)

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -5,47 +5,50 @@
   (import "ignored" "test" (param i32 i64 f32 f64))
   (import "ignored" "test2" (param i32) (result i32)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 02                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 02                                         ; num signatures
 ; signature 0
-0000002: 04                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 02                                         ; param type
-0000006: 03                                         ; param type
-0000007: 04                                         ; param type
+000000a: 04                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 02                                         ; param type
+000000e: 03                                         ; param type
+000000f: 04                                         ; param type
 ; signature 1
-0000008: 01                                         ; num params
-0000009: 01                                         ; result_type
-000000a: 01                                         ; param type
-000000b: 08                                         ; WASM_BINARY_SECTION_IMPORTS
-000000c: 02                                         ; num imports
+0000010: 01                                         ; num params
+0000011: 01                                         ; result_type
+0000012: 01                                         ; param type
+0000013: 08                                         ; WASM_BINARY_SECTION_IMPORTS
+0000014: 02                                         ; num imports
 ; import header 0
-000000d: 0000                                       ; import signature index
-000000f: 0000 0000                                  ; import module name offset
-0000013: 0000 0000                                  ; import function name offset
+0000015: 0000                                       ; import signature index
+0000017: 0000 0000                                  ; import module name offset
+000001b: 0000 0000                                  ; import function name offset
 ; import header 1
-0000017: 0100                                       ; import signature index
-0000019: 0000 0000                                  ; import module name offset
-000001d: 0000 0000                                  ; import function name offset
-0000021: 06                                         ; WASM_BINARY_SECTION_END
+000001f: 0100                                       ; import signature index
+0000021: 0000 0000                                  ; import module name offset
+0000025: 0000 0000                                  ; import function name offset
+0000029: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-000000f: 2200 0000                                  ; FIXUP import module name offset
-0000022: 6967 6e6f 7265 64                          ; import module name
-0000029: 00                                         ; \0
-0000013: 2a00 0000                                  ; FIXUP import function name offset
-000002a: 7465 7374                                  ; import function name
-000002e: 00                                         ; \0
-; import 1
-0000019: 2f00 0000                                  ; FIXUP import module name offset
-000002f: 6967 6e6f 7265 64                          ; import module name
+0000017: 2a00 0000                                  ; FIXUP import module name offset
+000002a: 6967 6e6f 7265 64                          ; import module name
+0000031: 00                                         ; \0
+000001b: 3200 0000                                  ; FIXUP import function name offset
+0000032: 7465 7374                                  ; import function name
 0000036: 00                                         ; \0
-000001d: 3700 0000                                  ; FIXUP import function name offset
-0000037: 7465 7374 32                               ; import function name
-000003c: 00                                         ; \0
+; import 1
+0000021: 3700 0000                                  ; FIXUP import module name offset
+0000037: 6967 6e6f 7265 64                          ; import module name
+000003e: 00                                         ; \0
+0000025: 3f00 0000                                  ; FIXUP import function name offset
+000003f: 7465 7374 32                               ; import function name
+0000044: 00                                         ; \0
 ;; dump
-0000000: 0102 0400 0102 0304 0101 0108 0200 0022  
-0000010: 0000 002a 0000 0001 002f 0000 0037 0000  
-0000020: 0006 6967 6e6f 7265 6400 7465 7374 0069  
-0000030: 676e 6f72 6564 0074 6573 7432 00         
+0000000: 0061 736d 0a00 0000 0102 0400 0102 0304  
+0000010: 0101 0108 0200 002a 0000 0032 0000 0001  
+0000020: 0037 0000 003f 0000 0006 6967 6e6f 7265  
+0000030: 6400 7465 7374 0069 676e 6f72 6564 0074  
+0000040: 6573 7432 00                             
 ;;; STDOUT ;;)

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -36,25 +36,19 @@
     (i64.load32_s align=4 (i32.const 0))
     (i64.load32_s align=8 (i32.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-000000c: 00                                         ; load access byte
-000000d: 09                                         ; OPCODE_I8_CONST
-000000e: 00                                         ; u8 literal
-000000f: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-0000010: 00                                         ; load access byte
-0000011: 09                                         ; OPCODE_I8_CONST
-0000012: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
 0000013: 20                                         ; OPCODE_I32_LOAD_MEM8_S
 0000014: 00                                         ; load access byte
 0000015: 09                                         ; OPCODE_I8_CONST
@@ -63,44 +57,44 @@
 0000018: 00                                         ; load access byte
 0000019: 09                                         ; OPCODE_I8_CONST
 000001a: 00                                         ; u8 literal
-000001b: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-000001c: 80                                         ; load access byte
+000001b: 20                                         ; OPCODE_I32_LOAD_MEM8_S
+000001c: 00                                         ; load access byte
 000001d: 09                                         ; OPCODE_I8_CONST
 000001e: 00                                         ; u8 literal
-000001f: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+000001f: 20                                         ; OPCODE_I32_LOAD_MEM8_S
 0000020: 00                                         ; load access byte
 0000021: 09                                         ; OPCODE_I8_CONST
 0000022: 00                                         ; u8 literal
 0000023: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-0000024: 00                                         ; load access byte
+0000024: 80                                         ; load access byte
 0000025: 09                                         ; OPCODE_I8_CONST
 0000026: 00                                         ; u8 literal
 0000027: 22                                         ; OPCODE_I32_LOAD_MEM16_S
 0000028: 00                                         ; load access byte
 0000029: 09                                         ; OPCODE_I8_CONST
 000002a: 00                                         ; u8 literal
-000002b: 2a                                         ; OPCODE_I32_LOAD_MEM
-000002c: 80                                         ; load access byte
+000002b: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+000002c: 00                                         ; load access byte
 000002d: 09                                         ; OPCODE_I8_CONST
 000002e: 00                                         ; u8 literal
-000002f: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000030: 80                                         ; load access byte
+000002f: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+0000030: 00                                         ; load access byte
 0000031: 09                                         ; OPCODE_I8_CONST
 0000032: 00                                         ; u8 literal
 0000033: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000034: 00                                         ; load access byte
+0000034: 80                                         ; load access byte
 0000035: 09                                         ; OPCODE_I8_CONST
 0000036: 00                                         ; u8 literal
 0000037: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000038: 00                                         ; load access byte
+0000038: 80                                         ; load access byte
 0000039: 09                                         ; OPCODE_I8_CONST
 000003a: 00                                         ; u8 literal
-000003b: 2b                                         ; OPCODE_I64_LOAD_MEM
-000003c: 80                                         ; load access byte
+000003b: 2a                                         ; OPCODE_I32_LOAD_MEM
+000003c: 00                                         ; load access byte
 000003d: 09                                         ; OPCODE_I8_CONST
 000003e: 00                                         ; u8 literal
-000003f: 2b                                         ; OPCODE_I64_LOAD_MEM
-0000040: 80                                         ; load access byte
+000003f: 2a                                         ; OPCODE_I32_LOAD_MEM
+0000040: 00                                         ; load access byte
 0000041: 09                                         ; OPCODE_I8_CONST
 0000042: 00                                         ; u8 literal
 0000043: 2b                                         ; OPCODE_I64_LOAD_MEM
@@ -108,14 +102,14 @@
 0000045: 09                                         ; OPCODE_I8_CONST
 0000046: 00                                         ; u8 literal
 0000047: 2b                                         ; OPCODE_I64_LOAD_MEM
-0000048: 00                                         ; load access byte
+0000048: 80                                         ; load access byte
 0000049: 09                                         ; OPCODE_I8_CONST
 000004a: 00                                         ; u8 literal
-000004b: 24                                         ; OPCODE_I64_LOAD_MEM8_S
-000004c: 00                                         ; load access byte
+000004b: 2b                                         ; OPCODE_I64_LOAD_MEM
+000004c: 80                                         ; load access byte
 000004d: 09                                         ; OPCODE_I8_CONST
 000004e: 00                                         ; u8 literal
-000004f: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+000004f: 2b                                         ; OPCODE_I64_LOAD_MEM
 0000050: 00                                         ; load access byte
 0000051: 09                                         ; OPCODE_I8_CONST
 0000052: 00                                         ; u8 literal
@@ -127,47 +121,56 @@
 0000058: 00                                         ; load access byte
 0000059: 09                                         ; OPCODE_I8_CONST
 000005a: 00                                         ; u8 literal
-000005b: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-000005c: 80                                         ; load access byte
+000005b: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+000005c: 00                                         ; load access byte
 000005d: 09                                         ; OPCODE_I8_CONST
 000005e: 00                                         ; u8 literal
-000005f: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+000005f: 24                                         ; OPCODE_I64_LOAD_MEM8_S
 0000060: 00                                         ; load access byte
 0000061: 09                                         ; OPCODE_I8_CONST
 0000062: 00                                         ; u8 literal
 0000063: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-0000064: 00                                         ; load access byte
+0000064: 80                                         ; load access byte
 0000065: 09                                         ; OPCODE_I8_CONST
 0000066: 00                                         ; u8 literal
 0000067: 26                                         ; OPCODE_I64_LOAD_MEM16_S
 0000068: 00                                         ; load access byte
 0000069: 09                                         ; OPCODE_I8_CONST
 000006a: 00                                         ; u8 literal
-000006b: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-000006c: 80                                         ; load access byte
+000006b: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+000006c: 00                                         ; load access byte
 000006d: 09                                         ; OPCODE_I8_CONST
 000006e: 00                                         ; u8 literal
-000006f: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000070: 80                                         ; load access byte
+000006f: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+0000070: 00                                         ; load access byte
 0000071: 09                                         ; OPCODE_I8_CONST
 0000072: 00                                         ; u8 literal
 0000073: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000074: 00                                         ; load access byte
+0000074: 80                                         ; load access byte
 0000075: 09                                         ; OPCODE_I8_CONST
 0000076: 00                                         ; u8 literal
 0000077: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000078: 00                                         ; load access byte
+0000078: 80                                         ; load access byte
 0000079: 09                                         ; OPCODE_I8_CONST
 000007a: 00                                         ; u8 literal
-0000009: 7000                                       ; FIXUP func body size
-000007b: 06                                         ; WASM_BINARY_SECTION_END
+000007b: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+000007c: 00                                         ; load access byte
+000007d: 09                                         ; OPCODE_I8_CONST
+000007e: 00                                         ; u8 literal
+000007f: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+0000080: 00                                         ; load access byte
+0000081: 09                                         ; OPCODE_I8_CONST
+0000082: 00                                         ; u8 literal
+0000011: 7000                                       ; FIXUP func body size
+0000083: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0070 0020 0009 0020  
-0000010: 0009 0020 0009 0020 0009 0022 8009 0022  
-0000020: 0009 0022 0009 0022 0009 002a 8009 002a  
-0000030: 8009 002a 0009 002a 0009 002b 8009 002b  
-0000040: 8009 002b 8009 002b 0009 0024 0009 0024  
-0000050: 0009 0024 0009 0024 0009 0026 8009 0026  
-0000060: 0009 0026 0009 0026 0009 0028 8009 0028  
-0000070: 8009 0028 0009 0028 0009 0006            
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0070 0020 0009 0020 0009 0020 0009 0020  
+0000020: 0009 0022 8009 0022 0009 0022 0009 0022  
+0000030: 0009 002a 8009 002a 8009 002a 0009 002a  
+0000040: 0009 002b 8009 002b 8009 002b 8009 002b  
+0000050: 0009 0024 0009 0024 0009 0024 0009 0024  
+0000060: 0009 0026 8009 0026 0009 0026 0009 0026  
+0000070: 0009 0028 8009 0028 8009 0028 0009 0028  
+0000080: 0009 0006                                
 ;;; STDOUT ;;)

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -16,79 +16,81 @@
     (f32.load (i32.const 0))
     (f64.load (i32.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 2a                                         ; OPCODE_I32_LOAD_MEM
-000000c: 00                                         ; load access byte
-000000d: 09                                         ; OPCODE_I8_CONST
-000000e: 00                                         ; u8 literal
-000000f: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-0000010: 00                                         ; load access byte
-0000011: 09                                         ; OPCODE_I8_CONST
-0000012: 00                                         ; u8 literal
-0000013: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 2a                                         ; OPCODE_I32_LOAD_MEM
 0000014: 00                                         ; load access byte
 0000015: 09                                         ; OPCODE_I8_CONST
 0000016: 00                                         ; u8 literal
-0000017: 21                                         ; OPCODE_I32_LOAD_MEM8_U
+0000017: 20                                         ; OPCODE_I32_LOAD_MEM8_S
 0000018: 00                                         ; load access byte
 0000019: 09                                         ; OPCODE_I8_CONST
 000001a: 00                                         ; u8 literal
-000001b: 23                                         ; OPCODE_I32_LOAD_MEM16_U
+000001b: 22                                         ; OPCODE_I32_LOAD_MEM16_S
 000001c: 00                                         ; load access byte
 000001d: 09                                         ; OPCODE_I8_CONST
 000001e: 00                                         ; u8 literal
-000001f: 2b                                         ; OPCODE_I64_LOAD_MEM
+000001f: 21                                         ; OPCODE_I32_LOAD_MEM8_U
 0000020: 00                                         ; load access byte
 0000021: 09                                         ; OPCODE_I8_CONST
 0000022: 00                                         ; u8 literal
-0000023: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+0000023: 23                                         ; OPCODE_I32_LOAD_MEM16_U
 0000024: 00                                         ; load access byte
 0000025: 09                                         ; OPCODE_I8_CONST
 0000026: 00                                         ; u8 literal
-0000027: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+0000027: 2b                                         ; OPCODE_I64_LOAD_MEM
 0000028: 00                                         ; load access byte
 0000029: 09                                         ; OPCODE_I8_CONST
 000002a: 00                                         ; u8 literal
-000002b: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+000002b: 24                                         ; OPCODE_I64_LOAD_MEM8_S
 000002c: 00                                         ; load access byte
 000002d: 09                                         ; OPCODE_I8_CONST
 000002e: 00                                         ; u8 literal
-000002f: 25                                         ; OPCODE_I64_LOAD_MEM8_U
+000002f: 26                                         ; OPCODE_I64_LOAD_MEM16_S
 0000030: 00                                         ; load access byte
 0000031: 09                                         ; OPCODE_I8_CONST
 0000032: 00                                         ; u8 literal
-0000033: 27                                         ; OPCODE_I64_LOAD_MEM16_U
+0000033: 28                                         ; OPCODE_I64_LOAD_MEM32_S
 0000034: 00                                         ; load access byte
 0000035: 09                                         ; OPCODE_I8_CONST
 0000036: 00                                         ; u8 literal
-0000037: 29                                         ; OPCODE_I64_LOAD_MEM32_U
+0000037: 25                                         ; OPCODE_I64_LOAD_MEM8_U
 0000038: 00                                         ; load access byte
 0000039: 09                                         ; OPCODE_I8_CONST
 000003a: 00                                         ; u8 literal
-000003b: 2c                                         ; OPCODE_F32_LOAD_MEM
+000003b: 27                                         ; OPCODE_I64_LOAD_MEM16_U
 000003c: 00                                         ; load access byte
 000003d: 09                                         ; OPCODE_I8_CONST
 000003e: 00                                         ; u8 literal
-000003f: 2d                                         ; OPCODE_F64_LOAD_MEM
+000003f: 29                                         ; OPCODE_I64_LOAD_MEM32_U
 0000040: 00                                         ; load access byte
 0000041: 09                                         ; OPCODE_I8_CONST
 0000042: 00                                         ; u8 literal
-0000009: 3800                                       ; FIXUP func body size
-0000043: 06                                         ; WASM_BINARY_SECTION_END
+0000043: 2c                                         ; OPCODE_F32_LOAD_MEM
+0000044: 00                                         ; load access byte
+0000045: 09                                         ; OPCODE_I8_CONST
+0000046: 00                                         ; u8 literal
+0000047: 2d                                         ; OPCODE_F64_LOAD_MEM
+0000048: 00                                         ; load access byte
+0000049: 09                                         ; OPCODE_I8_CONST
+000004a: 00                                         ; u8 literal
+0000011: 3800                                       ; FIXUP func body size
+000004b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0038 002a 0009 0020  
-0000010: 0009 0022 0009 0021 0009 0023 0009 002b  
-0000020: 0009 0024 0009 0026 0009 0028 0009 0025  
-0000030: 0009 0027 0009 0029 0009 002c 0009 002d  
-0000040: 0009 0006                                
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0038 002a 0009 0020 0009 0022 0009 0021  
+0000020: 0009 0023 0009 002b 0009 0024 0009 0026  
+0000030: 0009 0028 0009 0025 0009 0027 0009 0029  
+0000040: 0009 002c 0009 002d 0009 0006            
 ;;; STDOUT ;;)

--- a/test/dump/loadglobal.txt
+++ b/test/dump/loadglobal.txt
@@ -7,47 +7,50 @@
     (load_global 2)
     (load_global 3)))
 (;; STDOUT ;;;
-0000000: 03                                         ; WASM_BINARY_SECTION_GLOBALS
-0000001: 04                                         ; num globals
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 03                                         ; WASM_BINARY_SECTION_GLOBALS
+0000009: 04                                         ; num globals
 ; global header 0
-0000002: 0000 0000                                  ; global name offset
-0000006: 04                                         ; global mem type
-0000007: 00                                         ; export global
+000000a: 0000 0000                                  ; global name offset
+000000e: 04                                         ; global mem type
+000000f: 00                                         ; export global
 ; global header 1
-0000008: 0000 0000                                  ; global name offset
-000000c: 06                                         ; global mem type
-000000d: 00                                         ; export global
+0000010: 0000 0000                                  ; global name offset
+0000014: 06                                         ; global mem type
+0000015: 00                                         ; export global
 ; global header 2
-000000e: 0000 0000                                  ; global name offset
-0000012: 08                                         ; global mem type
-0000013: 00                                         ; export global
+0000016: 0000 0000                                  ; global name offset
+000001a: 08                                         ; global mem type
+000001b: 00                                         ; export global
 ; global header 3
-0000014: 0000 0000                                  ; global name offset
-0000018: 09                                         ; global mem type
-0000019: 00                                         ; export global
-000001a: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-000001b: 01                                         ; num signatures
+000001c: 0000 0000                                  ; global name offset
+0000020: 09                                         ; global mem type
+0000021: 00                                         ; export global
+0000022: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000023: 01                                         ; num signatures
 ; signature 0
-000001c: 00                                         ; num params
-000001d: 00                                         ; result_type
-000001e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-000001f: 01                                         ; num functions
+0000024: 00                                         ; num params
+0000025: 00                                         ; result_type
+0000026: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000027: 01                                         ; num functions
 ; function 0
-0000020: 00                                         ; func flags
-0000021: 0000                                       ; func signature index
-0000023: 0000                                       ; func body size
-0000025: 10                                         ; OPCODE_LOAD_GLOBAL
-0000026: 00                                         ; global index
-0000027: 10                                         ; OPCODE_LOAD_GLOBAL
-0000028: 01                                         ; global index
-0000029: 10                                         ; OPCODE_LOAD_GLOBAL
-000002a: 02                                         ; global index
-000002b: 10                                         ; OPCODE_LOAD_GLOBAL
-000002c: 03                                         ; global index
-0000023: 0800                                       ; FIXUP func body size
-000002d: 06                                         ; WASM_BINARY_SECTION_END
+0000028: 00                                         ; func flags
+0000029: 0000                                       ; func signature index
+000002b: 0000                                       ; func body size
+000002d: 10                                         ; OPCODE_LOAD_GLOBAL
+000002e: 00                                         ; global index
+000002f: 10                                         ; OPCODE_LOAD_GLOBAL
+0000030: 01                                         ; global index
+0000031: 10                                         ; OPCODE_LOAD_GLOBAL
+0000032: 02                                         ; global index
+0000033: 10                                         ; OPCODE_LOAD_GLOBAL
+0000034: 03                                         ; global index
+000002b: 0800                                       ; FIXUP func body size
+0000035: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0304 0000 0000 0400 0000 0000 0600 0000  
-0000010: 0000 0800 0000 0000 0900 0101 0000 0201  
-0000020: 0000 0008 0010 0010 0110 0210 0306       
+0000000: 0061 736d 0a00 0000 0304 0000 0000 0400  
+0000010: 0000 0000 0600 0000 0000 0800 0000 0000  
+0000020: 0900 0101 0000 0201 0000 0008 0010 0010  
+0000030: 0110 0210 0306                           
 ;;; STDOUT ;;)

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -2,24 +2,26 @@
 (module
   (func (local i32 i64 i64 f32 f32 f32 f64 f64 f64 f64)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 04                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0100                                       ; num local i32
-000000b: 0200                                       ; num local i64
-000000d: 0300                                       ; num local f32
-000000f: 0400                                       ; num local f64
-0000011: 0000                                       ; func body size
-0000011: 0000                                       ; FIXUP func body size
-0000013: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 04                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0100                                       ; num local i32
+0000013: 0200                                       ; num local i64
+0000015: 0300                                       ; num local f32
+0000017: 0400                                       ; num local f64
+0000019: 0000                                       ; func body size
+0000019: 0000                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0400 0001 0002 0003 0004  
-0000010: 0000 0006                                
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0400  
+0000010: 0001 0002 0003 0004 0000 0006            
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -49,29 +49,23 @@
       (br 0)       ;; depth 1 (due to implicit block)
 )))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 02                                         ; num expressions (byte 1)
-000000d: 01                                         ; OPCODE_BLOCK
-000000e: ff                                         ; num expressions (byte 0)
-000000f: 00                                         ; OPCODE_NOP
-0000010: 00                                         ; OPCODE_NOP
-0000011: 00                                         ; OPCODE_NOP
-0000012: 00                                         ; OPCODE_NOP
-0000013: 00                                         ; OPCODE_NOP
-0000014: 00                                         ; OPCODE_NOP
-0000015: 00                                         ; OPCODE_NOP
-0000016: 00                                         ; OPCODE_NOP
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 02                                         ; num expressions (byte 1)
+0000015: 01                                         ; OPCODE_BLOCK
+0000016: ff                                         ; num expressions (byte 0)
 0000017: 00                                         ; OPCODE_NOP
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
@@ -319,26 +313,34 @@
 000010b: 00                                         ; OPCODE_NOP
 000010c: 00                                         ; OPCODE_NOP
 000010d: 00                                         ; OPCODE_NOP
-000010e: 01                                         ; OPCODE_BLOCK
-000010f: 05                                         ; num expressions (byte 0)
+000010e: 00                                         ; OPCODE_NOP
+000010f: 00                                         ; OPCODE_NOP
 0000110: 00                                         ; OPCODE_NOP
-0000111: 06                                         ; OPCODE_BR
-0000112: 02                                         ; break depth
+0000111: 00                                         ; OPCODE_NOP
+0000112: 00                                         ; OPCODE_NOP
 0000113: 00                                         ; OPCODE_NOP
-0000114: 06                                         ; OPCODE_BR
-0000115: 01                                         ; break depth
-0000116: 00                                         ; OPCODE_NOP
-0000117: 06                                         ; OPCODE_BR
-0000118: 02                                         ; break depth
-0000119: 00                                         ; OPCODE_NOP
-000011a: 06                                         ; OPCODE_BR
-000011b: 01                                         ; break depth
-000011c: 00                                         ; OPCODE_NOP
-0000009: 1201                                       ; FIXUP func body size
-000011d: 06                                         ; WASM_BINARY_SECTION_END
+0000114: 00                                         ; OPCODE_NOP
+0000115: 00                                         ; OPCODE_NOP
+0000116: 01                                         ; OPCODE_BLOCK
+0000117: 05                                         ; num expressions (byte 0)
+0000118: 00                                         ; OPCODE_NOP
+0000119: 06                                         ; OPCODE_BR
+000011a: 02                                         ; break depth
+000011b: 00                                         ; OPCODE_NOP
+000011c: 06                                         ; OPCODE_BR
+000011d: 01                                         ; break depth
+000011e: 00                                         ; OPCODE_NOP
+000011f: 06                                         ; OPCODE_BR
+0000120: 02                                         ; break depth
+0000121: 00                                         ; OPCODE_NOP
+0000122: 06                                         ; OPCODE_BR
+0000123: 01                                         ; break depth
+0000124: 00                                         ; OPCODE_NOP
+0000011: 1201                                       ; FIXUP func body size
+0000125: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0012 0102 0201 ff00  
-0000010: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0012 0102 0201 ff00 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -353,6 +355,7 @@
 00000d0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000100: 0000 0000 0000 0000 0000 0000 0000 0105  
-0000110: 0006 0200 0601 0006 0200 0601 0006       
+0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000110: 0000 0000 0000 0105 0006 0200 0601 0006  
+0000120: 0200 0601 0006                           
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -45,29 +45,23 @@
       ;; 257
       (nop))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 02                                         ; num expressions (byte 1)
-000000d: 01                                         ; OPCODE_BLOCK
-000000e: ff                                         ; num expressions (byte 0)
-000000f: 00                                         ; OPCODE_NOP
-0000010: 00                                         ; OPCODE_NOP
-0000011: 00                                         ; OPCODE_NOP
-0000012: 00                                         ; OPCODE_NOP
-0000013: 00                                         ; OPCODE_NOP
-0000014: 00                                         ; OPCODE_NOP
-0000015: 00                                         ; OPCODE_NOP
-0000016: 00                                         ; OPCODE_NOP
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 02                                         ; num expressions (byte 1)
+0000015: 01                                         ; OPCODE_BLOCK
+0000016: ff                                         ; num expressions (byte 0)
 0000017: 00                                         ; OPCODE_NOP
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
@@ -315,15 +309,23 @@
 000010b: 00                                         ; OPCODE_NOP
 000010c: 00                                         ; OPCODE_NOP
 000010d: 00                                         ; OPCODE_NOP
-000010e: 01                                         ; OPCODE_BLOCK
-000010f: 02                                         ; num expressions (byte 0)
+000010e: 00                                         ; OPCODE_NOP
+000010f: 00                                         ; OPCODE_NOP
 0000110: 00                                         ; OPCODE_NOP
 0000111: 00                                         ; OPCODE_NOP
-0000009: 0701                                       ; FIXUP func body size
-0000112: 06                                         ; WASM_BINARY_SECTION_END
+0000112: 00                                         ; OPCODE_NOP
+0000113: 00                                         ; OPCODE_NOP
+0000114: 00                                         ; OPCODE_NOP
+0000115: 00                                         ; OPCODE_NOP
+0000116: 01                                         ; OPCODE_BLOCK
+0000117: 02                                         ; num expressions (byte 0)
+0000118: 00                                         ; OPCODE_NOP
+0000119: 00                                         ; OPCODE_NOP
+0000011: 0701                                       ; FIXUP func body size
+000011a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0007 0102 0201 ff00  
-0000010: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0007 0102 0201 ff00 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -338,6 +340,6 @@
 00000d0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000100: 0000 0000 0000 0000 0000 0000 0000 0102  
-0000110: 0000 06                                  
+0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
+0000110: 0000 0000 0000 0102 0000 06              
 ;;; STDOUT ;;)

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -5,23 +5,26 @@
       (nop)
       (nop))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 02                                         ; OPCODE_LOOP
-000000c: 02                                         ; num expressions
-000000d: 00                                         ; OPCODE_NOP
-000000e: 00                                         ; OPCODE_NOP
-0000009: 0400                                       ; FIXUP func body size
-000000f: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 02                                         ; OPCODE_LOOP
+0000014: 02                                         ; num expressions
+0000015: 00                                         ; OPCODE_NOP
+0000016: 00                                         ; OPCODE_NOP
+0000011: 0400                                       ; FIXUP func body size
+0000017: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0004 0002 0200 0006  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0004 0002 0200 0006                      
 ;;; STDOUT ;;)

--- a/test/dump/memory-1-byte.txt
+++ b/test/dump/memory-1-byte.txt
@@ -1,11 +1,13 @@
 ;;; FLAGS: -dv
 (module (memory 1))
 (;; STDOUT ;;;
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 00                                         ; min mem size log 2
-0000002: 00                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 06                                         ; WASM_BINARY_SECTION_END
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 00                                         ; min mem size log 2
+000000a: 00                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0000 0001 06                             
+0000000: 0061 736d 0a00 0000 0000 0001 06         
 ;;; STDOUT ;;)

--- a/test/dump/memory-data-size.txt
+++ b/test/dump/memory-data-size.txt
@@ -4,24 +4,32 @@
 (module (memory 512))
 (module (memory 1000))
 (;; STDOUT ;;;
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 07                                         ; min mem size log 2
-0000002: 07                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 06                                         ; WASM_BINARY_SECTION_END
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 08                                         ; min mem size log 2
-0000002: 08                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 06                                         ; WASM_BINARY_SECTION_END
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 09                                         ; min mem size log 2
-0000002: 09                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 06                                         ; WASM_BINARY_SECTION_END
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 0a                                         ; min mem size log 2
-0000002: 0a                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 06                                         ; WASM_BINARY_SECTION_END
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 07                                         ; min mem size log 2
+000000a: 07                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 06                                         ; WASM_BINARY_SECTION_END
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 08                                         ; min mem size log 2
+000000a: 08                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 06                                         ; WASM_BINARY_SECTION_END
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 09                                         ; min mem size log 2
+000000a: 09                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 06                                         ; WASM_BINARY_SECTION_END
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 0a                                         ; min mem size log 2
+000000a: 0a                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 06                                         ; WASM_BINARY_SECTION_END
 ;;; STDOUT ;;)

--- a/test/dump/memory-hex.txt
+++ b/test/dump/memory-hex.txt
@@ -3,22 +3,25 @@
   (memory 100
     (segment 0 "\00\01\02\03\04\05\06\07\08\09\0a")))
 (;; STDOUT ;;;
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 07                                         ; min mem size log 2
-0000002: 07                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 04                                         ; WASM_BINARY_SECTION_DATA_SEGMENTS
-0000005: 01                                         ; num data segments
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 07                                         ; min mem size log 2
+000000a: 07                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 04                                         ; WASM_BINARY_SECTION_DATA_SEGMENTS
+000000d: 01                                         ; num data segments
 ; segment header 0
-0000006: 0000 0000                                  ; segment address
-000000a: 0000 0000                                  ; segment data offset
-000000e: 0b00 0000                                  ; segment size
-0000012: 01                                         ; segment init
-0000013: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 0000 0000                                  ; segment address
+0000012: 0000 0000                                  ; segment data offset
+0000016: 0b00 0000                                  ; segment size
+000001a: 01                                         ; segment init
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ; segment data 0
-000000a: 1400 0000                                  ; FIXUP segment data offset
-0000014: 0001 0203 0405 0607 0809 0a                ; segment data
+0000012: 1c00 0000                                  ; FIXUP segment data offset
+000001c: 0001 0203 0405 0607 0809 0a                ; segment data
 ;; dump
-0000000: 0007 0701 0401 0000 0000 1400 0000 0b00  
-0000010: 0000 0106 0001 0203 0405 0607 0809 0a    
+0000000: 0061 736d 0a00 0000 0007 0701 0401 0000  
+0000010: 0000 1c00 0000 0b00 0000 0106 0001 0203  
+0000020: 0405 0607 0809 0a                        
 ;;; STDOUT ;;)

--- a/test/dump/memory-size.txt
+++ b/test/dump/memory-size.txt
@@ -4,25 +4,27 @@
   (func (result i32)
     (memory_size)))
 (;; STDOUT ;;;
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 0a                                         ; min mem size log 2
-0000002: 0a                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000005: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 0a                                         ; min mem size log 2
+000000a: 0a                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+000000d: 01                                         ; num signatures
 ; signature 0
-0000006: 00                                         ; num params
-0000007: 01                                         ; result_type
-0000008: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000009: 01                                         ; num functions
+000000e: 00                                         ; num params
+000000f: 01                                         ; result_type
+0000010: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000011: 01                                         ; num functions
 ; function 0
-000000a: 00                                         ; func flags
-000000b: 0000                                       ; func signature index
-000000d: 0000                                       ; func body size
-000000f: 3b                                         ; OPCODE_MEMORY_SIZE
-000000d: 0100                                       ; FIXUP func body size
-0000010: 06                                         ; WASM_BINARY_SECTION_END
+0000012: 00                                         ; func flags
+0000013: 0000                                       ; func signature index
+0000015: 0000                                       ; func body size
+0000017: 3b                                         ; OPCODE_MEMORY_SIZE
+0000015: 0100                                       ; FIXUP func body size
+0000018: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 000a 0a01 0101 0001 0201 0000 0001 003b  
-0000010: 06                                       
+0000000: 0061 736d 0a00 0000 000a 0a01 0101 0001  
+0000010: 0201 0000 0001 003b 06                   
 ;;; STDOUT ;;)

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -2,31 +2,34 @@
 (module
   (memory 100 (segment 10 "hello") (segment 20 "goodbye")))
 (;; STDOUT ;;;
-0000000: 00                                         ; WASM_BINARY_SECTION_MEMORY
-0000001: 07                                         ; min mem size log 2
-0000002: 07                                         ; max mem size log 2
-0000003: 01                                         ; export mem
-0000004: 04                                         ; WASM_BINARY_SECTION_DATA_SEGMENTS
-0000005: 02                                         ; num data segments
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 00                                         ; WASM_BINARY_SECTION_MEMORY
+0000009: 07                                         ; min mem size log 2
+000000a: 07                                         ; max mem size log 2
+000000b: 01                                         ; export mem
+000000c: 04                                         ; WASM_BINARY_SECTION_DATA_SEGMENTS
+000000d: 02                                         ; num data segments
 ; segment header 0
-0000006: 0a00 0000                                  ; segment address
-000000a: 0000 0000                                  ; segment data offset
-000000e: 0500 0000                                  ; segment size
-0000012: 01                                         ; segment init
+000000e: 0a00 0000                                  ; segment address
+0000012: 0000 0000                                  ; segment data offset
+0000016: 0500 0000                                  ; segment size
+000001a: 01                                         ; segment init
 ; segment header 1
-0000013: 1400 0000                                  ; segment address
-0000017: 0000 0000                                  ; segment data offset
-000001b: 0700 0000                                  ; segment size
-000001f: 01                                         ; segment init
-0000020: 06                                         ; WASM_BINARY_SECTION_END
+000001b: 1400 0000                                  ; segment address
+000001f: 0000 0000                                  ; segment data offset
+0000023: 0700 0000                                  ; segment size
+0000027: 01                                         ; segment init
+0000028: 06                                         ; WASM_BINARY_SECTION_END
 ; segment data 0
-000000a: 2100 0000                                  ; FIXUP segment data offset
-0000021: 6865 6c6c 6f                               ; segment data
+0000012: 2900 0000                                  ; FIXUP segment data offset
+0000029: 6865 6c6c 6f                               ; segment data
 ; segment data 1
-0000017: 2600 0000                                  ; FIXUP segment data offset
-0000026: 676f 6f64 6279 65                          ; segment data
+000001f: 2e00 0000                                  ; FIXUP segment data offset
+000002e: 676f 6f64 6279 65                          ; segment data
 ;; dump
-0000000: 0007 0701 0402 0a00 0000 2100 0000 0500  
-0000010: 0000 0114 0000 0026 0000 0007 0000 0001  
-0000020: 0668 656c 6c6f 676f 6f64 6279 65         
+0000000: 0061 736d 0a00 0000 0007 0701 0402 0a00  
+0000010: 0000 2900 0000 0500 0000 0114 0000 002e  
+0000020: 0000 0007 0000 0001 0668 656c 6c6f 676f  
+0000030: 6f64 6279 65                             
 ;;; STDOUT ;;)

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -2,20 +2,23 @@
 (module
   (func (nop)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 00                                         ; OPCODE_NOP
-0000009: 0100                                       ; FIXUP func body size
-000000c: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 00                                         ; OPCODE_NOP
+0000011: 0100                                       ; FIXUP func body size
+0000014: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0001 0000 06         
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0001 0000 06                             
 ;;; STDOUT ;;)

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -2,23 +2,26 @@
 (module
   (func (param i32 i64 f32 f64)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 04                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 02                                         ; param type
-0000006: 03                                         ; param type
-0000007: 04                                         ; param type
-0000008: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000009: 01                                         ; num functions
+000000a: 04                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 02                                         ; param type
+000000e: 03                                         ; param type
+000000f: 04                                         ; param type
+0000010: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000011: 01                                         ; num functions
 ; function 0
-000000a: 00                                         ; func flags
-000000b: 0000                                       ; func signature index
-000000d: 0000                                       ; func body size
-000000d: 0000                                       ; FIXUP func body size
-000000f: 06                                         ; WASM_BINARY_SECTION_END
+0000012: 00                                         ; func flags
+0000013: 0000                                       ; func signature index
+0000015: 0000                                       ; func body size
+0000015: 0000                                       ; FIXUP func body size
+0000017: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0400 0102 0304 0201 0000 0000 0006  
+0000000: 0061 736d 0a00 0000 0101 0400 0102 0304  
+0000010: 0201 0000 0000 0006                      
 ;;; STDOUT ;;)

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -5,54 +5,57 @@
   (func (result f32) (f32.const 0))
   (func (result f64) (f64.const 0)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 04                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 04                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 01                                         ; result_type
+000000a: 00                                         ; num params
+000000b: 01                                         ; result_type
 ; signature 1
-0000004: 00                                         ; num params
-0000005: 02                                         ; result_type
+000000c: 00                                         ; num params
+000000d: 02                                         ; result_type
 ; signature 2
-0000006: 00                                         ; num params
-0000007: 03                                         ; result_type
+000000e: 00                                         ; num params
+000000f: 03                                         ; result_type
 ; signature 3
-0000008: 00                                         ; num params
-0000009: 04                                         ; result_type
-000000a: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-000000b: 04                                         ; num functions
+0000010: 00                                         ; num params
+0000011: 04                                         ; result_type
+0000012: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000013: 04                                         ; num functions
 ; function 0
-000000c: 00                                         ; func flags
-000000d: 0000                                       ; func signature index
-000000f: 0000                                       ; func body size
-0000011: 09                                         ; OPCODE_I8_CONST
-0000012: 00                                         ; u8 literal
-000000f: 0200                                       ; FIXUP func body size
+0000014: 00                                         ; func flags
+0000015: 0000                                       ; func signature index
+0000017: 0000                                       ; func body size
+0000019: 09                                         ; OPCODE_I8_CONST
+000001a: 00                                         ; u8 literal
+0000017: 0200                                       ; FIXUP func body size
 ; function 1
-0000013: 00                                         ; func flags
-0000014: 0100                                       ; func signature index
-0000016: 0000                                       ; func body size
-0000018: 0b                                         ; OPCODE_I64_CONST
-0000019: 0000 0000 0000 0000                        ; u64 literal
-0000016: 0900                                       ; FIXUP func body size
+000001b: 00                                         ; func flags
+000001c: 0100                                       ; func signature index
+000001e: 0000                                       ; func body size
+0000020: 0b                                         ; OPCODE_I64_CONST
+0000021: 0000 0000 0000 0000                        ; u64 literal
+000001e: 0900                                       ; FIXUP func body size
 ; function 2
-0000021: 00                                         ; func flags
-0000022: 0200                                       ; func signature index
-0000024: 0000                                       ; func body size
-0000026: 0d                                         ; OPCODE_F32_CONST
-0000027: 0000 0000                                  ; f32 literal
-0000024: 0500                                       ; FIXUP func body size
+0000029: 00                                         ; func flags
+000002a: 0200                                       ; func signature index
+000002c: 0000                                       ; func body size
+000002e: 0d                                         ; OPCODE_F32_CONST
+000002f: 0000 0000                                  ; f32 literal
+000002c: 0500                                       ; FIXUP func body size
 ; function 3
-000002b: 00                                         ; func flags
-000002c: 0300                                       ; func signature index
-000002e: 0000                                       ; func body size
-0000030: 0c                                         ; OPCODE_F64_CONST
-0000031: 0000 0000 0000 0000                        ; f64 literal
-000002e: 0900                                       ; FIXUP func body size
-0000039: 06                                         ; WASM_BINARY_SECTION_END
+0000033: 00                                         ; func flags
+0000034: 0300                                       ; func signature index
+0000036: 0000                                       ; func body size
+0000038: 0c                                         ; OPCODE_F64_CONST
+0000039: 0000 0000 0000 0000                        ; f64 literal
+0000036: 0900                                       ; FIXUP func body size
+0000041: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0104 0001 0002 0003 0004 0204 0000 0002  
-0000010: 0009 0000 0100 0900 0b00 0000 0000 0000  
-0000020: 0000 0200 0500 0d00 0000 0000 0300 0900  
-0000030: 0c00 0000 0000 0000 0006                 
+0000000: 0061 736d 0a00 0000 0104 0001 0002 0003  
+0000010: 0004 0204 0000 0002 0009 0000 0100 0900  
+0000020: 0b00 0000 0000 0000 0000 0200 0500 0d00  
+0000030: 0000 0000 0300 0900 0c00 0000 0000 0000  
+0000040: 0006                                     
 ;;; STDOUT ;;)

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -4,32 +4,34 @@
     (return (i32.const 42)))
   (func (return)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 02                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 02                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 01                                         ; result_type
+000000a: 00                                         ; num params
+000000b: 01                                         ; result_type
 ; signature 1
-0000004: 00                                         ; num params
-0000005: 00                                         ; result_type
-0000006: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000007: 02                                         ; num functions
+000000c: 00                                         ; num params
+000000d: 00                                         ; result_type
+000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000f: 02                                         ; num functions
 ; function 0
-0000008: 00                                         ; func flags
-0000009: 0000                                       ; func signature index
-000000b: 0000                                       ; func body size
-000000d: 14                                         ; OPCODE_RETURN
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 2a                                         ; u8 literal
-000000b: 0300                                       ; FIXUP func body size
-; function 1
 0000010: 00                                         ; func flags
-0000011: 0100                                       ; func signature index
+0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
 0000015: 14                                         ; OPCODE_RETURN
-0000013: 0100                                       ; FIXUP func body size
-0000016: 06                                         ; WASM_BINARY_SECTION_END
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 2a                                         ; u8 literal
+0000013: 0300                                       ; FIXUP func body size
+; function 1
+0000018: 00                                         ; func flags
+0000019: 0100                                       ; func signature index
+000001b: 0000                                       ; func body size
+000001d: 14                                         ; OPCODE_RETURN
+000001b: 0100                                       ; FIXUP func body size
+000001e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0102 0001 0000 0202 0000 0003 0014 092a  
-0000010: 0001 0001 0014 06                        
+0000000: 0061 736d 0a00 0000 0102 0001 0000 0202  
+0000010: 0000 0003 0014 092a 0001 0001 0014 06    
 ;;; STDOUT ;;)

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -6,51 +6,54 @@
     (f32.select (f32.const 2) (f32.const 3) (i32.const 1))
     (f64.select (f64.const 2) (f64.const 3) (i32.const 1))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 05                                         ; OPCODE_SELECT
-000000c: 09                                         ; OPCODE_I8_CONST
-000000d: 02                                         ; u8 literal
-000000e: 09                                         ; OPCODE_I8_CONST
-000000f: 03                                         ; u8 literal
-0000010: 09                                         ; OPCODE_I8_CONST
-0000011: 01                                         ; u8 literal
-0000012: 05                                         ; OPCODE_SELECT
-0000013: 0b                                         ; OPCODE_I64_CONST
-0000014: 0200 0000 0000 0000                        ; u64 literal
-000001c: 0b                                         ; OPCODE_I64_CONST
-000001d: 0300 0000 0000 0000                        ; u64 literal
-0000025: 09                                         ; OPCODE_I8_CONST
-0000026: 01                                         ; u8 literal
-0000027: 05                                         ; OPCODE_SELECT
-0000028: 0d                                         ; OPCODE_F32_CONST
-0000029: 0000 0040                                  ; f32 literal
-000002d: 0d                                         ; OPCODE_F32_CONST
-000002e: 0000 4040                                  ; f32 literal
-0000032: 09                                         ; OPCODE_I8_CONST
-0000033: 01                                         ; u8 literal
-0000034: 05                                         ; OPCODE_SELECT
-0000035: 0c                                         ; OPCODE_F64_CONST
-0000036: 0000 0000 0000 0040                        ; f64 literal
-000003e: 0c                                         ; OPCODE_F64_CONST
-000003f: 0000 0000 0000 0840                        ; f64 literal
-0000047: 09                                         ; OPCODE_I8_CONST
-0000048: 01                                         ; u8 literal
-0000009: 3e00                                       ; FIXUP func body size
-0000049: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 05                                         ; OPCODE_SELECT
+0000014: 09                                         ; OPCODE_I8_CONST
+0000015: 02                                         ; u8 literal
+0000016: 09                                         ; OPCODE_I8_CONST
+0000017: 03                                         ; u8 literal
+0000018: 09                                         ; OPCODE_I8_CONST
+0000019: 01                                         ; u8 literal
+000001a: 05                                         ; OPCODE_SELECT
+000001b: 0b                                         ; OPCODE_I64_CONST
+000001c: 0200 0000 0000 0000                        ; u64 literal
+0000024: 0b                                         ; OPCODE_I64_CONST
+0000025: 0300 0000 0000 0000                        ; u64 literal
+000002d: 09                                         ; OPCODE_I8_CONST
+000002e: 01                                         ; u8 literal
+000002f: 05                                         ; OPCODE_SELECT
+0000030: 0d                                         ; OPCODE_F32_CONST
+0000031: 0000 0040                                  ; f32 literal
+0000035: 0d                                         ; OPCODE_F32_CONST
+0000036: 0000 4040                                  ; f32 literal
+000003a: 09                                         ; OPCODE_I8_CONST
+000003b: 01                                         ; u8 literal
+000003c: 05                                         ; OPCODE_SELECT
+000003d: 0c                                         ; OPCODE_F64_CONST
+000003e: 0000 0000 0000 0040                        ; f64 literal
+0000046: 0c                                         ; OPCODE_F64_CONST
+0000047: 0000 0000 0000 0840                        ; f64 literal
+000004f: 09                                         ; OPCODE_I8_CONST
+0000050: 01                                         ; u8 literal
+0000011: 3e00                                       ; FIXUP func body size
+0000051: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 003e 0005 0902 0903  
-0000010: 0901 050b 0200 0000 0000 0000 0b03 0000  
-0000020: 0000 0000 0009 0105 0d00 0000 400d 0000  
-0000030: 4040 0901 050c 0000 0000 0000 0040 0c00  
-0000040: 0000 0000 0008 4009 0106                 
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 003e 0005 0902 0903 0901 050b 0200 0000  
+0000020: 0000 0000 0b03 0000 0000 0000 0009 0105  
+0000030: 0d00 0000 400d 0000 4040 0901 050c 0000  
+0000040: 0000 0000 0040 0c00 0000 0000 0008 4009  
+0000050: 0106                                     
 ;;; STDOUT ;;)

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -13,52 +13,55 @@
     (set_local 4 (i32.const 0))
     (set_local 5 (f32.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 02                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
-0000005: 03                                         ; param type
-0000006: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000007: 01                                         ; num functions
+000000a: 02                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
+000000d: 03                                         ; param type
+000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000f: 01                                         ; num functions
 ; function 0
-0000008: 04                                         ; func flags
-0000009: 0000                                       ; func signature index
-000000b: 0100                                       ; num local i32
-000000d: 0100                                       ; num local i64
-000000f: 0200                                       ; num local f32
-0000011: 0000                                       ; num local f64
-0000013: 0000                                       ; func body size
-0000015: 0f                                         ; OPCODE_SET_LOCAL
-0000016: 00                                         ; remapped local index
-0000017: 09                                         ; OPCODE_I8_CONST
-0000018: 00                                         ; u8 literal
-0000019: 0f                                         ; OPCODE_SET_LOCAL
-000001a: 01                                         ; remapped local index
-000001b: 0d                                         ; OPCODE_F32_CONST
-000001c: 0000 0000                                  ; f32 literal
-0000020: 0f                                         ; OPCODE_SET_LOCAL
-0000021: 03                                         ; remapped local index
-0000022: 0b                                         ; OPCODE_I64_CONST
-0000023: 0000 0000 0000 0000                        ; u64 literal
-000002b: 0f                                         ; OPCODE_SET_LOCAL
-000002c: 04                                         ; remapped local index
-000002d: 0d                                         ; OPCODE_F32_CONST
-000002e: 0000 0000                                  ; f32 literal
-0000032: 0f                                         ; OPCODE_SET_LOCAL
-0000033: 02                                         ; remapped local index
-0000034: 09                                         ; OPCODE_I8_CONST
-0000035: 00                                         ; u8 literal
-0000036: 0f                                         ; OPCODE_SET_LOCAL
-0000037: 05                                         ; remapped local index
-0000038: 0d                                         ; OPCODE_F32_CONST
-0000039: 0000 0000                                  ; f32 literal
-0000013: 2800                                       ; FIXUP func body size
-000003d: 06                                         ; WASM_BINARY_SECTION_END
+0000010: 04                                         ; func flags
+0000011: 0000                                       ; func signature index
+0000013: 0100                                       ; num local i32
+0000015: 0100                                       ; num local i64
+0000017: 0200                                       ; num local f32
+0000019: 0000                                       ; num local f64
+000001b: 0000                                       ; func body size
+000001d: 0f                                         ; OPCODE_SET_LOCAL
+000001e: 00                                         ; remapped local index
+000001f: 09                                         ; OPCODE_I8_CONST
+0000020: 00                                         ; u8 literal
+0000021: 0f                                         ; OPCODE_SET_LOCAL
+0000022: 01                                         ; remapped local index
+0000023: 0d                                         ; OPCODE_F32_CONST
+0000024: 0000 0000                                  ; f32 literal
+0000028: 0f                                         ; OPCODE_SET_LOCAL
+0000029: 03                                         ; remapped local index
+000002a: 0b                                         ; OPCODE_I64_CONST
+000002b: 0000 0000 0000 0000                        ; u64 literal
+0000033: 0f                                         ; OPCODE_SET_LOCAL
+0000034: 04                                         ; remapped local index
+0000035: 0d                                         ; OPCODE_F32_CONST
+0000036: 0000 0000                                  ; f32 literal
+000003a: 0f                                         ; OPCODE_SET_LOCAL
+000003b: 02                                         ; remapped local index
+000003c: 09                                         ; OPCODE_I8_CONST
+000003d: 00                                         ; u8 literal
+000003e: 0f                                         ; OPCODE_SET_LOCAL
+000003f: 05                                         ; remapped local index
+0000040: 0d                                         ; OPCODE_F32_CONST
+0000041: 0000 0000                                  ; f32 literal
+000001b: 2800                                       ; FIXUP func body size
+0000045: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0200 0103 0201 0400 0001 0001 0002  
-0000010: 0000 0028 000f 0009 000f 010d 0000 0000  
-0000020: 0f03 0b00 0000 0000 0000 000f 040d 0000  
-0000030: 0000 0f02 0900 0f05 0d00 0000 0006       
+0000000: 0061 736d 0a00 0000 0101 0200 0103 0201  
+0000010: 0400 0001 0001 0002 0000 0028 000f 0009  
+0000020: 000f 010d 0000 0000 0f03 0b00 0000 0000  
+0000030: 0000 000f 040d 0000 0000 0f02 0900 0f05  
+0000040: 0d00 0000 0006                           
 ;;; STDOUT ;;)

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -15,60 +15,62 @@
     (set_local 6 (f64.const 0))
     (set_local 7 (i64.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 04                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0200                                       ; num local i32
-000000b: 0200                                       ; num local i64
-000000d: 0200                                       ; num local f32
-000000f: 0200                                       ; num local f64
-0000011: 0000                                       ; func body size
-0000013: 0f                                         ; OPCODE_SET_LOCAL
-0000014: 06                                         ; remapped local index
-0000015: 0c                                         ; OPCODE_F64_CONST
-0000016: 0000 0000 0000 0000                        ; f64 literal
-000001e: 0f                                         ; OPCODE_SET_LOCAL
-000001f: 04                                         ; remapped local index
-0000020: 0d                                         ; OPCODE_F32_CONST
-0000021: 0000 0000                                  ; f32 literal
-0000025: 0f                                         ; OPCODE_SET_LOCAL
-0000026: 02                                         ; remapped local index
-0000027: 0b                                         ; OPCODE_I64_CONST
-0000028: 0000 0000 0000 0000                        ; u64 literal
-0000030: 0f                                         ; OPCODE_SET_LOCAL
-0000031: 00                                         ; remapped local index
-0000032: 09                                         ; OPCODE_I8_CONST
-0000033: 00                                         ; u8 literal
-0000034: 0f                                         ; OPCODE_SET_LOCAL
-0000035: 01                                         ; remapped local index
-0000036: 09                                         ; OPCODE_I8_CONST
-0000037: 00                                         ; u8 literal
+000000e: 04                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0200                                       ; num local i32
+0000013: 0200                                       ; num local i64
+0000015: 0200                                       ; num local f32
+0000017: 0200                                       ; num local f64
+0000019: 0000                                       ; func body size
+000001b: 0f                                         ; OPCODE_SET_LOCAL
+000001c: 06                                         ; remapped local index
+000001d: 0c                                         ; OPCODE_F64_CONST
+000001e: 0000 0000 0000 0000                        ; f64 literal
+0000026: 0f                                         ; OPCODE_SET_LOCAL
+0000027: 04                                         ; remapped local index
+0000028: 0d                                         ; OPCODE_F32_CONST
+0000029: 0000 0000                                  ; f32 literal
+000002d: 0f                                         ; OPCODE_SET_LOCAL
+000002e: 02                                         ; remapped local index
+000002f: 0b                                         ; OPCODE_I64_CONST
+0000030: 0000 0000 0000 0000                        ; u64 literal
 0000038: 0f                                         ; OPCODE_SET_LOCAL
-0000039: 05                                         ; remapped local index
-000003a: 0d                                         ; OPCODE_F32_CONST
-000003b: 0000 0000                                  ; f32 literal
-000003f: 0f                                         ; OPCODE_SET_LOCAL
-0000040: 07                                         ; remapped local index
-0000041: 0c                                         ; OPCODE_F64_CONST
-0000042: 0000 0000 0000 0000                        ; f64 literal
-000004a: 0f                                         ; OPCODE_SET_LOCAL
-000004b: 03                                         ; remapped local index
-000004c: 0b                                         ; OPCODE_I64_CONST
-000004d: 0000 0000 0000 0000                        ; u64 literal
-0000011: 4200                                       ; FIXUP func body size
-0000055: 06                                         ; WASM_BINARY_SECTION_END
+0000039: 00                                         ; remapped local index
+000003a: 09                                         ; OPCODE_I8_CONST
+000003b: 00                                         ; u8 literal
+000003c: 0f                                         ; OPCODE_SET_LOCAL
+000003d: 01                                         ; remapped local index
+000003e: 09                                         ; OPCODE_I8_CONST
+000003f: 00                                         ; u8 literal
+0000040: 0f                                         ; OPCODE_SET_LOCAL
+0000041: 05                                         ; remapped local index
+0000042: 0d                                         ; OPCODE_F32_CONST
+0000043: 0000 0000                                  ; f32 literal
+0000047: 0f                                         ; OPCODE_SET_LOCAL
+0000048: 07                                         ; remapped local index
+0000049: 0c                                         ; OPCODE_F64_CONST
+000004a: 0000 0000 0000 0000                        ; f64 literal
+0000052: 0f                                         ; OPCODE_SET_LOCAL
+0000053: 03                                         ; remapped local index
+0000054: 0b                                         ; OPCODE_I64_CONST
+0000055: 0000 0000 0000 0000                        ; u64 literal
+0000019: 4200                                       ; FIXUP func body size
+000005d: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0400 0002 0002 0002 0002  
-0000010: 0042 000f 060c 0000 0000 0000 0000 0f04  
-0000020: 0d00 0000 000f 020b 0000 0000 0000 0000  
-0000030: 0f00 0900 0f01 0900 0f05 0d00 0000 000f  
-0000040: 070c 0000 0000 0000 0000 0f03 0b00 0000  
-0000050: 0000 0000 0006                           
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0400  
+0000010: 0002 0002 0002 0002 0042 000f 060c 0000  
+0000020: 0000 0000 0000 0f04 0d00 0000 000f 020b  
+0000030: 0000 0000 0000 0000 0f00 0900 0f01 0900  
+0000040: 0f05 0d00 0000 000f 070c 0000 0000 0000  
+0000050: 0000 0f03 0b00 0000 0000 0000 0006       
 ;;; STDOUT ;;)

--- a/test/dump/signatures.txt
+++ b/test/dump/signatures.txt
@@ -12,42 +12,45 @@
 
   (type (func (param i32) (result f64))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 09                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 09                                         ; num signatures
 ; signature 0
-0000002: 01                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
+000000a: 01                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
 ; signature 1
-0000005: 01                                         ; num params
-0000006: 00                                         ; result_type
-0000007: 02                                         ; param type
+000000d: 01                                         ; num params
+000000e: 00                                         ; result_type
+000000f: 02                                         ; param type
 ; signature 2
-0000008: 01                                         ; num params
-0000009: 00                                         ; result_type
-000000a: 03                                         ; param type
+0000010: 01                                         ; num params
+0000011: 00                                         ; result_type
+0000012: 03                                         ; param type
 ; signature 3
-000000b: 01                                         ; num params
-000000c: 00                                         ; result_type
-000000d: 04                                         ; param type
+0000013: 01                                         ; num params
+0000014: 00                                         ; result_type
+0000015: 04                                         ; param type
 ; signature 4
-000000e: 00                                         ; num params
-000000f: 01                                         ; result_type
+0000016: 00                                         ; num params
+0000017: 01                                         ; result_type
 ; signature 5
-0000010: 00                                         ; num params
-0000011: 02                                         ; result_type
+0000018: 00                                         ; num params
+0000019: 02                                         ; result_type
 ; signature 6
-0000012: 00                                         ; num params
-0000013: 03                                         ; result_type
+000001a: 00                                         ; num params
+000001b: 03                                         ; result_type
 ; signature 7
-0000014: 00                                         ; num params
-0000015: 04                                         ; result_type
+000001c: 00                                         ; num params
+000001d: 04                                         ; result_type
 ; signature 8
-0000016: 01                                         ; num params
-0000017: 04                                         ; result_type
-0000018: 01                                         ; param type
-0000019: 06                                         ; WASM_BINARY_SECTION_END
+000001e: 01                                         ; num params
+000001f: 04                                         ; result_type
+0000020: 01                                         ; param type
+0000021: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0109 0100 0101 0002 0100 0301 0004 0001  
-0000010: 0002 0003 0004 0104 0106                 
+0000000: 0061 736d 0a00 0000 0109 0100 0101 0002  
+0000010: 0100 0301 0004 0001 0002 0003 0004 0104  
+0000020: 0106                                     
 ;;; STDOUT ;;)

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -36,205 +36,207 @@
     (i64.store align=4 (i32.const 0) (i64.const 0))
     (i64.store align=8 (i32.const 0) (i64.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 2e                                         ; OPCODE_I32_STORE_MEM8
-000000c: 00                                         ; store access byte
-000000d: 09                                         ; OPCODE_I8_CONST
-000000e: 00                                         ; u8 literal
-000000f: 09                                         ; OPCODE_I8_CONST
-0000010: 00                                         ; u8 literal
-0000011: 2e                                         ; OPCODE_I32_STORE_MEM8
-0000012: 00                                         ; store access byte
-0000013: 09                                         ; OPCODE_I8_CONST
-0000014: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000014: 00                                         ; store access byte
 0000015: 09                                         ; OPCODE_I8_CONST
 0000016: 00                                         ; u8 literal
-0000017: 2e                                         ; OPCODE_I32_STORE_MEM8
-0000018: 00                                         ; store access byte
-0000019: 09                                         ; OPCODE_I8_CONST
-000001a: 00                                         ; u8 literal
+0000017: 09                                         ; OPCODE_I8_CONST
+0000018: 00                                         ; u8 literal
+0000019: 2e                                         ; OPCODE_I32_STORE_MEM8
+000001a: 00                                         ; store access byte
 000001b: 09                                         ; OPCODE_I8_CONST
 000001c: 00                                         ; u8 literal
-000001d: 2e                                         ; OPCODE_I32_STORE_MEM8
-000001e: 00                                         ; store access byte
-000001f: 09                                         ; OPCODE_I8_CONST
-0000020: 00                                         ; u8 literal
+000001d: 09                                         ; OPCODE_I8_CONST
+000001e: 00                                         ; u8 literal
+000001f: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000020: 00                                         ; store access byte
 0000021: 09                                         ; OPCODE_I8_CONST
 0000022: 00                                         ; u8 literal
-0000023: 2f                                         ; OPCODE_I32_STORE_MEM16
-0000024: 80                                         ; store access byte
-0000025: 09                                         ; OPCODE_I8_CONST
-0000026: 00                                         ; u8 literal
+0000023: 09                                         ; OPCODE_I8_CONST
+0000024: 00                                         ; u8 literal
+0000025: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000026: 00                                         ; store access byte
 0000027: 09                                         ; OPCODE_I8_CONST
 0000028: 00                                         ; u8 literal
-0000029: 2f                                         ; OPCODE_I32_STORE_MEM16
-000002a: 00                                         ; store access byte
-000002b: 09                                         ; OPCODE_I8_CONST
-000002c: 00                                         ; u8 literal
+0000029: 09                                         ; OPCODE_I8_CONST
+000002a: 00                                         ; u8 literal
+000002b: 2f                                         ; OPCODE_I32_STORE_MEM16
+000002c: 80                                         ; store access byte
 000002d: 09                                         ; OPCODE_I8_CONST
 000002e: 00                                         ; u8 literal
-000002f: 2f                                         ; OPCODE_I32_STORE_MEM16
-0000030: 00                                         ; store access byte
-0000031: 09                                         ; OPCODE_I8_CONST
-0000032: 00                                         ; u8 literal
+000002f: 09                                         ; OPCODE_I8_CONST
+0000030: 00                                         ; u8 literal
+0000031: 2f                                         ; OPCODE_I32_STORE_MEM16
+0000032: 00                                         ; store access byte
 0000033: 09                                         ; OPCODE_I8_CONST
 0000034: 00                                         ; u8 literal
-0000035: 2f                                         ; OPCODE_I32_STORE_MEM16
-0000036: 00                                         ; store access byte
-0000037: 09                                         ; OPCODE_I8_CONST
-0000038: 00                                         ; u8 literal
+0000035: 09                                         ; OPCODE_I8_CONST
+0000036: 00                                         ; u8 literal
+0000037: 2f                                         ; OPCODE_I32_STORE_MEM16
+0000038: 00                                         ; store access byte
 0000039: 09                                         ; OPCODE_I8_CONST
 000003a: 00                                         ; u8 literal
-000003b: 33                                         ; OPCODE_I32_STORE_MEM
-000003c: 80                                         ; store access byte
-000003d: 09                                         ; OPCODE_I8_CONST
-000003e: 00                                         ; u8 literal
+000003b: 09                                         ; OPCODE_I8_CONST
+000003c: 00                                         ; u8 literal
+000003d: 2f                                         ; OPCODE_I32_STORE_MEM16
+000003e: 00                                         ; store access byte
 000003f: 09                                         ; OPCODE_I8_CONST
 0000040: 00                                         ; u8 literal
-0000041: 33                                         ; OPCODE_I32_STORE_MEM
-0000042: 80                                         ; store access byte
-0000043: 09                                         ; OPCODE_I8_CONST
-0000044: 00                                         ; u8 literal
+0000041: 09                                         ; OPCODE_I8_CONST
+0000042: 00                                         ; u8 literal
+0000043: 33                                         ; OPCODE_I32_STORE_MEM
+0000044: 80                                         ; store access byte
 0000045: 09                                         ; OPCODE_I8_CONST
 0000046: 00                                         ; u8 literal
-0000047: 33                                         ; OPCODE_I32_STORE_MEM
-0000048: 00                                         ; store access byte
-0000049: 09                                         ; OPCODE_I8_CONST
-000004a: 00                                         ; u8 literal
+0000047: 09                                         ; OPCODE_I8_CONST
+0000048: 00                                         ; u8 literal
+0000049: 33                                         ; OPCODE_I32_STORE_MEM
+000004a: 80                                         ; store access byte
 000004b: 09                                         ; OPCODE_I8_CONST
 000004c: 00                                         ; u8 literal
-000004d: 33                                         ; OPCODE_I32_STORE_MEM
-000004e: 00                                         ; store access byte
-000004f: 09                                         ; OPCODE_I8_CONST
-0000050: 00                                         ; u8 literal
+000004d: 09                                         ; OPCODE_I8_CONST
+000004e: 00                                         ; u8 literal
+000004f: 33                                         ; OPCODE_I32_STORE_MEM
+0000050: 00                                         ; store access byte
 0000051: 09                                         ; OPCODE_I8_CONST
 0000052: 00                                         ; u8 literal
-0000053: 34                                         ; OPCODE_I64_STORE_MEM
-0000054: 80                                         ; store access byte
-0000055: 09                                         ; OPCODE_I8_CONST
-0000056: 00                                         ; u8 literal
-0000057: 0b                                         ; OPCODE_I64_CONST
-0000058: 0000 0000 0000 0000                        ; u64 literal
-0000060: 34                                         ; OPCODE_I64_STORE_MEM
-0000061: 80                                         ; store access byte
-0000062: 09                                         ; OPCODE_I8_CONST
-0000063: 00                                         ; u8 literal
-0000064: 0b                                         ; OPCODE_I64_CONST
-0000065: 0000 0000 0000 0000                        ; u64 literal
-000006d: 34                                         ; OPCODE_I64_STORE_MEM
-000006e: 80                                         ; store access byte
-000006f: 09                                         ; OPCODE_I8_CONST
-0000070: 00                                         ; u8 literal
-0000071: 0b                                         ; OPCODE_I64_CONST
-0000072: 0000 0000 0000 0000                        ; u64 literal
-000007a: 34                                         ; OPCODE_I64_STORE_MEM
-000007b: 00                                         ; store access byte
-000007c: 09                                         ; OPCODE_I8_CONST
-000007d: 00                                         ; u8 literal
-000007e: 0b                                         ; OPCODE_I64_CONST
-000007f: 0000 0000 0000 0000                        ; u64 literal
-0000087: 30                                         ; OPCODE_I64_STORE_MEM8
-0000088: 00                                         ; store access byte
-0000089: 09                                         ; OPCODE_I8_CONST
-000008a: 00                                         ; u8 literal
-000008b: 0b                                         ; OPCODE_I64_CONST
-000008c: 0000 0000 0000 0000                        ; u64 literal
-0000094: 30                                         ; OPCODE_I64_STORE_MEM8
-0000095: 00                                         ; store access byte
-0000096: 09                                         ; OPCODE_I8_CONST
-0000097: 00                                         ; u8 literal
-0000098: 0b                                         ; OPCODE_I64_CONST
-0000099: 0000 0000 0000 0000                        ; u64 literal
-00000a1: 30                                         ; OPCODE_I64_STORE_MEM8
-00000a2: 00                                         ; store access byte
-00000a3: 09                                         ; OPCODE_I8_CONST
-00000a4: 00                                         ; u8 literal
-00000a5: 0b                                         ; OPCODE_I64_CONST
-00000a6: 0000 0000 0000 0000                        ; u64 literal
-00000ae: 30                                         ; OPCODE_I64_STORE_MEM8
-00000af: 00                                         ; store access byte
-00000b0: 09                                         ; OPCODE_I8_CONST
-00000b1: 00                                         ; u8 literal
-00000b2: 0b                                         ; OPCODE_I64_CONST
-00000b3: 0000 0000 0000 0000                        ; u64 literal
-00000bb: 31                                         ; OPCODE_I64_STORE_MEM16
-00000bc: 80                                         ; store access byte
-00000bd: 09                                         ; OPCODE_I8_CONST
-00000be: 00                                         ; u8 literal
-00000bf: 0b                                         ; OPCODE_I64_CONST
-00000c0: 0000 0000 0000 0000                        ; u64 literal
-00000c8: 31                                         ; OPCODE_I64_STORE_MEM16
-00000c9: 00                                         ; store access byte
-00000ca: 09                                         ; OPCODE_I8_CONST
-00000cb: 00                                         ; u8 literal
-00000cc: 0b                                         ; OPCODE_I64_CONST
-00000cd: 0000 0000 0000 0000                        ; u64 literal
-00000d5: 31                                         ; OPCODE_I64_STORE_MEM16
-00000d6: 00                                         ; store access byte
-00000d7: 09                                         ; OPCODE_I8_CONST
-00000d8: 00                                         ; u8 literal
-00000d9: 0b                                         ; OPCODE_I64_CONST
-00000da: 0000 0000 0000 0000                        ; u64 literal
-00000e2: 31                                         ; OPCODE_I64_STORE_MEM16
-00000e3: 00                                         ; store access byte
-00000e4: 09                                         ; OPCODE_I8_CONST
-00000e5: 00                                         ; u8 literal
-00000e6: 0b                                         ; OPCODE_I64_CONST
-00000e7: 0000 0000 0000 0000                        ; u64 literal
-00000ef: 34                                         ; OPCODE_I64_STORE_MEM
-00000f0: 80                                         ; store access byte
-00000f1: 09                                         ; OPCODE_I8_CONST
-00000f2: 00                                         ; u8 literal
-00000f3: 0b                                         ; OPCODE_I64_CONST
-00000f4: 0000 0000 0000 0000                        ; u64 literal
-00000fc: 34                                         ; OPCODE_I64_STORE_MEM
-00000fd: 80                                         ; store access byte
-00000fe: 09                                         ; OPCODE_I8_CONST
-00000ff: 00                                         ; u8 literal
-0000100: 0b                                         ; OPCODE_I64_CONST
-0000101: 0000 0000 0000 0000                        ; u64 literal
-0000109: 34                                         ; OPCODE_I64_STORE_MEM
-000010a: 80                                         ; store access byte
-000010b: 09                                         ; OPCODE_I8_CONST
-000010c: 00                                         ; u8 literal
-000010d: 0b                                         ; OPCODE_I64_CONST
-000010e: 0000 0000 0000 0000                        ; u64 literal
-0000116: 34                                         ; OPCODE_I64_STORE_MEM
-0000117: 00                                         ; store access byte
-0000118: 09                                         ; OPCODE_I8_CONST
-0000119: 00                                         ; u8 literal
-000011a: 0b                                         ; OPCODE_I64_CONST
-000011b: 0000 0000 0000 0000                        ; u64 literal
-0000009: 1801                                       ; FIXUP func body size
-0000123: 06                                         ; WASM_BINARY_SECTION_END
+0000053: 09                                         ; OPCODE_I8_CONST
+0000054: 00                                         ; u8 literal
+0000055: 33                                         ; OPCODE_I32_STORE_MEM
+0000056: 00                                         ; store access byte
+0000057: 09                                         ; OPCODE_I8_CONST
+0000058: 00                                         ; u8 literal
+0000059: 09                                         ; OPCODE_I8_CONST
+000005a: 00                                         ; u8 literal
+000005b: 34                                         ; OPCODE_I64_STORE_MEM
+000005c: 80                                         ; store access byte
+000005d: 09                                         ; OPCODE_I8_CONST
+000005e: 00                                         ; u8 literal
+000005f: 0b                                         ; OPCODE_I64_CONST
+0000060: 0000 0000 0000 0000                        ; u64 literal
+0000068: 34                                         ; OPCODE_I64_STORE_MEM
+0000069: 80                                         ; store access byte
+000006a: 09                                         ; OPCODE_I8_CONST
+000006b: 00                                         ; u8 literal
+000006c: 0b                                         ; OPCODE_I64_CONST
+000006d: 0000 0000 0000 0000                        ; u64 literal
+0000075: 34                                         ; OPCODE_I64_STORE_MEM
+0000076: 80                                         ; store access byte
+0000077: 09                                         ; OPCODE_I8_CONST
+0000078: 00                                         ; u8 literal
+0000079: 0b                                         ; OPCODE_I64_CONST
+000007a: 0000 0000 0000 0000                        ; u64 literal
+0000082: 34                                         ; OPCODE_I64_STORE_MEM
+0000083: 00                                         ; store access byte
+0000084: 09                                         ; OPCODE_I8_CONST
+0000085: 00                                         ; u8 literal
+0000086: 0b                                         ; OPCODE_I64_CONST
+0000087: 0000 0000 0000 0000                        ; u64 literal
+000008f: 30                                         ; OPCODE_I64_STORE_MEM8
+0000090: 00                                         ; store access byte
+0000091: 09                                         ; OPCODE_I8_CONST
+0000092: 00                                         ; u8 literal
+0000093: 0b                                         ; OPCODE_I64_CONST
+0000094: 0000 0000 0000 0000                        ; u64 literal
+000009c: 30                                         ; OPCODE_I64_STORE_MEM8
+000009d: 00                                         ; store access byte
+000009e: 09                                         ; OPCODE_I8_CONST
+000009f: 00                                         ; u8 literal
+00000a0: 0b                                         ; OPCODE_I64_CONST
+00000a1: 0000 0000 0000 0000                        ; u64 literal
+00000a9: 30                                         ; OPCODE_I64_STORE_MEM8
+00000aa: 00                                         ; store access byte
+00000ab: 09                                         ; OPCODE_I8_CONST
+00000ac: 00                                         ; u8 literal
+00000ad: 0b                                         ; OPCODE_I64_CONST
+00000ae: 0000 0000 0000 0000                        ; u64 literal
+00000b6: 30                                         ; OPCODE_I64_STORE_MEM8
+00000b7: 00                                         ; store access byte
+00000b8: 09                                         ; OPCODE_I8_CONST
+00000b9: 00                                         ; u8 literal
+00000ba: 0b                                         ; OPCODE_I64_CONST
+00000bb: 0000 0000 0000 0000                        ; u64 literal
+00000c3: 31                                         ; OPCODE_I64_STORE_MEM16
+00000c4: 80                                         ; store access byte
+00000c5: 09                                         ; OPCODE_I8_CONST
+00000c6: 00                                         ; u8 literal
+00000c7: 0b                                         ; OPCODE_I64_CONST
+00000c8: 0000 0000 0000 0000                        ; u64 literal
+00000d0: 31                                         ; OPCODE_I64_STORE_MEM16
+00000d1: 00                                         ; store access byte
+00000d2: 09                                         ; OPCODE_I8_CONST
+00000d3: 00                                         ; u8 literal
+00000d4: 0b                                         ; OPCODE_I64_CONST
+00000d5: 0000 0000 0000 0000                        ; u64 literal
+00000dd: 31                                         ; OPCODE_I64_STORE_MEM16
+00000de: 00                                         ; store access byte
+00000df: 09                                         ; OPCODE_I8_CONST
+00000e0: 00                                         ; u8 literal
+00000e1: 0b                                         ; OPCODE_I64_CONST
+00000e2: 0000 0000 0000 0000                        ; u64 literal
+00000ea: 31                                         ; OPCODE_I64_STORE_MEM16
+00000eb: 00                                         ; store access byte
+00000ec: 09                                         ; OPCODE_I8_CONST
+00000ed: 00                                         ; u8 literal
+00000ee: 0b                                         ; OPCODE_I64_CONST
+00000ef: 0000 0000 0000 0000                        ; u64 literal
+00000f7: 34                                         ; OPCODE_I64_STORE_MEM
+00000f8: 80                                         ; store access byte
+00000f9: 09                                         ; OPCODE_I8_CONST
+00000fa: 00                                         ; u8 literal
+00000fb: 0b                                         ; OPCODE_I64_CONST
+00000fc: 0000 0000 0000 0000                        ; u64 literal
+0000104: 34                                         ; OPCODE_I64_STORE_MEM
+0000105: 80                                         ; store access byte
+0000106: 09                                         ; OPCODE_I8_CONST
+0000107: 00                                         ; u8 literal
+0000108: 0b                                         ; OPCODE_I64_CONST
+0000109: 0000 0000 0000 0000                        ; u64 literal
+0000111: 34                                         ; OPCODE_I64_STORE_MEM
+0000112: 80                                         ; store access byte
+0000113: 09                                         ; OPCODE_I8_CONST
+0000114: 00                                         ; u8 literal
+0000115: 0b                                         ; OPCODE_I64_CONST
+0000116: 0000 0000 0000 0000                        ; u64 literal
+000011e: 34                                         ; OPCODE_I64_STORE_MEM
+000011f: 00                                         ; store access byte
+0000120: 09                                         ; OPCODE_I8_CONST
+0000121: 00                                         ; u8 literal
+0000122: 0b                                         ; OPCODE_I64_CONST
+0000123: 0000 0000 0000 0000                        ; u64 literal
+0000011: 1801                                       ; FIXUP func body size
+000012b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0018 012e 0009 0009  
-0000010: 002e 0009 0009 002e 0009 0009 002e 0009  
-0000020: 0009 002f 8009 0009 002f 0009 0009 002f  
-0000030: 0009 0009 002f 0009 0009 0033 8009 0009  
-0000040: 0033 8009 0009 0033 0009 0009 0033 0009  
-0000050: 0009 0034 8009 000b 0000 0000 0000 0000  
-0000060: 3480 0900 0b00 0000 0000 0000 0034 8009  
-0000070: 000b 0000 0000 0000 0000 3400 0900 0b00  
-0000080: 0000 0000 0000 0030 0009 000b 0000 0000  
-0000090: 0000 0000 3000 0900 0b00 0000 0000 0000  
-00000a0: 0030 0009 000b 0000 0000 0000 0000 3000  
-00000b0: 0900 0b00 0000 0000 0000 0031 8009 000b  
-00000c0: 0000 0000 0000 0000 3100 0900 0b00 0000  
-00000d0: 0000 0000 0031 0009 000b 0000 0000 0000  
-00000e0: 0000 3100 0900 0b00 0000 0000 0000 0034  
-00000f0: 8009 000b 0000 0000 0000 0000 3480 0900  
-0000100: 0b00 0000 0000 0000 0034 8009 000b 0000  
-0000110: 0000 0000 0000 3400 0900 0b00 0000 0000  
-0000120: 0000 0006                                
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0018 012e 0009 0009 002e 0009 0009 002e  
+0000020: 0009 0009 002e 0009 0009 002f 8009 0009  
+0000030: 002f 0009 0009 002f 0009 0009 002f 0009  
+0000040: 0009 0033 8009 0009 0033 8009 0009 0033  
+0000050: 0009 0009 0033 0009 0009 0034 8009 000b  
+0000060: 0000 0000 0000 0000 3480 0900 0b00 0000  
+0000070: 0000 0000 0034 8009 000b 0000 0000 0000  
+0000080: 0000 3400 0900 0b00 0000 0000 0000 0030  
+0000090: 0009 000b 0000 0000 0000 0000 3000 0900  
+00000a0: 0b00 0000 0000 0000 0030 0009 000b 0000  
+00000b0: 0000 0000 0000 3000 0900 0b00 0000 0000  
+00000c0: 0000 0031 8009 000b 0000 0000 0000 0000  
+00000d0: 3100 0900 0b00 0000 0000 0000 0031 0009  
+00000e0: 000b 0000 0000 0000 0000 3100 0900 0b00  
+00000f0: 0000 0000 0000 0034 8009 000b 0000 0000  
+0000100: 0000 0000 3480 0900 0b00 0000 0000 0000  
+0000110: 0034 8009 000b 0000 0000 0000 0000 3400  
+0000120: 0900 0b00 0000 0000 0000 0006            
 ;;; STDOUT ;;)

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -11,79 +11,81 @@
     (f32.store (i32.const 0) (f32.const 0))
     (f64.store (i32.const 0) (f64.const 0))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 2e                                         ; OPCODE_I32_STORE_MEM8
-000000c: 00                                         ; store access byte
-000000d: 09                                         ; OPCODE_I8_CONST
-000000e: 00                                         ; u8 literal
-000000f: 09                                         ; OPCODE_I8_CONST
-0000010: 00                                         ; u8 literal
-0000011: 2f                                         ; OPCODE_I32_STORE_MEM16
-0000012: 00                                         ; store access byte
-0000013: 09                                         ; OPCODE_I8_CONST
-0000014: 00                                         ; u8 literal
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000014: 00                                         ; store access byte
 0000015: 09                                         ; OPCODE_I8_CONST
 0000016: 00                                         ; u8 literal
-0000017: 33                                         ; OPCODE_I32_STORE_MEM
-0000018: 00                                         ; store access byte
-0000019: 09                                         ; OPCODE_I8_CONST
-000001a: 00                                         ; u8 literal
+0000017: 09                                         ; OPCODE_I8_CONST
+0000018: 00                                         ; u8 literal
+0000019: 2f                                         ; OPCODE_I32_STORE_MEM16
+000001a: 00                                         ; store access byte
 000001b: 09                                         ; OPCODE_I8_CONST
 000001c: 00                                         ; u8 literal
-000001d: 34                                         ; OPCODE_I64_STORE_MEM
-000001e: 00                                         ; store access byte
-000001f: 09                                         ; OPCODE_I8_CONST
-0000020: 00                                         ; u8 literal
-0000021: 0b                                         ; OPCODE_I64_CONST
-0000022: 0000 0000 0000 0000                        ; u64 literal
-000002a: 30                                         ; OPCODE_I64_STORE_MEM8
-000002b: 00                                         ; store access byte
-000002c: 09                                         ; OPCODE_I8_CONST
-000002d: 00                                         ; u8 literal
-000002e: 0b                                         ; OPCODE_I64_CONST
-000002f: 0000 0000 0000 0000                        ; u64 literal
-0000037: 31                                         ; OPCODE_I64_STORE_MEM16
-0000038: 00                                         ; store access byte
-0000039: 09                                         ; OPCODE_I8_CONST
-000003a: 00                                         ; u8 literal
-000003b: 0b                                         ; OPCODE_I64_CONST
-000003c: 0000 0000 0000 0000                        ; u64 literal
-0000044: 32                                         ; OPCODE_I64_STORE_MEM32
-0000045: 00                                         ; store access byte
-0000046: 09                                         ; OPCODE_I8_CONST
-0000047: 00                                         ; u8 literal
-0000048: 0b                                         ; OPCODE_I64_CONST
-0000049: 0000 0000 0000 0000                        ; u64 literal
-0000051: 35                                         ; OPCODE_F32_STORE_MEM
-0000052: 00                                         ; store access byte
-0000053: 09                                         ; OPCODE_I8_CONST
-0000054: 00                                         ; u8 literal
-0000055: 0d                                         ; OPCODE_F32_CONST
-0000056: 0000 0000                                  ; f32 literal
-000005a: 36                                         ; OPCODE_F64_STORE_MEM
-000005b: 00                                         ; store access byte
-000005c: 09                                         ; OPCODE_I8_CONST
-000005d: 00                                         ; u8 literal
-000005e: 0c                                         ; OPCODE_F64_CONST
-000005f: 0000 0000 0000 0000                        ; f64 literal
-0000009: 5c00                                       ; FIXUP func body size
-0000067: 06                                         ; WASM_BINARY_SECTION_END
+000001d: 09                                         ; OPCODE_I8_CONST
+000001e: 00                                         ; u8 literal
+000001f: 33                                         ; OPCODE_I32_STORE_MEM
+0000020: 00                                         ; store access byte
+0000021: 09                                         ; OPCODE_I8_CONST
+0000022: 00                                         ; u8 literal
+0000023: 09                                         ; OPCODE_I8_CONST
+0000024: 00                                         ; u8 literal
+0000025: 34                                         ; OPCODE_I64_STORE_MEM
+0000026: 00                                         ; store access byte
+0000027: 09                                         ; OPCODE_I8_CONST
+0000028: 00                                         ; u8 literal
+0000029: 0b                                         ; OPCODE_I64_CONST
+000002a: 0000 0000 0000 0000                        ; u64 literal
+0000032: 30                                         ; OPCODE_I64_STORE_MEM8
+0000033: 00                                         ; store access byte
+0000034: 09                                         ; OPCODE_I8_CONST
+0000035: 00                                         ; u8 literal
+0000036: 0b                                         ; OPCODE_I64_CONST
+0000037: 0000 0000 0000 0000                        ; u64 literal
+000003f: 31                                         ; OPCODE_I64_STORE_MEM16
+0000040: 00                                         ; store access byte
+0000041: 09                                         ; OPCODE_I8_CONST
+0000042: 00                                         ; u8 literal
+0000043: 0b                                         ; OPCODE_I64_CONST
+0000044: 0000 0000 0000 0000                        ; u64 literal
+000004c: 32                                         ; OPCODE_I64_STORE_MEM32
+000004d: 00                                         ; store access byte
+000004e: 09                                         ; OPCODE_I8_CONST
+000004f: 00                                         ; u8 literal
+0000050: 0b                                         ; OPCODE_I64_CONST
+0000051: 0000 0000 0000 0000                        ; u64 literal
+0000059: 35                                         ; OPCODE_F32_STORE_MEM
+000005a: 00                                         ; store access byte
+000005b: 09                                         ; OPCODE_I8_CONST
+000005c: 00                                         ; u8 literal
+000005d: 0d                                         ; OPCODE_F32_CONST
+000005e: 0000 0000                                  ; f32 literal
+0000062: 36                                         ; OPCODE_F64_STORE_MEM
+0000063: 00                                         ; store access byte
+0000064: 09                                         ; OPCODE_I8_CONST
+0000065: 00                                         ; u8 literal
+0000066: 0c                                         ; OPCODE_F64_CONST
+0000067: 0000 0000 0000 0000                        ; f64 literal
+0000011: 5c00                                       ; FIXUP func body size
+000006f: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 005c 002e 0009 0009  
-0000010: 002f 0009 0009 0033 0009 0009 0034 0009  
-0000020: 000b 0000 0000 0000 0000 3000 0900 0b00  
-0000030: 0000 0000 0000 0031 0009 000b 0000 0000  
-0000040: 0000 0000 3200 0900 0b00 0000 0000 0000  
-0000050: 0035 0009 000d 0000 0000 3600 0900 0c00  
-0000060: 0000 0000 0000 0006                      
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 005c 002e 0009 0009 002f 0009 0009 0033  
+0000020: 0009 0009 0034 0009 000b 0000 0000 0000  
+0000030: 0000 3000 0900 0b00 0000 0000 0000 0031  
+0000040: 0009 000b 0000 0000 0000 0000 3200 0900  
+0000050: 0b00 0000 0000 0000 0035 0009 000d 0000  
+0000060: 0000 3600 0900 0c00 0000 0000 0000 0006  
 ;;; STDOUT ;;)

--- a/test/dump/storeglobal.txt
+++ b/test/dump/storeglobal.txt
@@ -7,57 +7,59 @@
     (store_global 2 (f32.const 2))
     (store_global 3 (f64.const 3))))
 (;; STDOUT ;;;
-0000000: 03                                         ; WASM_BINARY_SECTION_GLOBALS
-0000001: 04                                         ; num globals
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 03                                         ; WASM_BINARY_SECTION_GLOBALS
+0000009: 04                                         ; num globals
 ; global header 0
-0000002: 0000 0000                                  ; global name offset
-0000006: 04                                         ; global mem type
-0000007: 00                                         ; export global
+000000a: 0000 0000                                  ; global name offset
+000000e: 04                                         ; global mem type
+000000f: 00                                         ; export global
 ; global header 1
-0000008: 0000 0000                                  ; global name offset
-000000c: 06                                         ; global mem type
-000000d: 00                                         ; export global
+0000010: 0000 0000                                  ; global name offset
+0000014: 06                                         ; global mem type
+0000015: 00                                         ; export global
 ; global header 2
-000000e: 0000 0000                                  ; global name offset
-0000012: 08                                         ; global mem type
-0000013: 00                                         ; export global
+0000016: 0000 0000                                  ; global name offset
+000001a: 08                                         ; global mem type
+000001b: 00                                         ; export global
 ; global header 3
-0000014: 0000 0000                                  ; global name offset
-0000018: 09                                         ; global mem type
-0000019: 00                                         ; export global
-000001a: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-000001b: 01                                         ; num signatures
+000001c: 0000 0000                                  ; global name offset
+0000020: 09                                         ; global mem type
+0000021: 00                                         ; export global
+0000022: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000023: 01                                         ; num signatures
 ; signature 0
-000001c: 00                                         ; num params
-000001d: 00                                         ; result_type
-000001e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-000001f: 01                                         ; num functions
+0000024: 00                                         ; num params
+0000025: 00                                         ; result_type
+0000026: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000027: 01                                         ; num functions
 ; function 0
-0000020: 00                                         ; func flags
-0000021: 0000                                       ; func signature index
-0000023: 0000                                       ; func body size
-0000025: 11                                         ; OPCODE_STORE_GLOBAL
-0000026: 00                                         ; global index
-0000027: 09                                         ; OPCODE_I8_CONST
-0000028: 00                                         ; u8 literal
-0000029: 11                                         ; OPCODE_STORE_GLOBAL
-000002a: 01                                         ; global index
-000002b: 0b                                         ; OPCODE_I64_CONST
-000002c: 0100 0000 0000 0000                        ; u64 literal
-0000034: 11                                         ; OPCODE_STORE_GLOBAL
-0000035: 02                                         ; global index
-0000036: 0d                                         ; OPCODE_F32_CONST
-0000037: 0000 0040                                  ; f32 literal
-000003b: 11                                         ; OPCODE_STORE_GLOBAL
-000003c: 03                                         ; global index
-000003d: 0c                                         ; OPCODE_F64_CONST
-000003e: 0000 0000 0000 0840                        ; f64 literal
-0000023: 2100                                       ; FIXUP func body size
-0000046: 06                                         ; WASM_BINARY_SECTION_END
+0000028: 00                                         ; func flags
+0000029: 0000                                       ; func signature index
+000002b: 0000                                       ; func body size
+000002d: 11                                         ; OPCODE_STORE_GLOBAL
+000002e: 00                                         ; global index
+000002f: 09                                         ; OPCODE_I8_CONST
+0000030: 00                                         ; u8 literal
+0000031: 11                                         ; OPCODE_STORE_GLOBAL
+0000032: 01                                         ; global index
+0000033: 0b                                         ; OPCODE_I64_CONST
+0000034: 0100 0000 0000 0000                        ; u64 literal
+000003c: 11                                         ; OPCODE_STORE_GLOBAL
+000003d: 02                                         ; global index
+000003e: 0d                                         ; OPCODE_F32_CONST
+000003f: 0000 0040                                  ; f32 literal
+0000043: 11                                         ; OPCODE_STORE_GLOBAL
+0000044: 03                                         ; global index
+0000045: 0c                                         ; OPCODE_F64_CONST
+0000046: 0000 0000 0000 0840                        ; f64 literal
+000002b: 2100                                       ; FIXUP func body size
+000004e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0304 0000 0000 0400 0000 0000 0600 0000  
-0000010: 0000 0800 0000 0000 0900 0101 0000 0201  
-0000020: 0000 0021 0011 0009 0011 010b 0100 0000  
-0000030: 0000 0000 1102 0d00 0000 4011 030c 0000  
-0000040: 0000 0000 0840 06                        
+0000000: 0061 736d 0a00 0000 0304 0000 0000 0400  
+0000010: 0000 0000 0600 0000 0000 0800 0000 0000  
+0000020: 0900 0101 0000 0201 0000 0021 0011 0009  
+0000030: 0011 010b 0100 0000 0000 0000 1102 0d00  
+0000040: 0000 4011 030c 0000 0000 0000 0840 06    
 ;;; STDOUT ;;)

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -6,48 +6,51 @@
   (func (result f64) (f64.const 0))
   (table 0 0 1 2))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 03                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 03                                         ; num signatures
 ; signature 0
-0000002: 01                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 01                                         ; param type
+000000a: 01                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 01                                         ; param type
 ; signature 1
-0000005: 02                                         ; num params
-0000006: 00                                         ; result_type
-0000007: 01                                         ; param type
-0000008: 02                                         ; param type
+000000d: 02                                         ; num params
+000000e: 00                                         ; result_type
+000000f: 01                                         ; param type
+0000010: 02                                         ; param type
 ; signature 2
-0000009: 00                                         ; num params
-000000a: 04                                         ; result_type
-000000b: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-000000c: 03                                         ; num functions
+0000011: 00                                         ; num params
+0000012: 04                                         ; result_type
+0000013: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+0000014: 03                                         ; num functions
 ; function 0
-000000d: 00                                         ; func flags
-000000e: 0000                                       ; func signature index
-0000010: 0000                                       ; func body size
-0000010: 0000                                       ; FIXUP func body size
+0000015: 00                                         ; func flags
+0000016: 0000                                       ; func signature index
+0000018: 0000                                       ; func body size
+0000018: 0000                                       ; FIXUP func body size
 ; function 1
-0000012: 00                                         ; func flags
-0000013: 0100                                       ; func signature index
-0000015: 0000                                       ; func body size
-0000015: 0000                                       ; FIXUP func body size
+000001a: 00                                         ; func flags
+000001b: 0100                                       ; func signature index
+000001d: 0000                                       ; func body size
+000001d: 0000                                       ; FIXUP func body size
 ; function 2
-0000017: 00                                         ; func flags
-0000018: 0200                                       ; func signature index
-000001a: 0000                                       ; func body size
-000001c: 0c                                         ; OPCODE_F64_CONST
-000001d: 0000 0000 0000 0000                        ; f64 literal
-000001a: 0900                                       ; FIXUP func body size
-0000025: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-0000026: 04                                         ; num function table entries
-0000027: 0000                                       ; function table entry
-0000029: 0000                                       ; function table entry
-000002b: 0100                                       ; function table entry
-000002d: 0200                                       ; function table entry
-000002f: 06                                         ; WASM_BINARY_SECTION_END
+000001f: 00                                         ; func flags
+0000020: 0200                                       ; func signature index
+0000022: 0000                                       ; func body size
+0000024: 0c                                         ; OPCODE_F64_CONST
+0000025: 0000 0000 0000 0000                        ; f64 literal
+0000022: 0900                                       ; FIXUP func body size
+000002d: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+000002e: 04                                         ; num function table entries
+000002f: 0000                                       ; function table entry
+0000031: 0000                                       ; function table entry
+0000033: 0100                                       ; function table entry
+0000035: 0200                                       ; function table entry
+0000037: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0103 0100 0102 0001 0200 0402 0300 0000  
-0000010: 0000 0001 0000 0000 0200 0900 0c00 0000  
-0000020: 0000 0000 0005 0400 0000 0001 0002 0006  
+0000000: 0061 736d 0a00 0000 0103 0100 0102 0001  
+0000010: 0200 0402 0300 0000 0000 0001 0000 0000  
+0000020: 0200 0900 0c00 0000 0000 0000 0005 0400  
+0000030: 0000 0001 0002 0006                      
 ;;; STDOUT ;;)

--- a/test/dump/tableswitch-implicit-block.txt
+++ b/test/dump/tableswitch-implicit-block.txt
@@ -7,40 +7,42 @@
       (case $default (nop) (br 0)))  ;; depth 1 (due to implicit block)
 ))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 08                                         ; OPCODE_TABLESWITCH
-000000c: 0200                                       ; num cases
-000000e: 0200                                       ; num targets
-0000010: 0000                                       ; case index
-0000012: 0100                                       ; case index
-0000014: 09                                         ; OPCODE_I8_CONST
-0000015: 00                                         ; u8 literal
-0000016: 01                                         ; OPCODE_BLOCK
-0000017: 02                                         ; num expressions
-0000018: 00                                         ; OPCODE_NOP
-0000019: 06                                         ; OPCODE_BR
-000001a: 01                                         ; break depth
-000001b: 00                                         ; OPCODE_NOP
-000001c: 01                                         ; OPCODE_BLOCK
-000001d: 02                                         ; num expressions
-000001e: 00                                         ; OPCODE_NOP
-000001f: 06                                         ; OPCODE_BR
-0000020: 01                                         ; break depth
-0000021: 00                                         ; OPCODE_NOP
-0000009: 1700                                       ; FIXUP func body size
-0000022: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 08                                         ; OPCODE_TABLESWITCH
+0000014: 0200                                       ; num cases
+0000016: 0200                                       ; num targets
+0000018: 0000                                       ; case index
+000001a: 0100                                       ; case index
+000001c: 09                                         ; OPCODE_I8_CONST
+000001d: 00                                         ; u8 literal
+000001e: 01                                         ; OPCODE_BLOCK
+000001f: 02                                         ; num expressions
+0000020: 00                                         ; OPCODE_NOP
+0000021: 06                                         ; OPCODE_BR
+0000022: 01                                         ; break depth
+0000023: 00                                         ; OPCODE_NOP
+0000024: 01                                         ; OPCODE_BLOCK
+0000025: 02                                         ; num expressions
+0000026: 00                                         ; OPCODE_NOP
+0000027: 06                                         ; OPCODE_BR
+0000028: 01                                         ; break depth
+0000029: 00                                         ; OPCODE_NOP
+0000011: 1700                                       ; FIXUP func body size
+000002a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0017 0008 0200 0200  
-0000010: 0000 0100 0900 0102 0006 0100 0102 0006  
-0000020: 0100 06                                  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0017 0008 0200 0200 0000 0100 0900 0102  
+0000020: 0006 0100 0102 0006 0100 06              
 ;;; STDOUT ;;)

--- a/test/dump/tableswitch.txt
+++ b/test/dump/tableswitch.txt
@@ -7,38 +7,40 @@
       (case)  ;; fallthrough
       (case (i32.const 3)))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 08                                         ; OPCODE_TABLESWITCH
-000000c: 0300                                       ; num cases
-000000e: 0300                                       ; num targets
-0000010: 0000                                       ; case index
-0000012: 0100                                       ; case index
-0000014: 0080                                       ; br depth
-0000016: 09                                         ; OPCODE_I8_CONST
-0000017: 00                                         ; u8 literal
-0000018: 01                                         ; OPCODE_BLOCK
-0000019: 02                                         ; num expressions
-000001a: 09                                         ; OPCODE_I8_CONST
-000001b: 01                                         ; u8 literal
-000001c: 09                                         ; OPCODE_I8_CONST
-000001d: 02                                         ; u8 literal
-000001e: 00                                         ; OPCODE_NOP for fallthrough
-000001f: 09                                         ; OPCODE_I8_CONST
-0000020: 03                                         ; u8 literal
-0000009: 1600                                       ; FIXUP func body size
-0000021: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 08                                         ; OPCODE_TABLESWITCH
+0000014: 0300                                       ; num cases
+0000016: 0300                                       ; num targets
+0000018: 0000                                       ; case index
+000001a: 0100                                       ; case index
+000001c: 0080                                       ; br depth
+000001e: 09                                         ; OPCODE_I8_CONST
+000001f: 00                                         ; u8 literal
+0000020: 01                                         ; OPCODE_BLOCK
+0000021: 02                                         ; num expressions
+0000022: 09                                         ; OPCODE_I8_CONST
+0000023: 01                                         ; u8 literal
+0000024: 09                                         ; OPCODE_I8_CONST
+0000025: 02                                         ; u8 literal
+0000026: 00                                         ; OPCODE_NOP for fallthrough
+0000027: 09                                         ; OPCODE_I8_CONST
+0000028: 03                                         ; u8 literal
+0000011: 1600                                       ; FIXUP func body size
+0000029: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0016 0008 0300 0300  
-0000010: 0000 0100 0080 0900 0102 0901 0902 0009  
-0000020: 0306                                     
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0016 0008 0300 0300 0000 0100 0080 0900  
+0000020: 0102 0901 0902 0009 0306                 
 ;;; STDOUT ;;)

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -26,51 +26,54 @@
               (f64.trunc
                 (f64.nearest (f64.const 0))))))))))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 5a                                         ; OPCODE_BOOL_NOT
-000000c: 57                                         ; OPCODE_I32_CLZ
-000000d: 58                                         ; OPCODE_I32_CTZ
-000000e: 59                                         ; OPCODE_I32_POPCNT
-000000f: 09                                         ; OPCODE_I8_CONST
-0000010: 00                                         ; u8 literal
-0000011: 72                                         ; OPCODE_I64_CLZ
-0000012: 73                                         ; OPCODE_I64_CTZ
-0000013: 74                                         ; OPCODE_I64_POPCNT
-0000014: 0b                                         ; OPCODE_I64_CONST
-0000015: 0000 0000 0000 0000                        ; u64 literal
-000001d: 7c                                         ; OPCODE_F32_NEG
-000001e: 7b                                         ; OPCODE_F32_ABS
-000001f: 82                                         ; OPCODE_F32_SQRT
-0000020: 7e                                         ; OPCODE_F32_CEIL
-0000021: 7f                                         ; OPCODE_F32_FLOOR
-0000022: 80                                         ; OPCODE_F32_TRUNC
-0000023: 81                                         ; OPCODE_F32_NEAREST_INT
-0000024: 0d                                         ; OPCODE_F32_CONST
-0000025: 0000 0000                                  ; f32 literal
-0000029: 90                                         ; OPCODE_F64_NEG
-000002a: 8f                                         ; OPCODE_F64_ABS
-000002b: 96                                         ; OPCODE_F64_SQRT
-000002c: 92                                         ; OPCODE_F64_CEIL
-000002d: 93                                         ; OPCODE_F64_FLOOR
-000002e: 94                                         ; OPCODE_F64_TRUNC
-000002f: 95                                         ; OPCODE_F64_NEAREST_INT
-0000030: 0c                                         ; OPCODE_F64_CONST
-0000031: 0000 0000 0000 0000                        ; f64 literal
-0000009: 2e00                                       ; FIXUP func body size
-0000039: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 5a                                         ; OPCODE_BOOL_NOT
+0000014: 57                                         ; OPCODE_I32_CLZ
+0000015: 58                                         ; OPCODE_I32_CTZ
+0000016: 59                                         ; OPCODE_I32_POPCNT
+0000017: 09                                         ; OPCODE_I8_CONST
+0000018: 00                                         ; u8 literal
+0000019: 72                                         ; OPCODE_I64_CLZ
+000001a: 73                                         ; OPCODE_I64_CTZ
+000001b: 74                                         ; OPCODE_I64_POPCNT
+000001c: 0b                                         ; OPCODE_I64_CONST
+000001d: 0000 0000 0000 0000                        ; u64 literal
+0000025: 7c                                         ; OPCODE_F32_NEG
+0000026: 7b                                         ; OPCODE_F32_ABS
+0000027: 82                                         ; OPCODE_F32_SQRT
+0000028: 7e                                         ; OPCODE_F32_CEIL
+0000029: 7f                                         ; OPCODE_F32_FLOOR
+000002a: 80                                         ; OPCODE_F32_TRUNC
+000002b: 81                                         ; OPCODE_F32_NEAREST_INT
+000002c: 0d                                         ; OPCODE_F32_CONST
+000002d: 0000 0000                                  ; f32 literal
+0000031: 90                                         ; OPCODE_F64_NEG
+0000032: 8f                                         ; OPCODE_F64_ABS
+0000033: 96                                         ; OPCODE_F64_SQRT
+0000034: 92                                         ; OPCODE_F64_CEIL
+0000035: 93                                         ; OPCODE_F64_FLOOR
+0000036: 94                                         ; OPCODE_F64_TRUNC
+0000037: 95                                         ; OPCODE_F64_NEAREST_INT
+0000038: 0c                                         ; OPCODE_F64_CONST
+0000039: 0000 0000 0000 0000                        ; f64 literal
+0000011: 2e00                                       ; FIXUP func body size
+0000041: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 002e 005a 5758 5909  
-0000010: 0072 7374 0b00 0000 0000 0000 007c 7b82  
-0000020: 7e7f 8081 0d00 0000 0090 8f96 9293 9495  
-0000030: 0c00 0000 0000 0000 0006                 
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 002e 005a 5758 5909 0072 7374 0b00 0000  
+0000020: 0000 0000 007c 7b82 7e7f 8081 0d00 0000  
+0000030: 0090 8f96 9293 9495 0c00 0000 0000 0000  
+0000040: 0006                                     
 ;;; STDOUT ;;)

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -3,20 +3,23 @@
   (func
     (unreachable)))
 (;; STDOUT ;;;
-0000000: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
-0000001: 01                                         ; num signatures
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0a00 0000                                  ; WASM_BINARY_VERSION
+0000008: 01                                         ; WASM_BINARY_SECTION_SIGNATURES
+0000009: 01                                         ; num signatures
 ; signature 0
-0000002: 00                                         ; num params
-0000003: 00                                         ; result_type
-0000004: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
-0000005: 01                                         ; num functions
+000000a: 00                                         ; num params
+000000b: 00                                         ; result_type
+000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
+000000d: 01                                         ; num functions
 ; function 0
-0000006: 00                                         ; func flags
-0000007: 0000                                       ; func signature index
-0000009: 0000                                       ; func body size
-000000b: 15                                         ; OPCODE_UNREACHABLE
-0000009: 0100                                       ; FIXUP func body size
-000000c: 06                                         ; WASM_BINARY_SECTION_END
+000000e: 00                                         ; func flags
+000000f: 0000                                       ; func signature index
+0000011: 0000                                       ; func body size
+0000013: 15                                         ; OPCODE_UNREACHABLE
+0000011: 0100                                       ; FIXUP func body size
+0000014: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0101 0000 0201 0000 0001 0015 06         
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0001 0015 06                             
 ;;; STDOUT ;;)


### PR DESCRIPTION
@titzer @jfbastien 
This will break sexpr-wasm, as the corresponding change isn't rolled
into v8 yet.