### PR TITLE
Fix a test expected output after the memory-in-pages change.

### DIFF
--- a/test/spec/address.txt
+++ b/test/spec/address.txt
@@ -4,7 +4,7 @@
 (;; STDOUT ;;;
 assert_invalid error:
   third_party/testsuite/address.wast:33:63: offset must be less than or equal to 0xffffffff
-...ory 1) (func $bad1 (param $i i32) (i32.load offset=4294967296 (get_loca...
+...memory 1) (func $bad1 (param $i i32) (i32.load offset=4294967296 (get_loca...
                                         ^
 97
 98


### PR DESCRIPTION
Thank you for merging the memory-in-pages change. Retesting shows one failure in the expected output when using the pending spec tests.