### PR TITLE
Local decls rewrite

### DIFF
--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -996,7 +996,8 @@ static void write_module(WasmWriteContext* ctx, WasmModule* module) {
       out_u16(ws, ctx->func_sig_indexes[i], "func signature index");
       int num_locals[WASM_NUM_TYPES];
       ZERO_MEMORY(num_locals);
-      for (int j = 0; j < func->locals.types.size; ++j) {
+      int j;
+      for (j = 0; j < func->locals.types.size; ++j) {
 	num_locals[func->locals.types.data[j]]++;
       }
 

--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -989,45 +989,44 @@ static void write_module(WasmWriteContext* ctx, WasmModule* module) {
     for (i = 0; i < module->funcs.size; ++i) {
       WasmFunc* func = module->funcs.data[i];
       print_header(ctx, "function", i);
+      /* TODO(binji): we're still remapping the locals here, but we may want to
+       have this be an option, now that it is not necessary. */
       remap_locals(ctx, func);
 
       uint8_t flags = 0;
       out_u8(ws, flags, "func flags");
       out_u16(ws, ctx->func_sig_indexes[i], "func signature index");
-      int num_locals[WASM_NUM_TYPES];
-      ZERO_MEMORY(num_locals);
-      int j;
-      for (j = 0; j < func->locals.types.size; ++j) {
-	num_locals[func->locals.types.data[j]]++;
-      }
-
       size_t func_body_offset = ctx->writer_state.offset;
       out_u16(ws, 0, "func body size");
 
-      int local_decl_count = 0;
-      size_t local_decl_count_offset = ctx->writer_state.offset;
-      out_u8(ws, 0, "local decl count");
-      if (num_locals[WASM_TYPE_I32] > 0) {
-	out_u32_leb128(ws, num_locals[WASM_TYPE_I32], "local i32 count");
-	out_u8(ws, WASM_TYPE_I32, "type i32");
-	local_decl_count++;
+      int num_locals[WASM_NUM_TYPES];
+      ZERO_MEMORY(num_locals);
+      int j;
+      for (j = 0; j < func->locals.types.size; ++j)
+        num_locals[func->locals.types.data[j]]++;
+
+      int num_local_types = 0;
+      for (j = 0; j < WASM_NUM_TYPES; ++j)
+        if (num_locals[j])
+          num_local_types++;
+
+      out_u32_leb128(ws, num_local_types, "local decl count");
+      if (num_locals[WASM_TYPE_I32]) {
+        out_u32_leb128(ws, num_locals[WASM_TYPE_I32], "local i32 count");
+        out_u8(ws, WASM_TYPE_I32, "WASM_TYPE_I32");
       }
-      if (num_locals[WASM_TYPE_I64] > 0) {
-	out_u32_leb128(ws, num_locals[WASM_TYPE_I64], "local i64 count");
-	out_u8(ws, WASM_TYPE_I64, "type i64");
-	local_decl_count++;
+      if (num_locals[WASM_TYPE_I64]) {
+        out_u32_leb128(ws, num_locals[WASM_TYPE_I64], "local i64 count");
+        out_u8(ws, WASM_TYPE_I64, "WASM_TYPE_I64");
       }
-      if (num_locals[WASM_TYPE_F32] > 0) {
-	out_u32_leb128(ws, num_locals[WASM_TYPE_F32], "local f32 count");
-	out_u8(ws, WASM_TYPE_F32, "type f32");
-	local_decl_count++;
+      if (num_locals[WASM_TYPE_F32]) {
+        out_u32_leb128(ws, num_locals[WASM_TYPE_F32], "local f32 count");
+        out_u8(ws, WASM_TYPE_F32, "WASM_TYPE_F32");
       }
-      if (num_locals[WASM_TYPE_F64] > 0) {
-	out_u32_leb128(ws, num_locals[WASM_TYPE_F64], "local f64 count");
-	out_u8(ws, WASM_TYPE_F64, "type f64");
-	local_decl_count++;
+      if (num_locals[WASM_TYPE_F64]) {
+        out_u32_leb128(ws, num_locals[WASM_TYPE_F64], "local f64 count");
+        out_u8(ws, WASM_TYPE_F64, "WASM_TYPE_F64");
       }
-      out_u8_at(ws, local_decl_count_offset, local_decl_count, "local decl count");
 
       write_func(ctx, module, func);
       int func_size =

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -26,7 +26,6 @@
 0000015: 0000                                       ; func signature index
 0000017: 0000                                       ; func body size
 0000019: 00                                         ; local decl count
-0000019: 00                                         ; local decl count
 000001a: 33                                         ; OPCODE_I32_STORE_MEM
 000001b: 00                                         ; store access byte
 000001c: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -25,35 +25,37 @@
 0000014: 00                                         ; func flags
 0000015: 0000                                       ; func signature index
 0000017: 0000                                       ; func body size
-0000019: 33                                         ; OPCODE_I32_STORE_MEM
-000001a: 00                                         ; store access byte
-000001b: 0a                                         ; OPCODE_I32_CONST
-000001c: 00                                         ; i32 literal
-000001d: 40                                         ; OPCODE_I32_ADD
-000001e: 2a                                         ; OPCODE_I32_LOAD_MEM
-000001f: 00                                         ; load access byte
-0000020: 0a                                         ; OPCODE_I32_CONST
-0000021: 00                                         ; i32 literal
-0000022: 0a                                         ; OPCODE_I32_CONST
-0000023: 01                                         ; i32 literal
-0000024: 40                                         ; OPCODE_I32_ADD
-0000025: 0e                                         ; OPCODE_GET_LOCAL
-0000026: 00                                         ; remapped local index
-0000027: 0e                                         ; OPCODE_GET_LOCAL
-0000028: 01                                         ; remapped local index
-0000017: 1000                                       ; FIXUP func body size
-0000029: 09                                         ; WASM_BINARY_SECTION_EXPORTS
-000002a: 01                                         ; num exports
-000002b: 0000                                       ; export func index
-000002d: 0000 0000                                  ; export name offset
-0000031: 06                                         ; WASM_BINARY_SECTION_END
+0000019: 00                                         ; local decl count
+0000019: 00                                         ; local decl count
+000001a: 33                                         ; OPCODE_I32_STORE_MEM
+000001b: 00                                         ; store access byte
+000001c: 0a                                         ; OPCODE_I32_CONST
+000001d: 00                                         ; i32 literal
+000001e: 40                                         ; OPCODE_I32_ADD
+000001f: 2a                                         ; OPCODE_I32_LOAD_MEM
+0000020: 00                                         ; load access byte
+0000021: 0a                                         ; OPCODE_I32_CONST
+0000022: 00                                         ; i32 literal
+0000023: 0a                                         ; OPCODE_I32_CONST
+0000024: 01                                         ; i32 literal
+0000025: 40                                         ; OPCODE_I32_ADD
+0000026: 0e                                         ; OPCODE_GET_LOCAL
+0000027: 00                                         ; remapped local index
+0000028: 0e                                         ; OPCODE_GET_LOCAL
+0000029: 01                                         ; remapped local index
+0000017: 1100                                       ; FIXUP func body size
+000002a: 09                                         ; WASM_BINARY_SECTION_EXPORTS
+000002b: 01                                         ; num exports
+000002c: 0000                                       ; export func index
+000002e: 0000 0000                                  ; export name offset
+0000032: 06                                         ; WASM_BINARY_SECTION_END
 ; export 0
-000002d: 3200 0000                                  ; FIXUP func name offset
-0000032: 66                                         ; export name
-0000033: 00                                         ; \0
+000002e: 3300 0000                                  ; FIXUP func name offset
+0000033: 66                                         ; export name
+0000034: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0001 0101 0101 0201  
-0000010: 0101 0201 0000 0010 0033 000a 0040 2a00  
-0000020: 0a00 0a01 400e 000e 0109 0100 0032 0000  
-0000030: 0006 6600                                
+0000010: 0101 0201 0000 0011 0000 3300 0a00 402a  
+0000020: 000a 000a 0140 0e00 0e01 0901 0000 3300  
+0000030: 0000 0666 00                             
 ;;; STDOUT ;;)

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -113,162 +113,165 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 40                                         ; OPCODE_I32_ADD
-0000014: 41                                         ; OPCODE_I32_SUB
-0000015: 42                                         ; OPCODE_I32_MUL
-0000016: 43                                         ; OPCODE_I32_DIV_S
-0000017: 44                                         ; OPCODE_I32_DIV_U
-0000018: 45                                         ; OPCODE_I32_REM_S
-0000019: 46                                         ; OPCODE_I32_REM_U
-000001a: 47                                         ; OPCODE_I32_AND
-000001b: 48                                         ; OPCODE_I32_OR
-000001c: 49                                         ; OPCODE_I32_XOR
-000001d: 4a                                         ; OPCODE_I32_SHL
-000001e: 4b                                         ; OPCODE_I32_SHR_U
-000001f: 4c                                         ; OPCODE_I32_SHR_S
-0000020: b7                                         ; OPCODE_I32_ROL
-0000021: b6                                         ; OPCODE_I32_ROR
-0000022: 0a                                         ; OPCODE_I32_CONST
-0000023: 00                                         ; i32 literal
-0000024: 0a                                         ; OPCODE_I32_CONST
-0000025: 00                                         ; i32 literal
-0000026: 0a                                         ; OPCODE_I32_CONST
-0000027: 00                                         ; i32 literal
-0000028: 0a                                         ; OPCODE_I32_CONST
-0000029: 00                                         ; i32 literal
-000002a: 0a                                         ; OPCODE_I32_CONST
-000002b: 00                                         ; i32 literal
-000002c: 0a                                         ; OPCODE_I32_CONST
-000002d: 00                                         ; i32 literal
-000002e: 0a                                         ; OPCODE_I32_CONST
-000002f: 00                                         ; i32 literal
-0000030: 0a                                         ; OPCODE_I32_CONST
-0000031: 00                                         ; i32 literal
-0000032: 0a                                         ; OPCODE_I32_CONST
-0000033: 00                                         ; i32 literal
-0000034: 0a                                         ; OPCODE_I32_CONST
-0000035: 00                                         ; i32 literal
-0000036: 0a                                         ; OPCODE_I32_CONST
-0000037: 00                                         ; i32 literal
-0000038: 0a                                         ; OPCODE_I32_CONST
-0000039: 00                                         ; i32 literal
-000003a: 0a                                         ; OPCODE_I32_CONST
-000003b: 00                                         ; i32 literal
-000003c: 0a                                         ; OPCODE_I32_CONST
-000003d: 00                                         ; i32 literal
-000003e: 0a                                         ; OPCODE_I32_CONST
-000003f: 00                                         ; i32 literal
-0000040: 0a                                         ; OPCODE_I32_CONST
-0000041: 00                                         ; i32 literal
-0000042: 5b                                         ; OPCODE_I64_ADD
-0000043: 5c                                         ; OPCODE_I64_SUB
-0000044: 5d                                         ; OPCODE_I64_MUL
-0000045: 5e                                         ; OPCODE_I64_DIV_S
-0000046: 5f                                         ; OPCODE_I64_DIV_U
-0000047: 60                                         ; OPCODE_I64_REM_S
-0000048: 61                                         ; OPCODE_I64_REM_U
-0000049: 62                                         ; OPCODE_I64_AND
-000004a: 63                                         ; OPCODE_I64_OR
-000004b: 64                                         ; OPCODE_I64_XOR
-000004c: 65                                         ; OPCODE_I64_SHL
-000004d: 66                                         ; OPCODE_I64_SHR_U
-000004e: 67                                         ; OPCODE_I64_SHR_S
-000004f: b9                                         ; OPCODE_I64_ROL
-0000050: b8                                         ; OPCODE_I64_ROR
-0000051: 0b                                         ; OPCODE_I64_CONST
-0000052: 00                                         ; i64 literal
-0000053: 0b                                         ; OPCODE_I64_CONST
-0000054: 00                                         ; i64 literal
-0000055: 0b                                         ; OPCODE_I64_CONST
-0000056: 00                                         ; i64 literal
-0000057: 0b                                         ; OPCODE_I64_CONST
-0000058: 00                                         ; i64 literal
-0000059: 0b                                         ; OPCODE_I64_CONST
-000005a: 00                                         ; i64 literal
-000005b: 0b                                         ; OPCODE_I64_CONST
-000005c: 00                                         ; i64 literal
-000005d: 0b                                         ; OPCODE_I64_CONST
-000005e: 00                                         ; i64 literal
-000005f: 0b                                         ; OPCODE_I64_CONST
-0000060: 00                                         ; i64 literal
-0000061: 0b                                         ; OPCODE_I64_CONST
-0000062: 00                                         ; i64 literal
-0000063: 0b                                         ; OPCODE_I64_CONST
-0000064: 00                                         ; i64 literal
-0000065: 0b                                         ; OPCODE_I64_CONST
-0000066: 00                                         ; i64 literal
-0000067: 0b                                         ; OPCODE_I64_CONST
-0000068: 00                                         ; i64 literal
-0000069: 0b                                         ; OPCODE_I64_CONST
-000006a: 00                                         ; i64 literal
-000006b: 0b                                         ; OPCODE_I64_CONST
-000006c: 00                                         ; i64 literal
-000006d: 0b                                         ; OPCODE_I64_CONST
-000006e: 00                                         ; i64 literal
-000006f: 0b                                         ; OPCODE_I64_CONST
-0000070: 00                                         ; i64 literal
-0000071: 75                                         ; OPCODE_F32_ADD
-0000072: 76                                         ; OPCODE_F32_SUB
-0000073: 77                                         ; OPCODE_F32_MUL
-0000074: 78                                         ; OPCODE_F32_DIV
-0000075: 79                                         ; OPCODE_F32_MIN
-0000076: 7a                                         ; OPCODE_F32_MAX
-0000077: 7d                                         ; OPCODE_F32_COPYSIGN
-0000078: 0d                                         ; OPCODE_F32_CONST
-0000079: 0000 0000                                  ; f32 literal
-000007d: 0d                                         ; OPCODE_F32_CONST
-000007e: 0000 0000                                  ; f32 literal
-0000082: 0d                                         ; OPCODE_F32_CONST
-0000083: 0000 0000                                  ; f32 literal
-0000087: 0d                                         ; OPCODE_F32_CONST
-0000088: 0000 0000                                  ; f32 literal
-000008c: 0d                                         ; OPCODE_F32_CONST
-000008d: 0000 0000                                  ; f32 literal
-0000091: 0d                                         ; OPCODE_F32_CONST
-0000092: 0000 0000                                  ; f32 literal
-0000096: 0d                                         ; OPCODE_F32_CONST
-0000097: 0000 0000                                  ; f32 literal
-000009b: 0d                                         ; OPCODE_F32_CONST
-000009c: 0000 0000                                  ; f32 literal
-00000a0: 89                                         ; OPCODE_F64_ADD
-00000a1: 8a                                         ; OPCODE_F64_SUB
-00000a2: 8b                                         ; OPCODE_F64_MUL
-00000a3: 8c                                         ; OPCODE_F64_DIV
-00000a4: 8d                                         ; OPCODE_F64_MIN
-00000a5: 8e                                         ; OPCODE_F64_MAX
-00000a6: 91                                         ; OPCODE_F64_COPYSIGN
-00000a7: 0c                                         ; OPCODE_F64_CONST
-00000a8: 0000 0000 0000 0000                        ; f64 literal
-00000b0: 0c                                         ; OPCODE_F64_CONST
-00000b1: 0000 0000 0000 0000                        ; f64 literal
-00000b9: 0c                                         ; OPCODE_F64_CONST
-00000ba: 0000 0000 0000 0000                        ; f64 literal
-00000c2: 0c                                         ; OPCODE_F64_CONST
-00000c3: 0000 0000 0000 0000                        ; f64 literal
-00000cb: 0c                                         ; OPCODE_F64_CONST
-00000cc: 0000 0000 0000 0000                        ; f64 literal
-00000d4: 0c                                         ; OPCODE_F64_CONST
-00000d5: 0000 0000 0000 0000                        ; f64 literal
-00000dd: 0c                                         ; OPCODE_F64_CONST
-00000de: 0000 0000 0000 0000                        ; f64 literal
-00000e6: 0c                                         ; OPCODE_F64_CONST
-00000e7: 0000 0000 0000 0000                        ; f64 literal
-0000011: dc00                                       ; FIXUP func body size
-00000ef: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 40                                         ; OPCODE_I32_ADD
+0000015: 41                                         ; OPCODE_I32_SUB
+0000016: 42                                         ; OPCODE_I32_MUL
+0000017: 43                                         ; OPCODE_I32_DIV_S
+0000018: 44                                         ; OPCODE_I32_DIV_U
+0000019: 45                                         ; OPCODE_I32_REM_S
+000001a: 46                                         ; OPCODE_I32_REM_U
+000001b: 47                                         ; OPCODE_I32_AND
+000001c: 48                                         ; OPCODE_I32_OR
+000001d: 49                                         ; OPCODE_I32_XOR
+000001e: 4a                                         ; OPCODE_I32_SHL
+000001f: 4b                                         ; OPCODE_I32_SHR_U
+0000020: 4c                                         ; OPCODE_I32_SHR_S
+0000021: b7                                         ; OPCODE_I32_ROL
+0000022: b6                                         ; OPCODE_I32_ROR
+0000023: 0a                                         ; OPCODE_I32_CONST
+0000024: 00                                         ; i32 literal
+0000025: 0a                                         ; OPCODE_I32_CONST
+0000026: 00                                         ; i32 literal
+0000027: 0a                                         ; OPCODE_I32_CONST
+0000028: 00                                         ; i32 literal
+0000029: 0a                                         ; OPCODE_I32_CONST
+000002a: 00                                         ; i32 literal
+000002b: 0a                                         ; OPCODE_I32_CONST
+000002c: 00                                         ; i32 literal
+000002d: 0a                                         ; OPCODE_I32_CONST
+000002e: 00                                         ; i32 literal
+000002f: 0a                                         ; OPCODE_I32_CONST
+0000030: 00                                         ; i32 literal
+0000031: 0a                                         ; OPCODE_I32_CONST
+0000032: 00                                         ; i32 literal
+0000033: 0a                                         ; OPCODE_I32_CONST
+0000034: 00                                         ; i32 literal
+0000035: 0a                                         ; OPCODE_I32_CONST
+0000036: 00                                         ; i32 literal
+0000037: 0a                                         ; OPCODE_I32_CONST
+0000038: 00                                         ; i32 literal
+0000039: 0a                                         ; OPCODE_I32_CONST
+000003a: 00                                         ; i32 literal
+000003b: 0a                                         ; OPCODE_I32_CONST
+000003c: 00                                         ; i32 literal
+000003d: 0a                                         ; OPCODE_I32_CONST
+000003e: 00                                         ; i32 literal
+000003f: 0a                                         ; OPCODE_I32_CONST
+0000040: 00                                         ; i32 literal
+0000041: 0a                                         ; OPCODE_I32_CONST
+0000042: 00                                         ; i32 literal
+0000043: 5b                                         ; OPCODE_I64_ADD
+0000044: 5c                                         ; OPCODE_I64_SUB
+0000045: 5d                                         ; OPCODE_I64_MUL
+0000046: 5e                                         ; OPCODE_I64_DIV_S
+0000047: 5f                                         ; OPCODE_I64_DIV_U
+0000048: 60                                         ; OPCODE_I64_REM_S
+0000049: 61                                         ; OPCODE_I64_REM_U
+000004a: 62                                         ; OPCODE_I64_AND
+000004b: 63                                         ; OPCODE_I64_OR
+000004c: 64                                         ; OPCODE_I64_XOR
+000004d: 65                                         ; OPCODE_I64_SHL
+000004e: 66                                         ; OPCODE_I64_SHR_U
+000004f: 67                                         ; OPCODE_I64_SHR_S
+0000050: b9                                         ; OPCODE_I64_ROL
+0000051: b8                                         ; OPCODE_I64_ROR
+0000052: 0b                                         ; OPCODE_I64_CONST
+0000053: 00                                         ; i64 literal
+0000054: 0b                                         ; OPCODE_I64_CONST
+0000055: 00                                         ; i64 literal
+0000056: 0b                                         ; OPCODE_I64_CONST
+0000057: 00                                         ; i64 literal
+0000058: 0b                                         ; OPCODE_I64_CONST
+0000059: 00                                         ; i64 literal
+000005a: 0b                                         ; OPCODE_I64_CONST
+000005b: 00                                         ; i64 literal
+000005c: 0b                                         ; OPCODE_I64_CONST
+000005d: 00                                         ; i64 literal
+000005e: 0b                                         ; OPCODE_I64_CONST
+000005f: 00                                         ; i64 literal
+0000060: 0b                                         ; OPCODE_I64_CONST
+0000061: 00                                         ; i64 literal
+0000062: 0b                                         ; OPCODE_I64_CONST
+0000063: 00                                         ; i64 literal
+0000064: 0b                                         ; OPCODE_I64_CONST
+0000065: 00                                         ; i64 literal
+0000066: 0b                                         ; OPCODE_I64_CONST
+0000067: 00                                         ; i64 literal
+0000068: 0b                                         ; OPCODE_I64_CONST
+0000069: 00                                         ; i64 literal
+000006a: 0b                                         ; OPCODE_I64_CONST
+000006b: 00                                         ; i64 literal
+000006c: 0b                                         ; OPCODE_I64_CONST
+000006d: 00                                         ; i64 literal
+000006e: 0b                                         ; OPCODE_I64_CONST
+000006f: 00                                         ; i64 literal
+0000070: 0b                                         ; OPCODE_I64_CONST
+0000071: 00                                         ; i64 literal
+0000072: 75                                         ; OPCODE_F32_ADD
+0000073: 76                                         ; OPCODE_F32_SUB
+0000074: 77                                         ; OPCODE_F32_MUL
+0000075: 78                                         ; OPCODE_F32_DIV
+0000076: 79                                         ; OPCODE_F32_MIN
+0000077: 7a                                         ; OPCODE_F32_MAX
+0000078: 7d                                         ; OPCODE_F32_COPYSIGN
+0000079: 0d                                         ; OPCODE_F32_CONST
+000007a: 0000 0000                                  ; f32 literal
+000007e: 0d                                         ; OPCODE_F32_CONST
+000007f: 0000 0000                                  ; f32 literal
+0000083: 0d                                         ; OPCODE_F32_CONST
+0000084: 0000 0000                                  ; f32 literal
+0000088: 0d                                         ; OPCODE_F32_CONST
+0000089: 0000 0000                                  ; f32 literal
+000008d: 0d                                         ; OPCODE_F32_CONST
+000008e: 0000 0000                                  ; f32 literal
+0000092: 0d                                         ; OPCODE_F32_CONST
+0000093: 0000 0000                                  ; f32 literal
+0000097: 0d                                         ; OPCODE_F32_CONST
+0000098: 0000 0000                                  ; f32 literal
+000009c: 0d                                         ; OPCODE_F32_CONST
+000009d: 0000 0000                                  ; f32 literal
+00000a1: 89                                         ; OPCODE_F64_ADD
+00000a2: 8a                                         ; OPCODE_F64_SUB
+00000a3: 8b                                         ; OPCODE_F64_MUL
+00000a4: 8c                                         ; OPCODE_F64_DIV
+00000a5: 8d                                         ; OPCODE_F64_MIN
+00000a6: 8e                                         ; OPCODE_F64_MAX
+00000a7: 91                                         ; OPCODE_F64_COPYSIGN
+00000a8: 0c                                         ; OPCODE_F64_CONST
+00000a9: 0000 0000 0000 0000                        ; f64 literal
+00000b1: 0c                                         ; OPCODE_F64_CONST
+00000b2: 0000 0000 0000 0000                        ; f64 literal
+00000ba: 0c                                         ; OPCODE_F64_CONST
+00000bb: 0000 0000 0000 0000                        ; f64 literal
+00000c3: 0c                                         ; OPCODE_F64_CONST
+00000c4: 0000 0000 0000 0000                        ; f64 literal
+00000cc: 0c                                         ; OPCODE_F64_CONST
+00000cd: 0000 0000 0000 0000                        ; f64 literal
+00000d5: 0c                                         ; OPCODE_F64_CONST
+00000d6: 0000 0000 0000 0000                        ; f64 literal
+00000de: 0c                                         ; OPCODE_F64_CONST
+00000df: 0000 0000 0000 0000                        ; f64 literal
+00000e7: 0c                                         ; OPCODE_F64_CONST
+00000e8: 0000 0000 0000 0000                        ; f64 literal
+0000011: dd00                                       ; FIXUP func body size
+00000f0: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 00dc 0040 4142 4344 4546 4748 494a 4b4c  
-0000020: b7b6 0a00 0a00 0a00 0a00 0a00 0a00 0a00  
-0000030: 0a00 0a00 0a00 0a00 0a00 0a00 0a00 0a00  
-0000040: 0a00 5b5c 5d5e 5f60 6162 6364 6566 67b9  
-0000050: b80b 000b 000b 000b 000b 000b 000b 000b  
-0000060: 000b 000b 000b 000b 000b 000b 000b 000b  
-0000070: 0075 7677 7879 7a7d 0d00 0000 000d 0000  
-0000080: 0000 0d00 0000 000d 0000 0000 0d00 0000  
-0000090: 000d 0000 0000 0d00 0000 000d 0000 0000  
-00000a0: 898a 8b8c 8d8e 910c 0000 0000 0000 0000  
-00000b0: 0c00 0000 0000 0000 000c 0000 0000 0000  
-00000c0: 0000 0c00 0000 0000 0000 000c 0000 0000  
-00000d0: 0000 0000 0c00 0000 0000 0000 000c 0000  
-00000e0: 0000 0000 0000 0c00 0000 0000 0000 0006  
+0000010: 00dd 0000 4041 4243 4445 4647 4849 4a4b  
+0000020: 4cb7 b60a 000a 000a 000a 000a 000a 000a  
+0000030: 000a 000a 000a 000a 000a 000a 000a 000a  
+0000040: 000a 005b 5c5d 5e5f 6061 6263 6465 6667  
+0000050: b9b8 0b00 0b00 0b00 0b00 0b00 0b00 0b00  
+0000060: 0b00 0b00 0b00 0b00 0b00 0b00 0b00 0b00  
+0000070: 0b00 7576 7778 797a 7d0d 0000 0000 0d00  
+0000080: 0000 000d 0000 0000 0d00 0000 000d 0000  
+0000090: 0000 0d00 0000 000d 0000 0000 0d00 0000  
+00000a0: 0089 8a8b 8c8d 8e91 0c00 0000 0000 0000  
+00000b0: 000c 0000 0000 0000 0000 0c00 0000 0000  
+00000c0: 0000 000c 0000 0000 0000 0000 0c00 0000  
+00000d0: 0000 0000 000c 0000 0000 0000 0000 0c00  
+00000e0: 0000 0000 0000 000c 0000 0000 0000 0000  
+00000f0: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -114,7 +114,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 40                                         ; OPCODE_I32_ADD
 0000015: 41                                         ; OPCODE_I32_SUB
 0000016: 42                                         ; OPCODE_I32_MUL

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -60,11 +60,12 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 02                                         ; num expressions (byte 1)
-0000015: 01                                         ; OPCODE_BLOCK
-0000016: ff                                         ; num expressions (byte 0)
-0000017: 00                                         ; OPCODE_NOP
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 02                                         ; num expressions (byte 1)
+0000016: 01                                         ; OPCODE_BLOCK
+0000017: ff                                         ; num expressions (byte 0)
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
 000001a: 00                                         ; OPCODE_NOP
@@ -319,20 +320,21 @@
 0000113: 00                                         ; OPCODE_NOP
 0000114: 00                                         ; OPCODE_NOP
 0000115: 00                                         ; OPCODE_NOP
-0000116: 01                                         ; OPCODE_BLOCK
-0000117: 03                                         ; num expressions (byte 0)
-0000118: 00                                         ; OPCODE_NOP
-0000119: 06                                         ; OPCODE_BR
-000011a: 01                                         ; break depth
-000011b: 00                                         ; OPCODE_NOP
-000011c: 06                                         ; OPCODE_BR
-000011d: 01                                         ; break depth
-000011e: 00                                         ; OPCODE_NOP
-0000011: 0c01                                       ; FIXUP func body size
-000011f: 06                                         ; WASM_BINARY_SECTION_END
+0000116: 00                                         ; OPCODE_NOP
+0000117: 01                                         ; OPCODE_BLOCK
+0000118: 03                                         ; num expressions (byte 0)
+0000119: 00                                         ; OPCODE_NOP
+000011a: 06                                         ; OPCODE_BR
+000011b: 01                                         ; break depth
+000011c: 00                                         ; OPCODE_NOP
+000011d: 06                                         ; OPCODE_BR
+000011e: 01                                         ; break depth
+000011f: 00                                         ; OPCODE_NOP
+0000011: 0d01                                       ; FIXUP func body size
+0000120: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 000c 0101 0201 ff00 0000 0000 0000 0000  
+0000010: 000d 0100 0102 01ff 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -348,5 +350,6 @@
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000110: 0000 0000 0000 0103 0006 0100 0601 0006  
+0000110: 0000 0000 0000 0001 0300 0601 0006 0100  
+0000120: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -61,7 +61,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 02                                         ; num expressions (byte 1)
 0000016: 01                                         ; OPCODE_BLOCK

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -58,11 +58,12 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 02                                         ; num expressions (byte 1)
-0000015: 01                                         ; OPCODE_BLOCK
-0000016: ff                                         ; num expressions (byte 0)
-0000017: 00                                         ; OPCODE_NOP
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 02                                         ; num expressions (byte 1)
+0000016: 01                                         ; OPCODE_BLOCK
+0000017: ff                                         ; num expressions (byte 0)
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
 000001a: 00                                         ; OPCODE_NOP
@@ -317,15 +318,16 @@
 0000113: 00                                         ; OPCODE_NOP
 0000114: 00                                         ; OPCODE_NOP
 0000115: 00                                         ; OPCODE_NOP
-0000116: 01                                         ; OPCODE_BLOCK
-0000117: 02                                         ; num expressions (byte 0)
-0000118: 00                                         ; OPCODE_NOP
+0000116: 00                                         ; OPCODE_NOP
+0000117: 01                                         ; OPCODE_BLOCK
+0000118: 02                                         ; num expressions (byte 0)
 0000119: 00                                         ; OPCODE_NOP
-0000011: 0701                                       ; FIXUP func body size
-000011a: 06                                         ; WASM_BINARY_SECTION_END
+000011a: 00                                         ; OPCODE_NOP
+0000011: 0801                                       ; FIXUP func body size
+000011b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0007 0101 0201 ff00 0000 0000 0000 0000  
+0000010: 0008 0100 0102 01ff 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -341,5 +343,5 @@
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000110: 0000 0000 0000 0102 0000 06              
+0000110: 0000 0000 0000 0001 0200 0006            
 ;;; STDOUT ;;)

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -59,7 +59,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 02                                         ; num expressions (byte 1)
 0000016: 01                                         ; OPCODE_BLOCK

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -27,7 +27,6 @@
 0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
 0000015: 00                                         ; local decl count
-0000015: 00                                         ; local decl count
 0000016: 01                                         ; OPCODE_BLOCK
 0000017: 03                                         ; num expressions
 0000018: 00                                         ; OPCODE_NOP
@@ -38,7 +37,6 @@
 000001b: 00                                         ; func flags
 000001c: 0100                                       ; func signature index
 000001e: 0000                                       ; func body size
-0000020: 00                                         ; local decl count
 0000020: 00                                         ; local decl count
 0000021: 01                                         ; OPCODE_BLOCK
 0000022: 01                                         ; num expressions

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -26,24 +26,28 @@
 0000010: 00                                         ; func flags
 0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
-0000015: 01                                         ; OPCODE_BLOCK
-0000016: 03                                         ; num expressions
-0000017: 00                                         ; OPCODE_NOP
+0000015: 00                                         ; local decl count
+0000015: 00                                         ; local decl count
+0000016: 01                                         ; OPCODE_BLOCK
+0000017: 03                                         ; num expressions
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
-0000013: 0500                                       ; FIXUP func body size
+000001a: 00                                         ; OPCODE_NOP
+0000013: 0600                                       ; FIXUP func body size
 ; function 1
-000001a: 00                                         ; func flags
-000001b: 0100                                       ; func signature index
-000001d: 0000                                       ; func body size
-000001f: 01                                         ; OPCODE_BLOCK
-0000020: 01                                         ; num expressions
-0000021: 0a                                         ; OPCODE_I32_CONST
-0000022: 01                                         ; i32 literal
-000001d: 0400                                       ; FIXUP func body size
-0000023: 06                                         ; WASM_BINARY_SECTION_END
+000001b: 00                                         ; func flags
+000001c: 0100                                       ; func signature index
+000001e: 0000                                       ; func body size
+0000020: 00                                         ; local decl count
+0000020: 00                                         ; local decl count
+0000021: 01                                         ; OPCODE_BLOCK
+0000022: 01                                         ; num expressions
+0000023: 0a                                         ; OPCODE_I32_CONST
+0000024: 01                                         ; i32 literal
+000001e: 0500                                       ; FIXUP func body size
+0000025: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0102 0000 0001 0202  
-0000010: 0000 0005 0001 0300 0000 0001 0004 0001  
-0000020: 010a 0106                                
+0000010: 0000 0006 0000 0103 0000 0000 0100 0500  
+0000020: 0001 010a 0106                           
 ;;; STDOUT ;;)

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -22,26 +22,28 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 01                                         ; num expressions
-0000015: 02                                         ; OPCODE_LOOP
-0000016: 01                                         ; num expressions
-0000017: 01                                         ; OPCODE_BLOCK
-0000018: 02                                         ; num expressions
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-000001b: 01                                         ; OPCODE_BLOCK
-000001c: 02                                         ; num expressions
-000001d: 06                                         ; OPCODE_BR
-000001e: 00                                         ; break depth
-000001f: 00                                         ; OPCODE_NOP
-0000020: 06                                         ; OPCODE_BR
-0000021: 04                                         ; break depth
-0000022: 00                                         ; OPCODE_NOP
-0000011: 1000                                       ; FIXUP func body size
-0000023: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 01                                         ; num expressions
+0000016: 02                                         ; OPCODE_LOOP
+0000017: 01                                         ; num expressions
+0000018: 01                                         ; OPCODE_BLOCK
+0000019: 02                                         ; num expressions
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+000001c: 01                                         ; OPCODE_BLOCK
+000001d: 02                                         ; num expressions
+000001e: 06                                         ; OPCODE_BR
+000001f: 00                                         ; break depth
+0000020: 00                                         ; OPCODE_NOP
+0000021: 06                                         ; OPCODE_BR
+0000022: 04                                         ; break depth
+0000023: 00                                         ; OPCODE_NOP
+0000011: 1100                                       ; FIXUP func body size
+0000024: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0010 0001 0102 0101 020a 0001 0206 0000  
-0000020: 0604 0006                                
+0000010: 0011 0000 0101 0201 0102 0a00 0102 0600  
+0000020: 0006 0400 06                             
 ;;; STDOUT ;;)

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -23,7 +23,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 02                                         ; OPCODE_LOOP

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -26,7 +26,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 02                                         ; OPCODE_LOOP

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -25,35 +25,37 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 01                                         ; num expressions
-0000015: 02                                         ; OPCODE_LOOP
-0000016: 01                                         ; num expressions
-0000017: 01                                         ; OPCODE_BLOCK
-0000018: 02                                         ; num expressions
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-000001b: 01                                         ; OPCODE_BLOCK
-000001c: 05                                         ; num expressions
-000001d: 06                                         ; OPCODE_BR
-000001e: 00                                         ; break depth
-000001f: 00                                         ; OPCODE_NOP
-0000020: 06                                         ; OPCODE_BR
-0000021: 00                                         ; break depth
-0000022: 00                                         ; OPCODE_NOP
-0000023: 06                                         ; OPCODE_BR
-0000024: 01                                         ; break depth
-0000025: 00                                         ; OPCODE_NOP
-0000026: 06                                         ; OPCODE_BR
-0000027: 02                                         ; break depth
-0000028: 00                                         ; OPCODE_NOP
-0000029: 06                                         ; OPCODE_BR
-000002a: 03                                         ; break depth
-000002b: 00                                         ; OPCODE_NOP
-0000011: 1900                                       ; FIXUP func body size
-000002c: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 01                                         ; num expressions
+0000016: 02                                         ; OPCODE_LOOP
+0000017: 01                                         ; num expressions
+0000018: 01                                         ; OPCODE_BLOCK
+0000019: 02                                         ; num expressions
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+000001c: 01                                         ; OPCODE_BLOCK
+000001d: 05                                         ; num expressions
+000001e: 06                                         ; OPCODE_BR
+000001f: 00                                         ; break depth
+0000020: 00                                         ; OPCODE_NOP
+0000021: 06                                         ; OPCODE_BR
+0000022: 00                                         ; break depth
+0000023: 00                                         ; OPCODE_NOP
+0000024: 06                                         ; OPCODE_BR
+0000025: 01                                         ; break depth
+0000026: 00                                         ; OPCODE_NOP
+0000027: 06                                         ; OPCODE_BR
+0000028: 02                                         ; break depth
+0000029: 00                                         ; OPCODE_NOP
+000002a: 06                                         ; OPCODE_BR
+000002b: 03                                         ; break depth
+000002c: 00                                         ; OPCODE_NOP
+0000011: 1a00                                       ; FIXUP func body size
+000002d: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0019 0001 0102 0101 020a 0001 0506 0000  
-0000020: 0600 0006 0100 0602 0006 0300 06         
+0000010: 001a 0000 0101 0201 0102 0a00 0105 0600  
+0000020: 0006 0000 0601 0006 0200 0603 0006       
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -21,31 +21,33 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 03                                         ; num expressions
-0000015: 03                                         ; OPCODE_IF
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 01                                         ; i32 literal
-0000018: 01                                         ; OPCODE_BLOCK
-0000019: 01                                         ; num expressions
-000001a: 06                                         ; OPCODE_BR
-000001b: 01                                         ; break depth
-000001c: 00                                         ; OPCODE_NOP
-000001d: 03                                         ; OPCODE_IF
-000001e: 0a                                         ; OPCODE_I32_CONST
-000001f: 03                                         ; i32 literal
-0000020: 01                                         ; OPCODE_BLOCK
-0000021: 01                                         ; num expressions
-0000022: 06                                         ; OPCODE_BR
-0000023: 02                                         ; break depth
-0000024: 0a                                         ; OPCODE_I32_CONST
-0000025: 04                                         ; i32 literal
-0000026: 0a                                         ; OPCODE_I32_CONST
-0000027: 05                                         ; i32 literal
-0000011: 1500                                       ; FIXUP func body size
-0000028: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 03                                         ; num expressions
+0000016: 03                                         ; OPCODE_IF
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 01                                         ; i32 literal
+0000019: 01                                         ; OPCODE_BLOCK
+000001a: 01                                         ; num expressions
+000001b: 06                                         ; OPCODE_BR
+000001c: 01                                         ; break depth
+000001d: 00                                         ; OPCODE_NOP
+000001e: 03                                         ; OPCODE_IF
+000001f: 0a                                         ; OPCODE_I32_CONST
+0000020: 03                                         ; i32 literal
+0000021: 01                                         ; OPCODE_BLOCK
+0000022: 01                                         ; num expressions
+0000023: 06                                         ; OPCODE_BR
+0000024: 02                                         ; break depth
+0000025: 0a                                         ; OPCODE_I32_CONST
+0000026: 04                                         ; i32 literal
+0000027: 0a                                         ; OPCODE_I32_CONST
+0000028: 05                                         ; i32 literal
+0000011: 1600                                       ; FIXUP func body size
+0000029: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
-0000010: 0015 0002 0303 0a01 0101 0601 0003 0a03  
-0000020: 0101 0602 0a04 0a05 06                   
+0000010: 0016 0000 0203 030a 0101 0106 0100 030a  
+0000020: 0301 0106 020a 040a 0506                 
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -22,7 +22,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 03                                         ; num expressions
 0000016: 03                                         ; OPCODE_IF

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -20,28 +20,30 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 02                                         ; num expressions
-0000015: 03                                         ; OPCODE_IF
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 01                                         ; i32 literal
-0000018: 01                                         ; OPCODE_BLOCK
-0000019: 01                                         ; num expressions
-000001a: 06                                         ; OPCODE_BR
-000001b: 02                                         ; break depth
-000001c: 00                                         ; OPCODE_NOP
-000001d: 03                                         ; OPCODE_IF
-000001e: 0a                                         ; OPCODE_I32_CONST
-000001f: 02                                         ; i32 literal
-0000020: 01                                         ; OPCODE_BLOCK
-0000021: 01                                         ; num expressions
-0000022: 06                                         ; OPCODE_BR
-0000023: 01                                         ; break depth
-0000024: 00                                         ; OPCODE_NOP
-0000011: 1200                                       ; FIXUP func body size
-0000025: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 02                                         ; num expressions
+0000016: 03                                         ; OPCODE_IF
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 01                                         ; i32 literal
+0000019: 01                                         ; OPCODE_BLOCK
+000001a: 01                                         ; num expressions
+000001b: 06                                         ; OPCODE_BR
+000001c: 02                                         ; break depth
+000001d: 00                                         ; OPCODE_NOP
+000001e: 03                                         ; OPCODE_IF
+000001f: 0a                                         ; OPCODE_I32_CONST
+0000020: 02                                         ; i32 literal
+0000021: 01                                         ; OPCODE_BLOCK
+0000022: 01                                         ; num expressions
+0000023: 06                                         ; OPCODE_BR
+0000024: 01                                         ; break depth
+0000025: 00                                         ; OPCODE_NOP
+0000011: 1300                                       ; FIXUP func body size
+0000026: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0012 0002 0203 0a01 0101 0602 0003 0a02  
-0000020: 0101 0601 0006                           
+0000010: 0013 0000 0202 030a 0101 0106 0200 030a  
+0000020: 0201 0106 0100 06                        
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -21,7 +21,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 02                                         ; num expressions
 0000016: 03                                         ; OPCODE_IF

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -18,19 +18,21 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 01                                         ; num expressions
-0000015: 03                                         ; OPCODE_IF
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 01                                         ; i32 literal
-0000018: 01                                         ; OPCODE_BLOCK
-0000019: 01                                         ; num expressions
-000001a: 06                                         ; OPCODE_BR
-000001b: 01                                         ; break depth
-000001c: 00                                         ; OPCODE_NOP
-0000011: 0a00                                       ; FIXUP func body size
-000001d: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 01                                         ; num expressions
+0000016: 03                                         ; OPCODE_IF
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 01                                         ; i32 literal
+0000019: 01                                         ; OPCODE_BLOCK
+000001a: 01                                         ; num expressions
+000001b: 06                                         ; OPCODE_BR
+000001c: 01                                         ; break depth
+000001d: 00                                         ; OPCODE_NOP
+0000011: 0b00                                       ; FIXUP func body size
+000001e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 000a 0002 0103 0a01 0101 0601 0006       
+0000010: 000b 0000 0201 030a 0101 0106 0100 06    
 ;;; STDOUT ;;)

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -19,7 +19,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 01                                         ; num expressions
 0000016: 03                                         ; OPCODE_IF

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -17,16 +17,18 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 01                                         ; num expressions
-0000015: 07                                         ; OPCODE_BR_IF
-0000016: 00                                         ; break depth
-0000017: 00                                         ; OPCODE_NOP
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 00                                         ; i32 literal
-0000011: 0700                                       ; FIXUP func body size
-000001a: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 01                                         ; num expressions
+0000016: 07                                         ; OPCODE_BR_IF
+0000017: 00                                         ; break depth
+0000018: 00                                         ; OPCODE_NOP
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 00                                         ; i32 literal
+0000011: 0800                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0007 0002 0107 0000 0a00 06              
+0000010: 0008 0000 0201 0700 000a 0006            
 ;;; STDOUT ;;)

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -18,7 +18,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 01                                         ; num expressions
 0000016: 07                                         ; OPCODE_BR_IF

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -18,7 +18,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 07                                         ; OPCODE_BR_IF

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -17,16 +17,18 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 01                                         ; num expressions
-0000015: 07                                         ; OPCODE_BR_IF
-0000016: 00                                         ; break depth
-0000017: 00                                         ; OPCODE_NOP
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 01                                         ; i32 literal
-0000011: 0700                                       ; FIXUP func body size
-000001a: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 01                                         ; num expressions
+0000016: 07                                         ; OPCODE_BR_IF
+0000017: 00                                         ; break depth
+0000018: 00                                         ; OPCODE_NOP
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 01                                         ; i32 literal
+0000011: 0800                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0007 0001 0107 0000 0a01 06              
+0000010: 0008 0000 0101 0700 000a 0106            
 ;;; STDOUT ;;)

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -27,32 +27,34 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 01                                         ; num expressions
-0000015: 01                                         ; OPCODE_BLOCK
-0000016: 04                                         ; num expressions
-0000017: 01                                         ; OPCODE_BLOCK
-0000018: 01                                         ; num expressions
-0000019: 08                                         ; OPCODE_BR_TABLE
-000001a: 0200                                       ; num targets
-000001c: 0000                                       ; break depth
-000001e: 0100                                       ; break depth
-0000020: 0000                                       ; break depth for default
-0000022: 0a                                         ; OPCODE_I32_CONST
-0000023: 00                                         ; i32 literal
-0000024: 0a                                         ; OPCODE_I32_CONST
-0000025: 01                                         ; i32 literal
-0000026: 0a                                         ; OPCODE_I32_CONST
-0000027: 02                                         ; i32 literal
-0000028: 06                                         ; OPCODE_BR
-0000029: 01                                         ; break depth
-000002a: 00                                         ; OPCODE_NOP
-000002b: 0a                                         ; OPCODE_I32_CONST
-000002c: 03                                         ; i32 literal
-0000011: 1a00                                       ; FIXUP func body size
-000002d: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 01                                         ; num expressions
+0000016: 01                                         ; OPCODE_BLOCK
+0000017: 04                                         ; num expressions
+0000018: 01                                         ; OPCODE_BLOCK
+0000019: 01                                         ; num expressions
+000001a: 08                                         ; OPCODE_BR_TABLE
+000001b: 0200                                       ; num targets
+000001d: 0000                                       ; break depth
+000001f: 0100                                       ; break depth
+0000021: 0000                                       ; break depth for default
+0000023: 0a                                         ; OPCODE_I32_CONST
+0000024: 00                                         ; i32 literal
+0000025: 0a                                         ; OPCODE_I32_CONST
+0000026: 01                                         ; i32 literal
+0000027: 0a                                         ; OPCODE_I32_CONST
+0000028: 02                                         ; i32 literal
+0000029: 06                                         ; OPCODE_BR
+000002a: 01                                         ; break depth
+000002b: 00                                         ; OPCODE_NOP
+000002c: 0a                                         ; OPCODE_I32_CONST
+000002d: 03                                         ; i32 literal
+0000011: 1b00                                       ; FIXUP func body size
+000002e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 001a 0001 0101 0401 0108 0200 0000 0100  
-0000020: 0000 0a00 0a01 0a02 0601 000a 0306       
+0000010: 001b 0000 0101 0104 0101 0802 0000 0001  
+0000020: 0000 000a 000a 010a 0206 0100 0a03 06    
 ;;; STDOUT ;;)

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -28,7 +28,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 01                                         ; OPCODE_BLOCK

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -17,13 +17,15 @@
 000000f: 00                                         ; func flags
 0000010: 0000                                       ; func signature index
 0000012: 0000                                       ; func body size
-0000014: 12                                         ; OPCODE_CALL_FUNCTION
-0000015: 00                                         ; func index
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 01                                         ; i32 literal
-0000012: 0400                                       ; FIXUP func body size
-0000018: 06                                         ; WASM_BINARY_SECTION_END
+0000014: 00                                         ; local decl count
+0000014: 00                                         ; local decl count
+0000015: 12                                         ; OPCODE_CALL_FUNCTION
+0000016: 00                                         ; func index
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 01                                         ; i32 literal
+0000012: 0500                                       ; FIXUP func body size
+0000019: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0100 0102 0100  
-0000010: 0000 0400 1200 0a01 06                   
+0000010: 0000 0500 0012 000a 0106                 
 ;;; STDOUT ;;)

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -18,7 +18,6 @@
 0000010: 0000                                       ; func signature index
 0000012: 0000                                       ; func body size
 0000014: 00                                         ; local decl count
-0000014: 00                                         ; local decl count
 0000015: 12                                         ; OPCODE_CALL_FUNCTION
 0000016: 00                                         ; func index
 0000017: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -34,26 +34,28 @@
 000001e: 00                                         ; func flags
 000001f: 0100                                       ; func signature index
 0000021: 0000                                       ; func body size
-0000023: 1f                                         ; OPCODE_CALL_IMPORT
-0000024: 00                                         ; import index
-0000025: 0a                                         ; OPCODE_I32_CONST
-0000026: 01                                         ; i32 literal
-0000027: 0d                                         ; OPCODE_F32_CONST
-0000028: 0000 0040                                  ; f32 literal
-000002c: 12                                         ; OPCODE_CALL_FUNCTION
-000002d: 00                                         ; func index
-0000021: 0b00                                       ; FIXUP func body size
-000002e: 06                                         ; WASM_BINARY_SECTION_END
+0000023: 00                                         ; local decl count
+0000023: 00                                         ; local decl count
+0000024: 1f                                         ; OPCODE_CALL_IMPORT
+0000025: 00                                         ; import index
+0000026: 0a                                         ; OPCODE_I32_CONST
+0000027: 01                                         ; i32 literal
+0000028: 0d                                         ; OPCODE_F32_CONST
+0000029: 0000 0040                                  ; f32 literal
+000002d: 12                                         ; OPCODE_CALL_FUNCTION
+000002e: 00                                         ; func index
+0000021: 0c00                                       ; FIXUP func body size
+000002f: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-0000014: 2f00 0000                                  ; FIXUP import module name offset
-000002f: 666f 6f                                    ; import module name
-0000032: 00                                         ; \0
-0000018: 3300 0000                                  ; FIXUP import function name offset
-0000033: 6261 72                                    ; import function name
-0000036: 00                                         ; \0
+0000014: 3000 0000                                  ; FIXUP import module name offset
+0000030: 666f 6f                                    ; import module name
+0000033: 00                                         ; \0
+0000018: 3400 0000                                  ; FIXUP import function name offset
+0000034: 6261 72                                    ; import function name
+0000037: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0102 0201 0103 0001  
-0000010: 0801 0000 2f00 0000 3300 0000 0201 0001  
-0000020: 000b 001f 000a 010d 0000 0040 1200 0666  
-0000030: 6f6f 0062 6172 00                        
+0000010: 0801 0000 3000 0000 3400 0000 0201 0001  
+0000020: 000c 0000 1f00 0a01 0d00 0000 4012 0006  
+0000030: 666f 6f00 6261 7200                      
 ;;; STDOUT ;;)

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -35,7 +35,6 @@
 000001f: 0100                                       ; func signature index
 0000021: 0000                                       ; func body size
 0000023: 00                                         ; local decl count
-0000023: 00                                         ; local decl count
 0000024: 1f                                         ; OPCODE_CALL_IMPORT
 0000025: 00                                         ; import index
 0000026: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/callindirect-after-import.txt
+++ b/test/dump/callindirect-after-import.txt
@@ -45,14 +45,12 @@
 0000020: 0000                                       ; func signature index
 0000022: 0000                                       ; func body size
 0000024: 00                                         ; local decl count
-0000024: 00                                         ; local decl count
 0000025: 00                                         ; OPCODE_NOP
 0000022: 0200                                       ; FIXUP func body size
 ; function 1
 0000026: 00                                         ; func flags
 0000027: 0200                                       ; func signature index
 0000029: 0000                                       ; func body size
-000002b: 00                                         ; local decl count
 000002b: 00                                         ; local decl count
 000002c: 13                                         ; OPCODE_CALL_INDIRECT
 000002d: 00                                         ; signature index

--- a/test/dump/callindirect-after-import.txt
+++ b/test/dump/callindirect-after-import.txt
@@ -44,33 +44,38 @@
 000001f: 00                                         ; func flags
 0000020: 0000                                       ; func signature index
 0000022: 0000                                       ; func body size
-0000024: 00                                         ; OPCODE_NOP
-0000022: 0100                                       ; FIXUP func body size
+0000024: 00                                         ; local decl count
+0000024: 00                                         ; local decl count
+0000025: 00                                         ; OPCODE_NOP
+0000022: 0200                                       ; FIXUP func body size
 ; function 1
-0000025: 00                                         ; func flags
-0000026: 0200                                       ; func signature index
-0000028: 0000                                       ; func body size
-000002a: 13                                         ; OPCODE_CALL_INDIRECT
-000002b: 00                                         ; signature index
-000002c: 0a                                         ; OPCODE_I32_CONST
-000002d: 00                                         ; i32 literal
-000002e: 0d                                         ; OPCODE_F32_CONST
-000002f: 0000 803f                                  ; f32 literal
-0000028: 0900                                       ; FIXUP func body size
-0000033: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-0000034: 01                                         ; num function table entries
-0000035: 0000                                       ; function table entry
-0000037: 06                                         ; WASM_BINARY_SECTION_END
+0000026: 00                                         ; func flags
+0000027: 0200                                       ; func signature index
+0000029: 0000                                       ; func body size
+000002b: 00                                         ; local decl count
+000002b: 00                                         ; local decl count
+000002c: 13                                         ; OPCODE_CALL_INDIRECT
+000002d: 00                                         ; signature index
+000002e: 0a                                         ; OPCODE_I32_CONST
+000002f: 00                                         ; i32 literal
+0000030: 0d                                         ; OPCODE_F32_CONST
+0000031: 0000 803f                                  ; f32 literal
+0000029: 0a00                                       ; FIXUP func body size
+0000035: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+0000036: 01                                         ; num function table entries
+0000037: 0000                                       ; function table entry
+0000039: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-0000015: 3800 0000                                  ; FIXUP import module name offset
-0000038: 666f 6f                                    ; import module name
-000003b: 00                                         ; \0
-0000019: 3c00 0000                                  ; FIXUP import function name offset
-000003c: 6261 72                                    ; import function name
-000003f: 00                                         ; \0
+0000015: 3a00 0000                                  ; FIXUP import module name offset
+000003a: 666f 6f                                    ; import module name
+000003d: 00                                         ; \0
+0000019: 3e00 0000                                  ; FIXUP import function name offset
+000003e: 6261 72                                    ; import function name
+0000041: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0103 0100 0300 0100  
-0000010: 0008 0101 0038 0000 003c 0000 0002 0200  
-0000020: 0000 0100 0000 0200 0900 1300 0a00 0d00  
-0000030: 0080 3f05 0100 0006 666f 6f00 6261 7200  
+0000010: 0008 0101 003a 0000 003e 0000 0002 0200  
+0000020: 0000 0200 0000 0002 000a 0000 1300 0a00  
+0000030: 0d00 0080 3f05 0100 0006 666f 6f00 6261  
+0000040: 7200                                     
 ;;; STDOUT ;;)

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -20,7 +20,6 @@
 0000010: 0000                                       ; func signature index
 0000012: 0000                                       ; func body size
 0000014: 00                                         ; local decl count
-0000014: 00                                         ; local decl count
 0000015: 13                                         ; OPCODE_CALL_INDIRECT
 0000016: 00                                         ; signature index
 0000017: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -19,18 +19,20 @@
 000000f: 00                                         ; func flags
 0000010: 0000                                       ; func signature index
 0000012: 0000                                       ; func body size
-0000014: 13                                         ; OPCODE_CALL_INDIRECT
-0000015: 00                                         ; signature index
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 00                                         ; i32 literal
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 00                                         ; i32 literal
-0000012: 0600                                       ; FIXUP func body size
-000001a: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-000001b: 01                                         ; num function table entries
-000001c: 0000                                       ; function table entry
-000001e: 06                                         ; WASM_BINARY_SECTION_END
+0000014: 00                                         ; local decl count
+0000014: 00                                         ; local decl count
+0000015: 13                                         ; OPCODE_CALL_INDIRECT
+0000016: 00                                         ; signature index
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 00                                         ; i32 literal
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 00                                         ; i32 literal
+0000012: 0700                                       ; FIXUP func body size
+000001b: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+000001c: 01                                         ; num function table entries
+000001d: 0000                                       ; function table entry
+000001f: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0100 0102 0100  
-0000010: 0000 0600 1300 0a00 0a00 0501 0000 06    
+0000010: 0000 0700 0013 000a 000a 0005 0100 0006  
 ;;; STDOUT ;;)

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -21,7 +21,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: ad                                         ; OPCODE_F32_REINTERPRET_I32
 0000015: 0a                                         ; OPCODE_I32_CONST
 0000016: 00                                         ; i32 literal

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -20,22 +20,24 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: ad                                         ; OPCODE_F32_REINTERPRET_I32
-0000014: 0a                                         ; OPCODE_I32_CONST
-0000015: 00                                         ; i32 literal
-0000016: b4                                         ; OPCODE_I32_REINTERPRET_F32
-0000017: 0d                                         ; OPCODE_F32_CONST
-0000018: 0000 0000                                  ; f32 literal
-000001c: b3                                         ; OPCODE_F64_REINTERPRET_I64
-000001d: 0b                                         ; OPCODE_I64_CONST
-000001e: 00                                         ; i64 literal
-000001f: b5                                         ; OPCODE_I64_REINTERPRET_F64
-0000020: 0c                                         ; OPCODE_F64_CONST
-0000021: 0000 0000 0000 0000                        ; f64 literal
-0000011: 1600                                       ; FIXUP func body size
-0000029: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: ad                                         ; OPCODE_F32_REINTERPRET_I32
+0000015: 0a                                         ; OPCODE_I32_CONST
+0000016: 00                                         ; i32 literal
+0000017: b4                                         ; OPCODE_I32_REINTERPRET_F32
+0000018: 0d                                         ; OPCODE_F32_CONST
+0000019: 0000 0000                                  ; f32 literal
+000001d: b3                                         ; OPCODE_F64_REINTERPRET_I64
+000001e: 0b                                         ; OPCODE_I64_CONST
+000001f: 00                                         ; i64 literal
+0000020: b5                                         ; OPCODE_I64_REINTERPRET_F64
+0000021: 0c                                         ; OPCODE_F64_CONST
+0000022: 0000 0000 0000 0000                        ; f64 literal
+0000011: 1700                                       ; FIXUP func body size
+000002a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0016 00ad 0a00 b40d 0000 0000 b30b 00b5  
-0000020: 0c00 0000 0000 0000 0006                 
+0000010: 0017 0000 ad0a 00b4 0d00 0000 00b3 0b00  
+0000020: b50c 0000 0000 0000 0000 06              
 ;;; STDOUT ;;)

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -63,167 +63,169 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 4d                                         ; OPCODE_I32_EQ
-0000014: 4e                                         ; OPCODE_I32_NE
-0000015: 4f                                         ; OPCODE_I32_LT_S
-0000016: 51                                         ; OPCODE_I32_LT_U
-0000017: 50                                         ; OPCODE_I32_LE_S
-0000018: 52                                         ; OPCODE_I32_LE_U
-0000019: 53                                         ; OPCODE_I32_GT_S
-000001a: 55                                         ; OPCODE_I32_GT_U
-000001b: 54                                         ; OPCODE_I32_GE_S
-000001c: 56                                         ; OPCODE_I32_GE_U
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 00                                         ; i32 literal
-000001f: 0a                                         ; OPCODE_I32_CONST
-0000020: 00                                         ; i32 literal
-0000021: 0a                                         ; OPCODE_I32_CONST
-0000022: 00                                         ; i32 literal
-0000023: 0a                                         ; OPCODE_I32_CONST
-0000024: 00                                         ; i32 literal
-0000025: 0a                                         ; OPCODE_I32_CONST
-0000026: 00                                         ; i32 literal
-0000027: 0a                                         ; OPCODE_I32_CONST
-0000028: 00                                         ; i32 literal
-0000029: 0a                                         ; OPCODE_I32_CONST
-000002a: 00                                         ; i32 literal
-000002b: 0a                                         ; OPCODE_I32_CONST
-000002c: 00                                         ; i32 literal
-000002d: 0a                                         ; OPCODE_I32_CONST
-000002e: 00                                         ; i32 literal
-000002f: 0a                                         ; OPCODE_I32_CONST
-0000030: 00                                         ; i32 literal
-0000031: 0a                                         ; OPCODE_I32_CONST
-0000032: 00                                         ; i32 literal
-0000033: 68                                         ; OPCODE_I64_EQ
-0000034: 0b                                         ; OPCODE_I64_CONST
-0000035: 00                                         ; i64 literal
-0000036: 0b                                         ; OPCODE_I64_CONST
-0000037: 00                                         ; i64 literal
-0000038: 69                                         ; OPCODE_I64_NE
-0000039: 0b                                         ; OPCODE_I64_CONST
-000003a: 00                                         ; i64 literal
-000003b: 0b                                         ; OPCODE_I64_CONST
-000003c: 00                                         ; i64 literal
-000003d: 6a                                         ; OPCODE_I64_LT_S
-000003e: 0b                                         ; OPCODE_I64_CONST
-000003f: 00                                         ; i64 literal
-0000040: 0b                                         ; OPCODE_I64_CONST
-0000041: 00                                         ; i64 literal
-0000042: 6c                                         ; OPCODE_I64_LT_U
-0000043: 0b                                         ; OPCODE_I64_CONST
-0000044: 00                                         ; i64 literal
-0000045: 0b                                         ; OPCODE_I64_CONST
-0000046: 00                                         ; i64 literal
-0000047: 6b                                         ; OPCODE_I64_LE_S
-0000048: 0b                                         ; OPCODE_I64_CONST
-0000049: 00                                         ; i64 literal
-000004a: 0b                                         ; OPCODE_I64_CONST
-000004b: 00                                         ; i64 literal
-000004c: 6d                                         ; OPCODE_I64_LE_U
-000004d: 0b                                         ; OPCODE_I64_CONST
-000004e: 00                                         ; i64 literal
-000004f: 0b                                         ; OPCODE_I64_CONST
-0000050: 00                                         ; i64 literal
-0000051: 6e                                         ; OPCODE_I64_GT_S
-0000052: 0b                                         ; OPCODE_I64_CONST
-0000053: 00                                         ; i64 literal
-0000054: 0b                                         ; OPCODE_I64_CONST
-0000055: 00                                         ; i64 literal
-0000056: 70                                         ; OPCODE_I64_GT_U
-0000057: 0b                                         ; OPCODE_I64_CONST
-0000058: 00                                         ; i64 literal
-0000059: 0b                                         ; OPCODE_I64_CONST
-000005a: 00                                         ; i64 literal
-000005b: 6f                                         ; OPCODE_I64_GE_S
-000005c: 0b                                         ; OPCODE_I64_CONST
-000005d: 00                                         ; i64 literal
-000005e: 0b                                         ; OPCODE_I64_CONST
-000005f: 00                                         ; i64 literal
-0000060: 71                                         ; OPCODE_I64_GE_U
-0000061: 0b                                         ; OPCODE_I64_CONST
-0000062: 00                                         ; i64 literal
-0000063: 0b                                         ; OPCODE_I64_CONST
-0000064: 00                                         ; i64 literal
-0000065: 83                                         ; OPCODE_F32_EQ
-0000066: 0d                                         ; OPCODE_F32_CONST
-0000067: 0000 0000                                  ; f32 literal
-000006b: 0d                                         ; OPCODE_F32_CONST
-000006c: 0000 0000                                  ; f32 literal
-0000070: 84                                         ; OPCODE_F32_NE
-0000071: 0d                                         ; OPCODE_F32_CONST
-0000072: 0000 0000                                  ; f32 literal
-0000076: 0d                                         ; OPCODE_F32_CONST
-0000077: 0000 0000                                  ; f32 literal
-000007b: 85                                         ; OPCODE_F32_LT
-000007c: 0d                                         ; OPCODE_F32_CONST
-000007d: 0000 0000                                  ; f32 literal
-0000081: 0d                                         ; OPCODE_F32_CONST
-0000082: 0000 0000                                  ; f32 literal
-0000086: 86                                         ; OPCODE_F32_LE
-0000087: 0d                                         ; OPCODE_F32_CONST
-0000088: 0000 0000                                  ; f32 literal
-000008c: 0d                                         ; OPCODE_F32_CONST
-000008d: 0000 0000                                  ; f32 literal
-0000091: 87                                         ; OPCODE_F32_GT
-0000092: 0d                                         ; OPCODE_F32_CONST
-0000093: 0000 0000                                  ; f32 literal
-0000097: 0d                                         ; OPCODE_F32_CONST
-0000098: 0000 0000                                  ; f32 literal
-000009c: 88                                         ; OPCODE_F32_GE
-000009d: 0d                                         ; OPCODE_F32_CONST
-000009e: 0000 0000                                  ; f32 literal
-00000a2: 0d                                         ; OPCODE_F32_CONST
-00000a3: 0000 0000                                  ; f32 literal
-00000a7: 97                                         ; OPCODE_F64_EQ
-00000a8: 0c                                         ; OPCODE_F64_CONST
-00000a9: 0000 0000 0000 0000                        ; f64 literal
-00000b1: 0c                                         ; OPCODE_F64_CONST
-00000b2: 0000 0000 0000 0000                        ; f64 literal
-00000ba: 98                                         ; OPCODE_F64_NE
-00000bb: 0c                                         ; OPCODE_F64_CONST
-00000bc: 0000 0000 0000 0000                        ; f64 literal
-00000c4: 0c                                         ; OPCODE_F64_CONST
-00000c5: 0000 0000 0000 0000                        ; f64 literal
-00000cd: 99                                         ; OPCODE_F64_LT
-00000ce: 0c                                         ; OPCODE_F64_CONST
-00000cf: 0000 0000 0000 0000                        ; f64 literal
-00000d7: 0c                                         ; OPCODE_F64_CONST
-00000d8: 0000 0000 0000 0000                        ; f64 literal
-00000e0: 9a                                         ; OPCODE_F64_LE
-00000e1: 0c                                         ; OPCODE_F64_CONST
-00000e2: 0000 0000 0000 0000                        ; f64 literal
-00000ea: 0c                                         ; OPCODE_F64_CONST
-00000eb: 0000 0000 0000 0000                        ; f64 literal
-00000f3: 9b                                         ; OPCODE_F64_GT
-00000f4: 0c                                         ; OPCODE_F64_CONST
-00000f5: 0000 0000 0000 0000                        ; f64 literal
-00000fd: 0c                                         ; OPCODE_F64_CONST
-00000fe: 0000 0000 0000 0000                        ; f64 literal
-0000106: 9c                                         ; OPCODE_F64_GE
-0000107: 0c                                         ; OPCODE_F64_CONST
-0000108: 0000 0000 0000 0000                        ; f64 literal
-0000110: 0c                                         ; OPCODE_F64_CONST
-0000111: 0000 0000 0000 0000                        ; f64 literal
-0000011: 0601                                       ; FIXUP func body size
-0000119: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 4d                                         ; OPCODE_I32_EQ
+0000015: 4e                                         ; OPCODE_I32_NE
+0000016: 4f                                         ; OPCODE_I32_LT_S
+0000017: 51                                         ; OPCODE_I32_LT_U
+0000018: 50                                         ; OPCODE_I32_LE_S
+0000019: 52                                         ; OPCODE_I32_LE_U
+000001a: 53                                         ; OPCODE_I32_GT_S
+000001b: 55                                         ; OPCODE_I32_GT_U
+000001c: 54                                         ; OPCODE_I32_GE_S
+000001d: 56                                         ; OPCODE_I32_GE_U
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: 0a                                         ; OPCODE_I32_CONST
+0000021: 00                                         ; i32 literal
+0000022: 0a                                         ; OPCODE_I32_CONST
+0000023: 00                                         ; i32 literal
+0000024: 0a                                         ; OPCODE_I32_CONST
+0000025: 00                                         ; i32 literal
+0000026: 0a                                         ; OPCODE_I32_CONST
+0000027: 00                                         ; i32 literal
+0000028: 0a                                         ; OPCODE_I32_CONST
+0000029: 00                                         ; i32 literal
+000002a: 0a                                         ; OPCODE_I32_CONST
+000002b: 00                                         ; i32 literal
+000002c: 0a                                         ; OPCODE_I32_CONST
+000002d: 00                                         ; i32 literal
+000002e: 0a                                         ; OPCODE_I32_CONST
+000002f: 00                                         ; i32 literal
+0000030: 0a                                         ; OPCODE_I32_CONST
+0000031: 00                                         ; i32 literal
+0000032: 0a                                         ; OPCODE_I32_CONST
+0000033: 00                                         ; i32 literal
+0000034: 68                                         ; OPCODE_I64_EQ
+0000035: 0b                                         ; OPCODE_I64_CONST
+0000036: 00                                         ; i64 literal
+0000037: 0b                                         ; OPCODE_I64_CONST
+0000038: 00                                         ; i64 literal
+0000039: 69                                         ; OPCODE_I64_NE
+000003a: 0b                                         ; OPCODE_I64_CONST
+000003b: 00                                         ; i64 literal
+000003c: 0b                                         ; OPCODE_I64_CONST
+000003d: 00                                         ; i64 literal
+000003e: 6a                                         ; OPCODE_I64_LT_S
+000003f: 0b                                         ; OPCODE_I64_CONST
+0000040: 00                                         ; i64 literal
+0000041: 0b                                         ; OPCODE_I64_CONST
+0000042: 00                                         ; i64 literal
+0000043: 6c                                         ; OPCODE_I64_LT_U
+0000044: 0b                                         ; OPCODE_I64_CONST
+0000045: 00                                         ; i64 literal
+0000046: 0b                                         ; OPCODE_I64_CONST
+0000047: 00                                         ; i64 literal
+0000048: 6b                                         ; OPCODE_I64_LE_S
+0000049: 0b                                         ; OPCODE_I64_CONST
+000004a: 00                                         ; i64 literal
+000004b: 0b                                         ; OPCODE_I64_CONST
+000004c: 00                                         ; i64 literal
+000004d: 6d                                         ; OPCODE_I64_LE_U
+000004e: 0b                                         ; OPCODE_I64_CONST
+000004f: 00                                         ; i64 literal
+0000050: 0b                                         ; OPCODE_I64_CONST
+0000051: 00                                         ; i64 literal
+0000052: 6e                                         ; OPCODE_I64_GT_S
+0000053: 0b                                         ; OPCODE_I64_CONST
+0000054: 00                                         ; i64 literal
+0000055: 0b                                         ; OPCODE_I64_CONST
+0000056: 00                                         ; i64 literal
+0000057: 70                                         ; OPCODE_I64_GT_U
+0000058: 0b                                         ; OPCODE_I64_CONST
+0000059: 00                                         ; i64 literal
+000005a: 0b                                         ; OPCODE_I64_CONST
+000005b: 00                                         ; i64 literal
+000005c: 6f                                         ; OPCODE_I64_GE_S
+000005d: 0b                                         ; OPCODE_I64_CONST
+000005e: 00                                         ; i64 literal
+000005f: 0b                                         ; OPCODE_I64_CONST
+0000060: 00                                         ; i64 literal
+0000061: 71                                         ; OPCODE_I64_GE_U
+0000062: 0b                                         ; OPCODE_I64_CONST
+0000063: 00                                         ; i64 literal
+0000064: 0b                                         ; OPCODE_I64_CONST
+0000065: 00                                         ; i64 literal
+0000066: 83                                         ; OPCODE_F32_EQ
+0000067: 0d                                         ; OPCODE_F32_CONST
+0000068: 0000 0000                                  ; f32 literal
+000006c: 0d                                         ; OPCODE_F32_CONST
+000006d: 0000 0000                                  ; f32 literal
+0000071: 84                                         ; OPCODE_F32_NE
+0000072: 0d                                         ; OPCODE_F32_CONST
+0000073: 0000 0000                                  ; f32 literal
+0000077: 0d                                         ; OPCODE_F32_CONST
+0000078: 0000 0000                                  ; f32 literal
+000007c: 85                                         ; OPCODE_F32_LT
+000007d: 0d                                         ; OPCODE_F32_CONST
+000007e: 0000 0000                                  ; f32 literal
+0000082: 0d                                         ; OPCODE_F32_CONST
+0000083: 0000 0000                                  ; f32 literal
+0000087: 86                                         ; OPCODE_F32_LE
+0000088: 0d                                         ; OPCODE_F32_CONST
+0000089: 0000 0000                                  ; f32 literal
+000008d: 0d                                         ; OPCODE_F32_CONST
+000008e: 0000 0000                                  ; f32 literal
+0000092: 87                                         ; OPCODE_F32_GT
+0000093: 0d                                         ; OPCODE_F32_CONST
+0000094: 0000 0000                                  ; f32 literal
+0000098: 0d                                         ; OPCODE_F32_CONST
+0000099: 0000 0000                                  ; f32 literal
+000009d: 88                                         ; OPCODE_F32_GE
+000009e: 0d                                         ; OPCODE_F32_CONST
+000009f: 0000 0000                                  ; f32 literal
+00000a3: 0d                                         ; OPCODE_F32_CONST
+00000a4: 0000 0000                                  ; f32 literal
+00000a8: 97                                         ; OPCODE_F64_EQ
+00000a9: 0c                                         ; OPCODE_F64_CONST
+00000aa: 0000 0000 0000 0000                        ; f64 literal
+00000b2: 0c                                         ; OPCODE_F64_CONST
+00000b3: 0000 0000 0000 0000                        ; f64 literal
+00000bb: 98                                         ; OPCODE_F64_NE
+00000bc: 0c                                         ; OPCODE_F64_CONST
+00000bd: 0000 0000 0000 0000                        ; f64 literal
+00000c5: 0c                                         ; OPCODE_F64_CONST
+00000c6: 0000 0000 0000 0000                        ; f64 literal
+00000ce: 99                                         ; OPCODE_F64_LT
+00000cf: 0c                                         ; OPCODE_F64_CONST
+00000d0: 0000 0000 0000 0000                        ; f64 literal
+00000d8: 0c                                         ; OPCODE_F64_CONST
+00000d9: 0000 0000 0000 0000                        ; f64 literal
+00000e1: 9a                                         ; OPCODE_F64_LE
+00000e2: 0c                                         ; OPCODE_F64_CONST
+00000e3: 0000 0000 0000 0000                        ; f64 literal
+00000eb: 0c                                         ; OPCODE_F64_CONST
+00000ec: 0000 0000 0000 0000                        ; f64 literal
+00000f4: 9b                                         ; OPCODE_F64_GT
+00000f5: 0c                                         ; OPCODE_F64_CONST
+00000f6: 0000 0000 0000 0000                        ; f64 literal
+00000fe: 0c                                         ; OPCODE_F64_CONST
+00000ff: 0000 0000 0000 0000                        ; f64 literal
+0000107: 9c                                         ; OPCODE_F64_GE
+0000108: 0c                                         ; OPCODE_F64_CONST
+0000109: 0000 0000 0000 0000                        ; f64 literal
+0000111: 0c                                         ; OPCODE_F64_CONST
+0000112: 0000 0000 0000 0000                        ; f64 literal
+0000011: 0701                                       ; FIXUP func body size
+000011a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0006 014d 4e4f 5150 5253 5554 560a 000a  
-0000020: 000a 000a 000a 000a 000a 000a 000a 000a  
-0000030: 000a 0068 0b00 0b00 690b 000b 006a 0b00  
-0000040: 0b00 6c0b 000b 006b 0b00 0b00 6d0b 000b  
-0000050: 006e 0b00 0b00 700b 000b 006f 0b00 0b00  
-0000060: 710b 000b 0083 0d00 0000 000d 0000 0000  
-0000070: 840d 0000 0000 0d00 0000 0085 0d00 0000  
-0000080: 000d 0000 0000 860d 0000 0000 0d00 0000  
-0000090: 0087 0d00 0000 000d 0000 0000 880d 0000  
-00000a0: 0000 0d00 0000 0097 0c00 0000 0000 0000  
-00000b0: 000c 0000 0000 0000 0000 980c 0000 0000  
-00000c0: 0000 0000 0c00 0000 0000 0000 0099 0c00  
-00000d0: 0000 0000 0000 000c 0000 0000 0000 0000  
-00000e0: 9a0c 0000 0000 0000 0000 0c00 0000 0000  
-00000f0: 0000 009b 0c00 0000 0000 0000 000c 0000  
-0000100: 0000 0000 0000 9c0c 0000 0000 0000 0000  
-0000110: 0c00 0000 0000 0000 0006                 
+0000010: 0007 0100 4d4e 4f51 5052 5355 5456 0a00  
+0000020: 0a00 0a00 0a00 0a00 0a00 0a00 0a00 0a00  
+0000030: 0a00 0a00 680b 000b 0069 0b00 0b00 6a0b  
+0000040: 000b 006c 0b00 0b00 6b0b 000b 006d 0b00  
+0000050: 0b00 6e0b 000b 0070 0b00 0b00 6f0b 000b  
+0000060: 0071 0b00 0b00 830d 0000 0000 0d00 0000  
+0000070: 0084 0d00 0000 000d 0000 0000 850d 0000  
+0000080: 0000 0d00 0000 0086 0d00 0000 000d 0000  
+0000090: 0000 870d 0000 0000 0d00 0000 0088 0d00  
+00000a0: 0000 000d 0000 0000 970c 0000 0000 0000  
+00000b0: 0000 0c00 0000 0000 0000 0098 0c00 0000  
+00000c0: 0000 0000 000c 0000 0000 0000 0000 990c  
+00000d0: 0000 0000 0000 0000 0c00 0000 0000 0000  
+00000e0: 009a 0c00 0000 0000 0000 000c 0000 0000  
+00000f0: 0000 0000 9b0c 0000 0000 0000 0000 0c00  
+0000100: 0000 0000 0000 009c 0c00 0000 0000 0000  
+0000110: 000c 0000 0000 0000 0000 06              
 ;;; STDOUT ;;)

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -64,7 +64,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 4d                                         ; OPCODE_I32_EQ
 0000015: 4e                                         ; OPCODE_I32_NE
 0000016: 4f                                         ; OPCODE_I32_LT_S

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -57,7 +57,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 0a                                         ; OPCODE_I32_CONST
 0000015: 00                                         ; i32 literal
 0000016: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -56,100 +56,102 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 0a                                         ; OPCODE_I32_CONST
-0000014: 00                                         ; i32 literal
-0000015: 0a                                         ; OPCODE_I32_CONST
-0000016: 8080 8080 78                               ; i32 literal
-000001b: 0a                                         ; OPCODE_I32_CONST
-000001c: 7f                                         ; i32 literal
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 8080 8080 78                               ; i32 literal
-0000023: 0a                                         ; OPCODE_I32_CONST
-0000024: 7f                                         ; i32 literal
-0000025: 0b                                         ; OPCODE_I64_CONST
-0000026: 00                                         ; i64 literal
-0000027: 0b                                         ; OPCODE_I64_CONST
-0000028: 8080 8080 8080 8080 807f                   ; i64 literal
-0000032: 0b                                         ; OPCODE_I64_CONST
-0000033: 7f                                         ; i64 literal
-0000034: 0b                                         ; OPCODE_I64_CONST
-0000035: 8080 8080 8080 8080 807f                   ; i64 literal
-000003f: 0b                                         ; OPCODE_I64_CONST
-0000040: 7f                                         ; i64 literal
-0000041: 0d                                         ; OPCODE_F32_CONST
-0000042: 0000 0000                                  ; f32 literal
-0000046: 0d                                         ; OPCODE_F32_CONST
-0000047: 1668 a965                                  ; f32 literal
-000004b: 0d                                         ; OPCODE_F32_CONST
-000004c: 4020 4f37                                  ; f32 literal
-0000050: 0d                                         ; OPCODE_F32_CONST
-0000051: 0000 c07f                                  ; f32 literal
-0000055: 0d                                         ; OPCODE_F32_CONST
-0000056: 0000 c0ff                                  ; f32 literal
-000005a: 0d                                         ; OPCODE_F32_CONST
-000005b: 0000 c07f                                  ; f32 literal
-000005f: 0d                                         ; OPCODE_F32_CONST
-0000060: bc0a 807f                                  ; f32 literal
-0000064: 0d                                         ; OPCODE_F32_CONST
-0000065: bc0a 80ff                                  ; f32 literal
-0000069: 0d                                         ; OPCODE_F32_CONST
-000006a: bc0a 807f                                  ; f32 literal
-000006e: 0d                                         ; OPCODE_F32_CONST
-000006f: 0000 807f                                  ; f32 literal
-0000073: 0d                                         ; OPCODE_F32_CONST
-0000074: 0000 80ff                                  ; f32 literal
-0000078: 0d                                         ; OPCODE_F32_CONST
-0000079: 0000 807f                                  ; f32 literal
-000007d: 0d                                         ; OPCODE_F32_CONST
-000007e: 0000 00bf                                  ; f32 literal
-0000082: 0d                                         ; OPCODE_F32_CONST
-0000083: db0f c940                                  ; f32 literal
-0000087: 0c                                         ; OPCODE_F64_CONST
-0000088: 0000 0000 0000 0000                        ; f64 literal
-0000090: 0c                                         ; OPCODE_F64_CONST
-0000091: b856 0e3c dd9a efbf                        ; f64 literal
-0000099: 0c                                         ; OPCODE_F64_CONST
-000009a: 182d 4454 fb21 1940                        ; f64 literal
-00000a2: 0c                                         ; OPCODE_F64_CONST
-00000a3: 0000 0000 0000 f87f                        ; f64 literal
-00000ab: 0c                                         ; OPCODE_F64_CONST
-00000ac: 0000 0000 0000 f8ff                        ; f64 literal
-00000b4: 0c                                         ; OPCODE_F64_CONST
-00000b5: 0000 0000 0000 f87f                        ; f64 literal
-00000bd: 0c                                         ; OPCODE_F64_CONST
-00000be: bc0a 0000 0000 f07f                        ; f64 literal
-00000c6: 0c                                         ; OPCODE_F64_CONST
-00000c7: bc0a 0000 0000 f0ff                        ; f64 literal
-00000cf: 0c                                         ; OPCODE_F64_CONST
-00000d0: bc0a 0000 0000 f07f                        ; f64 literal
-00000d8: 0c                                         ; OPCODE_F64_CONST
-00000d9: 0000 0000 0000 f07f                        ; f64 literal
-00000e1: 0c                                         ; OPCODE_F64_CONST
-00000e2: 0000 0000 0000 f0ff                        ; f64 literal
-00000ea: 0c                                         ; OPCODE_F64_CONST
-00000eb: 0000 0000 0000 f07f                        ; f64 literal
-00000f3: 0c                                         ; OPCODE_F64_CONST
-00000f4: 0000 0000 0000 e0bf                        ; f64 literal
-00000fc: 0c                                         ; OPCODE_F64_CONST
-00000fd: 182d 4454 fb21 1940                        ; f64 literal
-0000011: f200                                       ; FIXUP func body size
-0000105: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 0a                                         ; OPCODE_I32_CONST
+0000015: 00                                         ; i32 literal
+0000016: 0a                                         ; OPCODE_I32_CONST
+0000017: 8080 8080 78                               ; i32 literal
+000001c: 0a                                         ; OPCODE_I32_CONST
+000001d: 7f                                         ; i32 literal
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 8080 8080 78                               ; i32 literal
+0000024: 0a                                         ; OPCODE_I32_CONST
+0000025: 7f                                         ; i32 literal
+0000026: 0b                                         ; OPCODE_I64_CONST
+0000027: 00                                         ; i64 literal
+0000028: 0b                                         ; OPCODE_I64_CONST
+0000029: 8080 8080 8080 8080 807f                   ; i64 literal
+0000033: 0b                                         ; OPCODE_I64_CONST
+0000034: 7f                                         ; i64 literal
+0000035: 0b                                         ; OPCODE_I64_CONST
+0000036: 8080 8080 8080 8080 807f                   ; i64 literal
+0000040: 0b                                         ; OPCODE_I64_CONST
+0000041: 7f                                         ; i64 literal
+0000042: 0d                                         ; OPCODE_F32_CONST
+0000043: 0000 0000                                  ; f32 literal
+0000047: 0d                                         ; OPCODE_F32_CONST
+0000048: 1668 a965                                  ; f32 literal
+000004c: 0d                                         ; OPCODE_F32_CONST
+000004d: 4020 4f37                                  ; f32 literal
+0000051: 0d                                         ; OPCODE_F32_CONST
+0000052: 0000 c07f                                  ; f32 literal
+0000056: 0d                                         ; OPCODE_F32_CONST
+0000057: 0000 c0ff                                  ; f32 literal
+000005b: 0d                                         ; OPCODE_F32_CONST
+000005c: 0000 c07f                                  ; f32 literal
+0000060: 0d                                         ; OPCODE_F32_CONST
+0000061: bc0a 807f                                  ; f32 literal
+0000065: 0d                                         ; OPCODE_F32_CONST
+0000066: bc0a 80ff                                  ; f32 literal
+000006a: 0d                                         ; OPCODE_F32_CONST
+000006b: bc0a 807f                                  ; f32 literal
+000006f: 0d                                         ; OPCODE_F32_CONST
+0000070: 0000 807f                                  ; f32 literal
+0000074: 0d                                         ; OPCODE_F32_CONST
+0000075: 0000 80ff                                  ; f32 literal
+0000079: 0d                                         ; OPCODE_F32_CONST
+000007a: 0000 807f                                  ; f32 literal
+000007e: 0d                                         ; OPCODE_F32_CONST
+000007f: 0000 00bf                                  ; f32 literal
+0000083: 0d                                         ; OPCODE_F32_CONST
+0000084: db0f c940                                  ; f32 literal
+0000088: 0c                                         ; OPCODE_F64_CONST
+0000089: 0000 0000 0000 0000                        ; f64 literal
+0000091: 0c                                         ; OPCODE_F64_CONST
+0000092: b856 0e3c dd9a efbf                        ; f64 literal
+000009a: 0c                                         ; OPCODE_F64_CONST
+000009b: 182d 4454 fb21 1940                        ; f64 literal
+00000a3: 0c                                         ; OPCODE_F64_CONST
+00000a4: 0000 0000 0000 f87f                        ; f64 literal
+00000ac: 0c                                         ; OPCODE_F64_CONST
+00000ad: 0000 0000 0000 f8ff                        ; f64 literal
+00000b5: 0c                                         ; OPCODE_F64_CONST
+00000b6: 0000 0000 0000 f87f                        ; f64 literal
+00000be: 0c                                         ; OPCODE_F64_CONST
+00000bf: bc0a 0000 0000 f07f                        ; f64 literal
+00000c7: 0c                                         ; OPCODE_F64_CONST
+00000c8: bc0a 0000 0000 f0ff                        ; f64 literal
+00000d0: 0c                                         ; OPCODE_F64_CONST
+00000d1: bc0a 0000 0000 f07f                        ; f64 literal
+00000d9: 0c                                         ; OPCODE_F64_CONST
+00000da: 0000 0000 0000 f07f                        ; f64 literal
+00000e2: 0c                                         ; OPCODE_F64_CONST
+00000e3: 0000 0000 0000 f0ff                        ; f64 literal
+00000eb: 0c                                         ; OPCODE_F64_CONST
+00000ec: 0000 0000 0000 f07f                        ; f64 literal
+00000f4: 0c                                         ; OPCODE_F64_CONST
+00000f5: 0000 0000 0000 e0bf                        ; f64 literal
+00000fd: 0c                                         ; OPCODE_F64_CONST
+00000fe: 182d 4454 fb21 1940                        ; f64 literal
+0000011: f300                                       ; FIXUP func body size
+0000106: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 00f2 000a 000a 8080 8080 780a 7f0a 8080  
-0000020: 8080 780a 7f0b 000b 8080 8080 8080 8080  
-0000030: 807f 0b7f 0b80 8080 8080 8080 8080 7f0b  
-0000040: 7f0d 0000 0000 0d16 68a9 650d 4020 4f37  
-0000050: 0d00 00c0 7f0d 0000 c0ff 0d00 00c0 7f0d  
-0000060: bc0a 807f 0dbc 0a80 ff0d bc0a 807f 0d00  
-0000070: 0080 7f0d 0000 80ff 0d00 0080 7f0d 0000  
-0000080: 00bf 0ddb 0fc9 400c 0000 0000 0000 0000  
-0000090: 0cb8 560e 3cdd 9aef bf0c 182d 4454 fb21  
-00000a0: 1940 0c00 0000 0000 00f8 7f0c 0000 0000  
-00000b0: 0000 f8ff 0c00 0000 0000 00f8 7f0c bc0a  
-00000c0: 0000 0000 f07f 0cbc 0a00 0000 00f0 ff0c  
-00000d0: bc0a 0000 0000 f07f 0c00 0000 0000 00f0  
-00000e0: 7f0c 0000 0000 0000 f0ff 0c00 0000 0000  
-00000f0: 00f0 7f0c 0000 0000 0000 e0bf 0c18 2d44  
-0000100: 54fb 2119 4006                           
+0000010: 00f3 0000 0a00 0a80 8080 8078 0a7f 0a80  
+0000020: 8080 8078 0a7f 0b00 0b80 8080 8080 8080  
+0000030: 8080 7f0b 7f0b 8080 8080 8080 8080 807f  
+0000040: 0b7f 0d00 0000 000d 1668 a965 0d40 204f  
+0000050: 370d 0000 c07f 0d00 00c0 ff0d 0000 c07f  
+0000060: 0dbc 0a80 7f0d bc0a 80ff 0dbc 0a80 7f0d  
+0000070: 0000 807f 0d00 0080 ff0d 0000 807f 0d00  
+0000080: 0000 bf0d db0f c940 0c00 0000 0000 0000  
+0000090: 000c b856 0e3c dd9a efbf 0c18 2d44 54fb  
+00000a0: 2119 400c 0000 0000 0000 f87f 0c00 0000  
+00000b0: 0000 00f8 ff0c 0000 0000 0000 f87f 0cbc  
+00000c0: 0a00 0000 00f0 7f0c bc0a 0000 0000 f0ff  
+00000d0: 0cbc 0a00 0000 00f0 7f0c 0000 0000 0000  
+00000e0: f07f 0c00 0000 0000 00f0 ff0c 0000 0000  
+00000f0: 0000 f07f 0c00 0000 0000 00e0 bf0c 182d  
+0000100: 4454 fb21 1940 06                        
 ;;; STDOUT ;;)

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -39,7 +39,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: a1                                         ; OPCODE_I32_CONVERT_I64
 0000015: a7                                         ; OPCODE_I64_UCONVERT_I32
 0000016: 9d                                         ; OPCODE_I32_SCONVERT_F32

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -38,38 +38,40 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: a1                                         ; OPCODE_I32_CONVERT_I64
-0000014: a7                                         ; OPCODE_I64_UCONVERT_I32
-0000015: 9d                                         ; OPCODE_I32_SCONVERT_F32
-0000016: a8                                         ; OPCODE_F32_SCONVERT_I32
-0000017: 9f                                         ; OPCODE_I32_UCONVERT_F32
-0000018: a9                                         ; OPCODE_F32_UCONVERT_I32
-0000019: 9e                                         ; OPCODE_I32_SCONVERT_F64
-000001a: ae                                         ; OPCODE_F64_SCONVERT_I32
-000001b: a0                                         ; OPCODE_I32_UCONVERT_F64
-000001c: af                                         ; OPCODE_F64_UCONVERT_I32
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 00                                         ; i32 literal
-000001f: a2                                         ; OPCODE_I64_SCONVERT_F32
-0000020: aa                                         ; OPCODE_F32_SCONVERT_I64
-0000021: a4                                         ; OPCODE_I64_UCONVERT_F32
-0000022: ab                                         ; OPCODE_F32_UCONVERT_I64
-0000023: a3                                         ; OPCODE_I64_SCONVERT_F64
-0000024: b0                                         ; OPCODE_F64_SCONVERT_I64
-0000025: a5                                         ; OPCODE_I64_UCONVERT_F64
-0000026: b1                                         ; OPCODE_F64_UCONVERT_I64
-0000027: a6                                         ; OPCODE_I64_SCONVERT_I32
-0000028: 0a                                         ; OPCODE_I32_CONST
-0000029: 00                                         ; i32 literal
-000002a: ac                                         ; OPCODE_F32_CONVERT_F64
-000002b: b2                                         ; OPCODE_F64_CONVERT_F32
-000002c: 0d                                         ; OPCODE_F32_CONST
-000002d: 0000 0000                                  ; f32 literal
-0000011: 1e00                                       ; FIXUP func body size
-0000031: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: a1                                         ; OPCODE_I32_CONVERT_I64
+0000015: a7                                         ; OPCODE_I64_UCONVERT_I32
+0000016: 9d                                         ; OPCODE_I32_SCONVERT_F32
+0000017: a8                                         ; OPCODE_F32_SCONVERT_I32
+0000018: 9f                                         ; OPCODE_I32_UCONVERT_F32
+0000019: a9                                         ; OPCODE_F32_UCONVERT_I32
+000001a: 9e                                         ; OPCODE_I32_SCONVERT_F64
+000001b: ae                                         ; OPCODE_F64_SCONVERT_I32
+000001c: a0                                         ; OPCODE_I32_UCONVERT_F64
+000001d: af                                         ; OPCODE_F64_UCONVERT_I32
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: a2                                         ; OPCODE_I64_SCONVERT_F32
+0000021: aa                                         ; OPCODE_F32_SCONVERT_I64
+0000022: a4                                         ; OPCODE_I64_UCONVERT_F32
+0000023: ab                                         ; OPCODE_F32_UCONVERT_I64
+0000024: a3                                         ; OPCODE_I64_SCONVERT_F64
+0000025: b0                                         ; OPCODE_F64_SCONVERT_I64
+0000026: a5                                         ; OPCODE_I64_UCONVERT_F64
+0000027: b1                                         ; OPCODE_F64_UCONVERT_I64
+0000028: a6                                         ; OPCODE_I64_SCONVERT_I32
+0000029: 0a                                         ; OPCODE_I32_CONST
+000002a: 00                                         ; i32 literal
+000002b: ac                                         ; OPCODE_F32_CONVERT_F64
+000002c: b2                                         ; OPCODE_F64_CONVERT_F32
+000002d: 0d                                         ; OPCODE_F32_CONST
+000002e: 0000 0000                                  ; f32 literal
+0000011: 1f00                                       ; FIXUP func body size
+0000032: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 001e 00a1 a79d a89f a99e aea0 af0a 00a2  
-0000020: aaa4 aba3 b0a5 b1a6 0a00 acb2 0d00 0000  
-0000030: 0006                                     
+0000010: 001f 0000 a1a7 9da8 9fa9 9eae a0af 0a00  
+0000020: a2aa a4ab a3b0 a5b1 a60a 00ac b20d 0000  
+0000030: 0000 06                                  
 ;;; STDOUT ;;)

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -24,19 +24,21 @@
 000001b: 00                                         ; func flags
 000001c: 0000                                       ; func signature index
 000001e: 0000                                       ; func body size
-0000020: 0b                                         ; OPCODE_I64_CONST
-0000021: 00                                         ; i64 literal
-000001e: 0200                                       ; FIXUP func body size
-0000022: 06                                         ; WASM_BINARY_SECTION_END
+0000020: 00                                         ; local decl count
+0000020: 00                                         ; local decl count
+0000021: 0b                                         ; OPCODE_I64_CONST
+0000022: 00                                         ; i64 literal
+000001e: 0300                                       ; FIXUP func body size
+0000023: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-0000011: 2300 0000                                  ; FIXUP import module name offset
-0000023: 666f 6f                                    ; import module name
-0000026: 00                                         ; \0
-0000015: 2700 0000                                  ; FIXUP import function name offset
-0000027: 6261 72                                    ; import function name
-000002a: 00                                         ; \0
+0000011: 2400 0000                                  ; FIXUP import module name offset
+0000024: 666f 6f                                    ; import module name
+0000027: 00                                         ; \0
+0000015: 2800 0000                                  ; FIXUP import function name offset
+0000028: 6261 72                                    ; import function name
+000002b: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0102 0108 0100  
-0000010: 0023 0000 0027 0000 0002 0100 0000 0200  
-0000020: 0b00 0666 6f6f 0062 6172 00              
+0000010: 0024 0000 0028 0000 0002 0100 0000 0300  
+0000020: 000b 0006 666f 6f00 6261 7200            
 ;;; STDOUT ;;)

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -25,7 +25,6 @@
 000001c: 0000                                       ; func signature index
 000001e: 0000                                       ; func body size
 0000020: 00                                         ; local decl count
-0000020: 00                                         ; local decl count
 0000021: 0b                                         ; OPCODE_I64_CONST
 0000022: 00                                         ; i64 literal
 000001e: 0300                                       ; FIXUP func body size

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -18,7 +18,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 00                                         ; OPCODE_NOP
 0000011: 0200                                       ; FIXUP func body size
 0000015: 09                                         ; WASM_BINARY_SECTION_EXPORTS

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -17,25 +17,27 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 00                                         ; OPCODE_NOP
-0000011: 0100                                       ; FIXUP func body size
-0000014: 09                                         ; WASM_BINARY_SECTION_EXPORTS
-0000015: 02                                         ; num exports
-0000016: 0000                                       ; export func index
-0000018: 0000 0000                                  ; export name offset
-000001c: 0000                                       ; export func index
-000001e: 0000 0000                                  ; export name offset
-0000022: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 00                                         ; OPCODE_NOP
+0000011: 0200                                       ; FIXUP func body size
+0000015: 09                                         ; WASM_BINARY_SECTION_EXPORTS
+0000016: 02                                         ; num exports
+0000017: 0000                                       ; export func index
+0000019: 0000 0000                                  ; export name offset
+000001d: 0000                                       ; export func index
+000001f: 0000 0000                                  ; export name offset
+0000023: 06                                         ; WASM_BINARY_SECTION_END
 ; export 0
-0000018: 2300 0000                                  ; FIXUP func name offset
-0000023: 61                                         ; export name
-0000024: 00                                         ; \0
+0000019: 2400 0000                                  ; FIXUP func name offset
+0000024: 61                                         ; export name
+0000025: 00                                         ; \0
 ; export 1
-000001e: 2500 0000                                  ; FIXUP func name offset
-0000025: 62                                         ; export name
-0000026: 00                                         ; \0
+000001f: 2600 0000                                  ; FIXUP func name offset
+0000026: 62                                         ; export name
+0000027: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0001 0000 0902 0000 2300 0000 0000 2500  
-0000020: 0000 0661 0062 00                        
+0000010: 0002 0000 0009 0200 0024 0000 0000 0026  
+0000020: 0000 0006 6100 6200                      
 ;;; STDOUT ;;)

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -18,7 +18,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 06                                         ; OPCODE_BR

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -17,15 +17,17 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 01                                         ; num expressions
-0000015: 06                                         ; OPCODE_BR
-0000016: 00                                         ; break depth
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 01                                         ; i32 literal
-0000011: 0600                                       ; FIXUP func body size
-0000019: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 01                                         ; num expressions
+0000016: 06                                         ; OPCODE_BR
+0000017: 00                                         ; break depth
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 01                                         ; i32 literal
+0000011: 0700                                       ; FIXUP func body size
+000001a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
-0000010: 0006 0001 0106 000a 0106                 
+0000010: 0007 0000 0101 0600 0a01 06              
 ;;; STDOUT ;;)

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -18,19 +18,21 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 01                                         ; OPCODE_BLOCK
-0000014: 02                                         ; num expressions
-0000015: 07                                         ; OPCODE_BR_IF
-0000016: 00                                         ; break depth
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 2a                                         ; i32 literal
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-000001b: 0a                                         ; OPCODE_I32_CONST
-000001c: 1d                                         ; i32 literal
-0000011: 0a00                                       ; FIXUP func body size
-000001d: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; OPCODE_BLOCK
+0000015: 02                                         ; num expressions
+0000016: 07                                         ; OPCODE_BR_IF
+0000017: 00                                         ; break depth
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 2a                                         ; i32 literal
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+000001c: 0a                                         ; OPCODE_I32_CONST
+000001d: 1d                                         ; i32 literal
+0000011: 0b00                                       ; FIXUP func body size
+000001e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
-0000010: 000a 0001 0207 000a 2a0a 000a 1d06       
+0000010: 000b 0000 0102 0700 0a2a 0a00 0a1d 06    
 ;;; STDOUT ;;)

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -19,7 +19,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 02                                         ; num expressions
 0000016: 07                                         ; OPCODE_BR_IF

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -16,17 +16,20 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000011: 0000                                       ; FIXUP func body size
-0000013: 09                                         ; WASM_BINARY_SECTION_EXPORTS
-0000014: 01                                         ; num exports
-0000015: 0000                                       ; export func index
-0000017: 0000 0000                                  ; export name offset
-000001b: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000011: 0100                                       ; FIXUP func body size
+0000014: 09                                         ; WASM_BINARY_SECTION_EXPORTS
+0000015: 01                                         ; num exports
+0000016: 0000                                       ; export func index
+0000018: 0000 0000                                  ; export name offset
+000001c: 06                                         ; WASM_BINARY_SECTION_END
 ; export 0
-0000017: 1c00 0000                                  ; FIXUP func name offset
-000001c: 666f 6f                                    ; export name
-000001f: 00                                         ; \0
+0000018: 1d00 0000                                  ; FIXUP func name offset
+000001d: 666f 6f                                    ; export name
+0000020: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0000 0009 0100 001c 0000 0006 666f 6f00  
+0000010: 0001 0000 0901 0000 1d00 0000 0666 6f6f  
+0000020: 00                                       
 ;;; STDOUT ;;)

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -17,7 +17,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000011: 0100                                       ; FIXUP func body size
 0000014: 09                                         ; WASM_BINARY_SECTION_EXPORTS
 0000015: 01                                         ; num exports

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -17,19 +17,26 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000011: 0000                                       ; FIXUP func body size
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000011: 0100                                       ; FIXUP func body size
 ; function 1
-0000013: 00                                         ; func flags
-0000014: 0000                                       ; func signature index
-0000016: 0000                                       ; func body size
-0000016: 0000                                       ; FIXUP func body size
+0000014: 00                                         ; func flags
+0000015: 0000                                       ; func signature index
+0000017: 0000                                       ; func body size
+0000019: 00                                         ; local decl count
+0000019: 00                                         ; local decl count
+0000017: 0100                                       ; FIXUP func body size
 ; function 2
-0000018: 00                                         ; func flags
-0000019: 0000                                       ; func signature index
-000001b: 0000                                       ; func body size
-000001b: 0000                                       ; FIXUP func body size
-000001d: 06                                         ; WASM_BINARY_SECTION_END
+000001a: 00                                         ; func flags
+000001b: 0000                                       ; func signature index
+000001d: 0000                                       ; func body size
+000001f: 00                                         ; local decl count
+000001f: 00                                         ; local decl count
+000001d: 0100                                       ; FIXUP func body size
+0000020: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0203 0000  
-0000010: 0000 0000 0000 0000 0000 0000 0006       
+0000010: 0001 0000 0000 0001 0000 0000 0001 0000  
+0000020: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -18,20 +18,17 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000011: 0100                                       ; FIXUP func body size
 ; function 1
 0000014: 00                                         ; func flags
 0000015: 0000                                       ; func signature index
 0000017: 0000                                       ; func body size
 0000019: 00                                         ; local decl count
-0000019: 00                                         ; local decl count
 0000017: 0100                                       ; FIXUP func body size
 ; function 2
 000001a: 00                                         ; func flags
 000001b: 0000                                       ; func signature index
 000001d: 0000                                       ; func body size
-000001f: 00                                         ; local decl count
 000001f: 00                                         ; local decl count
 000001d: 0100                                       ; FIXUP func body size
 0000020: 06                                         ; WASM_BINARY_SECTION_END

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -15,9 +15,11 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000011: 0000                                       ; FIXUP func body size
-0000013: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000011: 0100                                       ; FIXUP func body size
+0000014: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0000 0006                                
+0000010: 0001 0000 06                             
 ;;; STDOUT ;;)

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -16,7 +16,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000011: 0100                                       ; FIXUP func body size
 0000014: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -28,14 +28,13 @@
 0000010: 00                                         ; func flags
 0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
-0000015: 00                                         ; local decl count
-0000016: 01                                         ; local i32 count
-0000017: 01                                         ; type i32
-0000018: 01                                         ; local i64 count
-0000019: 02                                         ; type i64
-000001a: 02                                         ; local f32 count
-000001b: 03                                         ; type f32
 0000015: 03                                         ; local decl count
+0000016: 01                                         ; local i32 count
+0000017: 01                                         ; WASM_TYPE_I32
+0000018: 01                                         ; local i64 count
+0000019: 02                                         ; WASM_TYPE_I64
+000001a: 02                                         ; local f32 count
+000001b: 03                                         ; WASM_TYPE_F32
 000001c: 0e                                         ; OPCODE_GET_LOCAL
 000001d: 00                                         ; remapped local index
 000001e: 0e                                         ; OPCODE_GET_LOCAL

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -25,29 +25,33 @@
 000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
 000000f: 01                                         ; num functions
 ; function 0
-0000010: 04                                         ; func flags
+0000010: 00                                         ; func flags
 0000011: 0000                                       ; func signature index
-0000013: 0100                                       ; num local i32
-0000015: 0100                                       ; num local i64
-0000017: 0200                                       ; num local f32
-0000019: 0000                                       ; num local f64
-000001b: 0000                                       ; func body size
-000001d: 0e                                         ; OPCODE_GET_LOCAL
-000001e: 00                                         ; remapped local index
-000001f: 0e                                         ; OPCODE_GET_LOCAL
-0000020: 01                                         ; remapped local index
-0000021: 0e                                         ; OPCODE_GET_LOCAL
-0000022: 03                                         ; remapped local index
-0000023: 0e                                         ; OPCODE_GET_LOCAL
-0000024: 04                                         ; remapped local index
-0000025: 0e                                         ; OPCODE_GET_LOCAL
-0000026: 02                                         ; remapped local index
-0000027: 0e                                         ; OPCODE_GET_LOCAL
-0000028: 05                                         ; remapped local index
-000001b: 0c00                                       ; FIXUP func body size
-0000029: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 0000                                       ; func body size
+0000015: 00                                         ; local decl count
+0000016: 01                                         ; local i32 count
+0000017: 01                                         ; type i32
+0000018: 01                                         ; local i64 count
+0000019: 02                                         ; type i64
+000001a: 02                                         ; local f32 count
+000001b: 03                                         ; type f32
+0000015: 03                                         ; local decl count
+000001c: 0e                                         ; OPCODE_GET_LOCAL
+000001d: 00                                         ; remapped local index
+000001e: 0e                                         ; OPCODE_GET_LOCAL
+000001f: 01                                         ; remapped local index
+0000020: 0e                                         ; OPCODE_GET_LOCAL
+0000021: 03                                         ; remapped local index
+0000022: 0e                                         ; OPCODE_GET_LOCAL
+0000023: 04                                         ; remapped local index
+0000024: 0e                                         ; OPCODE_GET_LOCAL
+0000025: 02                                         ; remapped local index
+0000026: 0e                                         ; OPCODE_GET_LOCAL
+0000027: 05                                         ; remapped local index
+0000013: 1300                                       ; FIXUP func body size
+0000028: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0200 0103 0201  
-0000010: 0400 0001 0001 0002 0000 000c 000e 000e  
-0000020: 010e 030e 040e 020e 0506                 
+0000010: 0000 0013 0003 0101 0102 0203 0e00 0e01  
+0000020: 0e03 0e04 0e02 0e05 06                   
 ;;; STDOUT ;;)

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -28,16 +28,15 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 00                                         ; local decl count
-0000014: 02                                         ; local i32 count
-0000015: 01                                         ; type i32
-0000016: 02                                         ; local i64 count
-0000017: 02                                         ; type i64
-0000018: 02                                         ; local f32 count
-0000019: 03                                         ; type f32
-000001a: 02                                         ; local f64 count
-000001b: 04                                         ; type f64
 0000013: 04                                         ; local decl count
+0000014: 02                                         ; local i32 count
+0000015: 01                                         ; WASM_TYPE_I32
+0000016: 02                                         ; local i64 count
+0000017: 02                                         ; WASM_TYPE_I64
+0000018: 02                                         ; local f32 count
+0000019: 03                                         ; WASM_TYPE_F32
+000001a: 02                                         ; local f64 count
+000001b: 04                                         ; WASM_TYPE_F64
 000001c: 0e                                         ; OPCODE_GET_LOCAL
 000001d: 06                                         ; remapped local index
 000001e: 0e                                         ; OPCODE_GET_LOCAL

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -25,33 +25,39 @@
 000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
 000000d: 01                                         ; num functions
 ; function 0
-000000e: 04                                         ; func flags
+000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
-0000011: 0200                                       ; num local i32
-0000013: 0200                                       ; num local i64
-0000015: 0200                                       ; num local f32
-0000017: 0200                                       ; num local f64
-0000019: 0000                                       ; func body size
-000001b: 0e                                         ; OPCODE_GET_LOCAL
-000001c: 06                                         ; remapped local index
-000001d: 0e                                         ; OPCODE_GET_LOCAL
-000001e: 04                                         ; remapped local index
-000001f: 0e                                         ; OPCODE_GET_LOCAL
-0000020: 02                                         ; remapped local index
-0000021: 0e                                         ; OPCODE_GET_LOCAL
-0000022: 00                                         ; remapped local index
-0000023: 0e                                         ; OPCODE_GET_LOCAL
-0000024: 01                                         ; remapped local index
-0000025: 0e                                         ; OPCODE_GET_LOCAL
-0000026: 05                                         ; remapped local index
-0000027: 0e                                         ; OPCODE_GET_LOCAL
-0000028: 07                                         ; remapped local index
-0000029: 0e                                         ; OPCODE_GET_LOCAL
-000002a: 03                                         ; remapped local index
-0000019: 1000                                       ; FIXUP func body size
-000002b: 06                                         ; WASM_BINARY_SECTION_END
+0000011: 0000                                       ; func body size
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; local i32 count
+0000015: 01                                         ; type i32
+0000016: 02                                         ; local i64 count
+0000017: 02                                         ; type i64
+0000018: 02                                         ; local f32 count
+0000019: 03                                         ; type f32
+000001a: 02                                         ; local f64 count
+000001b: 04                                         ; type f64
+0000013: 04                                         ; local decl count
+000001c: 0e                                         ; OPCODE_GET_LOCAL
+000001d: 06                                         ; remapped local index
+000001e: 0e                                         ; OPCODE_GET_LOCAL
+000001f: 04                                         ; remapped local index
+0000020: 0e                                         ; OPCODE_GET_LOCAL
+0000021: 02                                         ; remapped local index
+0000022: 0e                                         ; OPCODE_GET_LOCAL
+0000023: 00                                         ; remapped local index
+0000024: 0e                                         ; OPCODE_GET_LOCAL
+0000025: 01                                         ; remapped local index
+0000026: 0e                                         ; OPCODE_GET_LOCAL
+0000027: 05                                         ; remapped local index
+0000028: 0e                                         ; OPCODE_GET_LOCAL
+0000029: 07                                         ; remapped local index
+000002a: 0e                                         ; OPCODE_GET_LOCAL
+000002b: 03                                         ; remapped local index
+0000011: 1900                                       ; FIXUP func body size
+000002c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0061 736d 0a00 0000 0101 0000 0201 0400  
-0000010: 0002 0002 0002 0002 0010 000e 060e 040e  
-0000020: 020e 000e 010e 050e 070e 0306            
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0019 0004 0201 0202 0203 0204 0e06 0e04  
+0000020: 0e02 0e00 0e01 0e05 0e07 0e03 06         
 ;;; STDOUT ;;)

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -23,7 +23,6 @@
 0000014: 0000                                       ; func signature index
 0000016: 0000                                       ; func body size
 0000018: 00                                         ; local decl count
-0000018: 00                                         ; local decl count
 0000019: 39                                         ; OPCODE_GROW_MEMORY
 000001a: 0e                                         ; OPCODE_GET_LOCAL
 000001b: 00                                         ; remapped local index

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -22,12 +22,14 @@
 0000013: 00                                         ; func flags
 0000014: 0000                                       ; func signature index
 0000016: 0000                                       ; func body size
-0000018: 39                                         ; OPCODE_GROW_MEMORY
-0000019: 0e                                         ; OPCODE_GET_LOCAL
-000001a: 00                                         ; remapped local index
-0000016: 0300                                       ; FIXUP func body size
-000001b: 06                                         ; WASM_BINARY_SECTION_END
+0000018: 00                                         ; local decl count
+0000018: 00                                         ; local decl count
+0000019: 39                                         ; OPCODE_GROW_MEMORY
+000001a: 0e                                         ; OPCODE_GET_LOCAL
+000001b: 00                                         ; remapped local index
+0000016: 0400                                       ; FIXUP func body size
+000001c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0001 0201 0101 0100  
-0000010: 0102 0100 0000 0300 390e 0006            
+0000010: 0102 0100 0000 0400 0039 0e00 06         
 ;;; STDOUT ;;)

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -18,25 +18,27 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 04                                         ; OPCODE_IF_THEN
-0000014: 0a                                         ; OPCODE_I32_CONST
-0000015: 01                                         ; i32 literal
-0000016: 01                                         ; OPCODE_BLOCK
-0000017: 02                                         ; num expressions
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 02                                         ; i32 literal
-000001a: 0a                                         ; OPCODE_I32_CONST
-000001b: 03                                         ; i32 literal
-000001c: 01                                         ; OPCODE_BLOCK
-000001d: 02                                         ; num expressions
-000001e: 0a                                         ; OPCODE_I32_CONST
-000001f: 04                                         ; i32 literal
-0000020: 0a                                         ; OPCODE_I32_CONST
-0000021: 05                                         ; i32 literal
-0000011: 0f00                                       ; FIXUP func body size
-0000022: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 04                                         ; OPCODE_IF_THEN
+0000015: 0a                                         ; OPCODE_I32_CONST
+0000016: 01                                         ; i32 literal
+0000017: 01                                         ; OPCODE_BLOCK
+0000018: 02                                         ; num expressions
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 02                                         ; i32 literal
+000001b: 0a                                         ; OPCODE_I32_CONST
+000001c: 03                                         ; i32 literal
+000001d: 01                                         ; OPCODE_BLOCK
+000001e: 02                                         ; num expressions
+000001f: 0a                                         ; OPCODE_I32_CONST
+0000020: 04                                         ; i32 literal
+0000021: 0a                                         ; OPCODE_I32_CONST
+0000022: 05                                         ; i32 literal
+0000011: 1000                                       ; FIXUP func body size
+0000023: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 000f 0004 0a01 0102 0a02 0a03 0102 0a04  
-0000020: 0a05 06                                  
+0000010: 0010 0000 040a 0101 020a 020a 0301 020a  
+0000020: 040a 0506                                
 ;;; STDOUT ;;)

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -19,7 +19,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 04                                         ; OPCODE_IF_THEN
 0000015: 0a                                         ; OPCODE_I32_CONST
 0000016: 01                                         ; i32 literal

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -18,7 +18,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 03                                         ; OPCODE_IF
 0000015: 0a                                         ; OPCODE_I32_CONST
 0000016: 01                                         ; i32 literal

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -17,16 +17,18 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 03                                         ; OPCODE_IF
-0000014: 0a                                         ; OPCODE_I32_CONST
-0000015: 01                                         ; i32 literal
-0000016: 01                                         ; OPCODE_BLOCK
-0000017: 02                                         ; num expressions
-0000018: 00                                         ; OPCODE_NOP
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 03                                         ; OPCODE_IF
+0000015: 0a                                         ; OPCODE_I32_CONST
+0000016: 01                                         ; i32 literal
+0000017: 01                                         ; OPCODE_BLOCK
+0000018: 02                                         ; num expressions
 0000019: 00                                         ; OPCODE_NOP
-0000011: 0700                                       ; FIXUP func body size
-000001a: 06                                         ; WASM_BINARY_SECTION_END
+000001a: 00                                         ; OPCODE_NOP
+0000011: 0800                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0007 0003 0a01 0102 0000 06              
+0000010: 0008 0000 030a 0101 0200 0006            
 ;;; STDOUT ;;)

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -19,42 +19,46 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 03                                         ; OPCODE_IF
-0000014: 0a                                         ; OPCODE_I32_CONST
-0000015: 01                                         ; i32 literal
-0000016: 01                                         ; OPCODE_BLOCK
-0000017: 01                                         ; num expressions
-0000018: 00                                         ; OPCODE_NOP
-0000019: 04                                         ; OPCODE_IF_THEN
-000001a: 0a                                         ; OPCODE_I32_CONST
-000001b: 00                                         ; i32 literal
-000001c: 01                                         ; OPCODE_BLOCK
-000001d: 01                                         ; num expressions
-000001e: 0d                                         ; OPCODE_F32_CONST
-000001f: 0000 803f                                  ; f32 literal
-0000023: 01                                         ; OPCODE_BLOCK
-0000024: 01                                         ; num expressions
-0000025: 0d                                         ; OPCODE_F32_CONST
-0000026: 0000 0040                                  ; f32 literal
-0000011: 1700                                       ; FIXUP func body size
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 03                                         ; OPCODE_IF
+0000015: 0a                                         ; OPCODE_I32_CONST
+0000016: 01                                         ; i32 literal
+0000017: 01                                         ; OPCODE_BLOCK
+0000018: 01                                         ; num expressions
+0000019: 00                                         ; OPCODE_NOP
+000001a: 04                                         ; OPCODE_IF_THEN
+000001b: 0a                                         ; OPCODE_I32_CONST
+000001c: 00                                         ; i32 literal
+000001d: 01                                         ; OPCODE_BLOCK
+000001e: 01                                         ; num expressions
+000001f: 0d                                         ; OPCODE_F32_CONST
+0000020: 0000 803f                                  ; f32 literal
+0000024: 01                                         ; OPCODE_BLOCK
+0000025: 01                                         ; num expressions
+0000026: 0d                                         ; OPCODE_F32_CONST
+0000027: 0000 0040                                  ; f32 literal
+0000011: 1800                                       ; FIXUP func body size
 ; function 1
-000002a: 00                                         ; func flags
-000002b: 0000                                       ; func signature index
-000002d: 0000                                       ; func body size
-000002f: 04                                         ; OPCODE_IF_THEN
-0000030: 0a                                         ; OPCODE_I32_CONST
-0000031: 01                                         ; i32 literal
-0000032: 01                                         ; OPCODE_BLOCK
-0000033: 01                                         ; num expressions
-0000034: 14                                         ; OPCODE_RETURN
-0000035: 01                                         ; OPCODE_BLOCK
-0000036: 01                                         ; num expressions
-0000037: 14                                         ; OPCODE_RETURN
-000002d: 0900                                       ; FIXUP func body size
-0000038: 06                                         ; WASM_BINARY_SECTION_END
+000002b: 00                                         ; func flags
+000002c: 0000                                       ; func signature index
+000002e: 0000                                       ; func body size
+0000030: 00                                         ; local decl count
+0000030: 00                                         ; local decl count
+0000031: 04                                         ; OPCODE_IF_THEN
+0000032: 0a                                         ; OPCODE_I32_CONST
+0000033: 01                                         ; i32 literal
+0000034: 01                                         ; OPCODE_BLOCK
+0000035: 01                                         ; num expressions
+0000036: 14                                         ; OPCODE_RETURN
+0000037: 01                                         ; OPCODE_BLOCK
+0000038: 01                                         ; num expressions
+0000039: 14                                         ; OPCODE_RETURN
+000002e: 0a00                                       ; FIXUP func body size
+000003a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0202 0000  
-0000010: 0017 0003 0a01 0101 0004 0a00 0101 0d00  
-0000020: 0080 3f01 010d 0000 0040 0000 0009 0004  
-0000030: 0a01 0101 1401 0114 06                   
+0000010: 0018 0000 030a 0101 0100 040a 0001 010d  
+0000020: 0000 803f 0101 0d00 0000 4000 0000 0a00  
+0000030: 0004 0a01 0101 1401 0114 06              
 ;;; STDOUT ;;)

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -20,7 +20,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 03                                         ; OPCODE_IF
 0000015: 0a                                         ; OPCODE_I32_CONST
 0000016: 01                                         ; i32 literal
@@ -43,7 +42,6 @@
 000002b: 00                                         ; func flags
 000002c: 0000                                       ; func signature index
 000002e: 0000                                       ; func body size
-0000030: 00                                         ; local decl count
 0000030: 00                                         ; local decl count
 0000031: 04                                         ; OPCODE_IF_THEN
 0000032: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -49,128 +49,130 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-0000014: 00                                         ; load access byte
-0000015: 0a                                         ; OPCODE_I32_CONST
-0000016: 00                                         ; i32 literal
-0000017: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-0000018: 00                                         ; load access byte
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-000001b: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-000001c: 00                                         ; load access byte
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 00                                         ; i32 literal
-000001f: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-0000020: 00                                         ; load access byte
-0000021: 0a                                         ; OPCODE_I32_CONST
-0000022: 00                                         ; i32 literal
-0000023: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-0000024: 80                                         ; load access byte
-0000025: 0a                                         ; OPCODE_I32_CONST
-0000026: 00                                         ; i32 literal
-0000027: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-0000028: 00                                         ; load access byte
-0000029: 0a                                         ; OPCODE_I32_CONST
-000002a: 00                                         ; i32 literal
-000002b: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-000002c: 00                                         ; load access byte
-000002d: 0a                                         ; OPCODE_I32_CONST
-000002e: 00                                         ; i32 literal
-000002f: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-0000030: 00                                         ; load access byte
-0000031: 0a                                         ; OPCODE_I32_CONST
-0000032: 00                                         ; i32 literal
-0000033: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000034: 80                                         ; load access byte
-0000035: 0a                                         ; OPCODE_I32_CONST
-0000036: 00                                         ; i32 literal
-0000037: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000038: 80                                         ; load access byte
-0000039: 0a                                         ; OPCODE_I32_CONST
-000003a: 00                                         ; i32 literal
-000003b: 2a                                         ; OPCODE_I32_LOAD_MEM
-000003c: 00                                         ; load access byte
-000003d: 0a                                         ; OPCODE_I32_CONST
-000003e: 00                                         ; i32 literal
-000003f: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000040: 00                                         ; load access byte
-0000041: 0a                                         ; OPCODE_I32_CONST
-0000042: 00                                         ; i32 literal
-0000043: 2b                                         ; OPCODE_I64_LOAD_MEM
-0000044: 80                                         ; load access byte
-0000045: 0a                                         ; OPCODE_I32_CONST
-0000046: 00                                         ; i32 literal
-0000047: 2b                                         ; OPCODE_I64_LOAD_MEM
-0000048: 80                                         ; load access byte
-0000049: 0a                                         ; OPCODE_I32_CONST
-000004a: 00                                         ; i32 literal
-000004b: 2b                                         ; OPCODE_I64_LOAD_MEM
-000004c: 80                                         ; load access byte
-000004d: 0a                                         ; OPCODE_I32_CONST
-000004e: 00                                         ; i32 literal
-000004f: 2b                                         ; OPCODE_I64_LOAD_MEM
-0000050: 00                                         ; load access byte
-0000051: 0a                                         ; OPCODE_I32_CONST
-0000052: 00                                         ; i32 literal
-0000053: 24                                         ; OPCODE_I64_LOAD_MEM8_S
-0000054: 00                                         ; load access byte
-0000055: 0a                                         ; OPCODE_I32_CONST
-0000056: 00                                         ; i32 literal
-0000057: 24                                         ; OPCODE_I64_LOAD_MEM8_S
-0000058: 00                                         ; load access byte
-0000059: 0a                                         ; OPCODE_I32_CONST
-000005a: 00                                         ; i32 literal
-000005b: 24                                         ; OPCODE_I64_LOAD_MEM8_S
-000005c: 00                                         ; load access byte
-000005d: 0a                                         ; OPCODE_I32_CONST
-000005e: 00                                         ; i32 literal
-000005f: 24                                         ; OPCODE_I64_LOAD_MEM8_S
-0000060: 00                                         ; load access byte
-0000061: 0a                                         ; OPCODE_I32_CONST
-0000062: 00                                         ; i32 literal
-0000063: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-0000064: 80                                         ; load access byte
-0000065: 0a                                         ; OPCODE_I32_CONST
-0000066: 00                                         ; i32 literal
-0000067: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-0000068: 00                                         ; load access byte
-0000069: 0a                                         ; OPCODE_I32_CONST
-000006a: 00                                         ; i32 literal
-000006b: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-000006c: 00                                         ; load access byte
-000006d: 0a                                         ; OPCODE_I32_CONST
-000006e: 00                                         ; i32 literal
-000006f: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-0000070: 00                                         ; load access byte
-0000071: 0a                                         ; OPCODE_I32_CONST
-0000072: 00                                         ; i32 literal
-0000073: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000074: 80                                         ; load access byte
-0000075: 0a                                         ; OPCODE_I32_CONST
-0000076: 00                                         ; i32 literal
-0000077: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000078: 80                                         ; load access byte
-0000079: 0a                                         ; OPCODE_I32_CONST
-000007a: 00                                         ; i32 literal
-000007b: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-000007c: 00                                         ; load access byte
-000007d: 0a                                         ; OPCODE_I32_CONST
-000007e: 00                                         ; i32 literal
-000007f: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000080: 00                                         ; load access byte
-0000081: 0a                                         ; OPCODE_I32_CONST
-0000082: 00                                         ; i32 literal
-0000011: 7000                                       ; FIXUP func body size
-0000083: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 20                                         ; OPCODE_I32_LOAD_MEM8_S
+0000015: 00                                         ; load access byte
+0000016: 0a                                         ; OPCODE_I32_CONST
+0000017: 00                                         ; i32 literal
+0000018: 20                                         ; OPCODE_I32_LOAD_MEM8_S
+0000019: 00                                         ; load access byte
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+000001c: 20                                         ; OPCODE_I32_LOAD_MEM8_S
+000001d: 00                                         ; load access byte
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: 20                                         ; OPCODE_I32_LOAD_MEM8_S
+0000021: 00                                         ; load access byte
+0000022: 0a                                         ; OPCODE_I32_CONST
+0000023: 00                                         ; i32 literal
+0000024: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+0000025: 80                                         ; load access byte
+0000026: 0a                                         ; OPCODE_I32_CONST
+0000027: 00                                         ; i32 literal
+0000028: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+0000029: 00                                         ; load access byte
+000002a: 0a                                         ; OPCODE_I32_CONST
+000002b: 00                                         ; i32 literal
+000002c: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+000002d: 00                                         ; load access byte
+000002e: 0a                                         ; OPCODE_I32_CONST
+000002f: 00                                         ; i32 literal
+0000030: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+0000031: 00                                         ; load access byte
+0000032: 0a                                         ; OPCODE_I32_CONST
+0000033: 00                                         ; i32 literal
+0000034: 2a                                         ; OPCODE_I32_LOAD_MEM
+0000035: 80                                         ; load access byte
+0000036: 0a                                         ; OPCODE_I32_CONST
+0000037: 00                                         ; i32 literal
+0000038: 2a                                         ; OPCODE_I32_LOAD_MEM
+0000039: 80                                         ; load access byte
+000003a: 0a                                         ; OPCODE_I32_CONST
+000003b: 00                                         ; i32 literal
+000003c: 2a                                         ; OPCODE_I32_LOAD_MEM
+000003d: 00                                         ; load access byte
+000003e: 0a                                         ; OPCODE_I32_CONST
+000003f: 00                                         ; i32 literal
+0000040: 2a                                         ; OPCODE_I32_LOAD_MEM
+0000041: 00                                         ; load access byte
+0000042: 0a                                         ; OPCODE_I32_CONST
+0000043: 00                                         ; i32 literal
+0000044: 2b                                         ; OPCODE_I64_LOAD_MEM
+0000045: 80                                         ; load access byte
+0000046: 0a                                         ; OPCODE_I32_CONST
+0000047: 00                                         ; i32 literal
+0000048: 2b                                         ; OPCODE_I64_LOAD_MEM
+0000049: 80                                         ; load access byte
+000004a: 0a                                         ; OPCODE_I32_CONST
+000004b: 00                                         ; i32 literal
+000004c: 2b                                         ; OPCODE_I64_LOAD_MEM
+000004d: 80                                         ; load access byte
+000004e: 0a                                         ; OPCODE_I32_CONST
+000004f: 00                                         ; i32 literal
+0000050: 2b                                         ; OPCODE_I64_LOAD_MEM
+0000051: 00                                         ; load access byte
+0000052: 0a                                         ; OPCODE_I32_CONST
+0000053: 00                                         ; i32 literal
+0000054: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+0000055: 00                                         ; load access byte
+0000056: 0a                                         ; OPCODE_I32_CONST
+0000057: 00                                         ; i32 literal
+0000058: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+0000059: 00                                         ; load access byte
+000005a: 0a                                         ; OPCODE_I32_CONST
+000005b: 00                                         ; i32 literal
+000005c: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+000005d: 00                                         ; load access byte
+000005e: 0a                                         ; OPCODE_I32_CONST
+000005f: 00                                         ; i32 literal
+0000060: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+0000061: 00                                         ; load access byte
+0000062: 0a                                         ; OPCODE_I32_CONST
+0000063: 00                                         ; i32 literal
+0000064: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+0000065: 80                                         ; load access byte
+0000066: 0a                                         ; OPCODE_I32_CONST
+0000067: 00                                         ; i32 literal
+0000068: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+0000069: 00                                         ; load access byte
+000006a: 0a                                         ; OPCODE_I32_CONST
+000006b: 00                                         ; i32 literal
+000006c: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+000006d: 00                                         ; load access byte
+000006e: 0a                                         ; OPCODE_I32_CONST
+000006f: 00                                         ; i32 literal
+0000070: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+0000071: 00                                         ; load access byte
+0000072: 0a                                         ; OPCODE_I32_CONST
+0000073: 00                                         ; i32 literal
+0000074: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+0000075: 80                                         ; load access byte
+0000076: 0a                                         ; OPCODE_I32_CONST
+0000077: 00                                         ; i32 literal
+0000078: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+0000079: 80                                         ; load access byte
+000007a: 0a                                         ; OPCODE_I32_CONST
+000007b: 00                                         ; i32 literal
+000007c: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+000007d: 00                                         ; load access byte
+000007e: 0a                                         ; OPCODE_I32_CONST
+000007f: 00                                         ; i32 literal
+0000080: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+0000081: 00                                         ; load access byte
+0000082: 0a                                         ; OPCODE_I32_CONST
+0000083: 00                                         ; i32 literal
+0000011: 7100                                       ; FIXUP func body size
+0000084: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0070 0020 000a 0020 000a 0020 000a 0020  
-0000020: 000a 0022 800a 0022 000a 0022 000a 0022  
-0000030: 000a 002a 800a 002a 800a 002a 000a 002a  
-0000040: 000a 002b 800a 002b 800a 002b 800a 002b  
-0000050: 000a 0024 000a 0024 000a 0024 000a 0024  
-0000060: 000a 0026 800a 0026 000a 0026 000a 0026  
-0000070: 000a 0028 800a 0028 800a 0028 000a 0028  
-0000080: 000a 0006                                
+0000010: 0071 0000 2000 0a00 2000 0a00 2000 0a00  
+0000020: 2000 0a00 2280 0a00 2200 0a00 2200 0a00  
+0000030: 2200 0a00 2a80 0a00 2a80 0a00 2a00 0a00  
+0000040: 2a00 0a00 2b80 0a00 2b80 0a00 2b80 0a00  
+0000050: 2b00 0a00 2400 0a00 2400 0a00 2400 0a00  
+0000060: 2400 0a00 2680 0a00 2600 0a00 2600 0a00  
+0000070: 2600 0a00 2880 0a00 2880 0a00 2800 0a00  
+0000080: 2800 0a00 06                             
 ;;; STDOUT ;;)

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -50,7 +50,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 20                                         ; OPCODE_I32_LOAD_MEM8_S
 0000015: 00                                         ; load access byte
 0000016: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -30,7 +30,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 2a                                         ; OPCODE_I32_LOAD_MEM
 0000015: 00                                         ; load access byte
 0000016: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -29,68 +29,70 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 2a                                         ; OPCODE_I32_LOAD_MEM
-0000014: 00                                         ; load access byte
-0000015: 0a                                         ; OPCODE_I32_CONST
-0000016: 00                                         ; i32 literal
-0000017: 20                                         ; OPCODE_I32_LOAD_MEM8_S
-0000018: 00                                         ; load access byte
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-000001b: 22                                         ; OPCODE_I32_LOAD_MEM16_S
-000001c: 00                                         ; load access byte
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 00                                         ; i32 literal
-000001f: 21                                         ; OPCODE_I32_LOAD_MEM8_U
-0000020: 00                                         ; load access byte
-0000021: 0a                                         ; OPCODE_I32_CONST
-0000022: 00                                         ; i32 literal
-0000023: 23                                         ; OPCODE_I32_LOAD_MEM16_U
-0000024: 00                                         ; load access byte
-0000025: 0a                                         ; OPCODE_I32_CONST
-0000026: 00                                         ; i32 literal
-0000027: 2b                                         ; OPCODE_I64_LOAD_MEM
-0000028: 00                                         ; load access byte
-0000029: 0a                                         ; OPCODE_I32_CONST
-000002a: 00                                         ; i32 literal
-000002b: 24                                         ; OPCODE_I64_LOAD_MEM8_S
-000002c: 00                                         ; load access byte
-000002d: 0a                                         ; OPCODE_I32_CONST
-000002e: 00                                         ; i32 literal
-000002f: 26                                         ; OPCODE_I64_LOAD_MEM16_S
-0000030: 00                                         ; load access byte
-0000031: 0a                                         ; OPCODE_I32_CONST
-0000032: 00                                         ; i32 literal
-0000033: 28                                         ; OPCODE_I64_LOAD_MEM32_S
-0000034: 00                                         ; load access byte
-0000035: 0a                                         ; OPCODE_I32_CONST
-0000036: 00                                         ; i32 literal
-0000037: 25                                         ; OPCODE_I64_LOAD_MEM8_U
-0000038: 00                                         ; load access byte
-0000039: 0a                                         ; OPCODE_I32_CONST
-000003a: 00                                         ; i32 literal
-000003b: 27                                         ; OPCODE_I64_LOAD_MEM16_U
-000003c: 00                                         ; load access byte
-000003d: 0a                                         ; OPCODE_I32_CONST
-000003e: 00                                         ; i32 literal
-000003f: 29                                         ; OPCODE_I64_LOAD_MEM32_U
-0000040: 00                                         ; load access byte
-0000041: 0a                                         ; OPCODE_I32_CONST
-0000042: 00                                         ; i32 literal
-0000043: 2c                                         ; OPCODE_F32_LOAD_MEM
-0000044: 00                                         ; load access byte
-0000045: 0a                                         ; OPCODE_I32_CONST
-0000046: 00                                         ; i32 literal
-0000047: 2d                                         ; OPCODE_F64_LOAD_MEM
-0000048: 00                                         ; load access byte
-0000049: 0a                                         ; OPCODE_I32_CONST
-000004a: 00                                         ; i32 literal
-0000011: 3800                                       ; FIXUP func body size
-000004b: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 2a                                         ; OPCODE_I32_LOAD_MEM
+0000015: 00                                         ; load access byte
+0000016: 0a                                         ; OPCODE_I32_CONST
+0000017: 00                                         ; i32 literal
+0000018: 20                                         ; OPCODE_I32_LOAD_MEM8_S
+0000019: 00                                         ; load access byte
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+000001c: 22                                         ; OPCODE_I32_LOAD_MEM16_S
+000001d: 00                                         ; load access byte
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: 21                                         ; OPCODE_I32_LOAD_MEM8_U
+0000021: 00                                         ; load access byte
+0000022: 0a                                         ; OPCODE_I32_CONST
+0000023: 00                                         ; i32 literal
+0000024: 23                                         ; OPCODE_I32_LOAD_MEM16_U
+0000025: 00                                         ; load access byte
+0000026: 0a                                         ; OPCODE_I32_CONST
+0000027: 00                                         ; i32 literal
+0000028: 2b                                         ; OPCODE_I64_LOAD_MEM
+0000029: 00                                         ; load access byte
+000002a: 0a                                         ; OPCODE_I32_CONST
+000002b: 00                                         ; i32 literal
+000002c: 24                                         ; OPCODE_I64_LOAD_MEM8_S
+000002d: 00                                         ; load access byte
+000002e: 0a                                         ; OPCODE_I32_CONST
+000002f: 00                                         ; i32 literal
+0000030: 26                                         ; OPCODE_I64_LOAD_MEM16_S
+0000031: 00                                         ; load access byte
+0000032: 0a                                         ; OPCODE_I32_CONST
+0000033: 00                                         ; i32 literal
+0000034: 28                                         ; OPCODE_I64_LOAD_MEM32_S
+0000035: 00                                         ; load access byte
+0000036: 0a                                         ; OPCODE_I32_CONST
+0000037: 00                                         ; i32 literal
+0000038: 25                                         ; OPCODE_I64_LOAD_MEM8_U
+0000039: 00                                         ; load access byte
+000003a: 0a                                         ; OPCODE_I32_CONST
+000003b: 00                                         ; i32 literal
+000003c: 27                                         ; OPCODE_I64_LOAD_MEM16_U
+000003d: 00                                         ; load access byte
+000003e: 0a                                         ; OPCODE_I32_CONST
+000003f: 00                                         ; i32 literal
+0000040: 29                                         ; OPCODE_I64_LOAD_MEM32_U
+0000041: 00                                         ; load access byte
+0000042: 0a                                         ; OPCODE_I32_CONST
+0000043: 00                                         ; i32 literal
+0000044: 2c                                         ; OPCODE_F32_LOAD_MEM
+0000045: 00                                         ; load access byte
+0000046: 0a                                         ; OPCODE_I32_CONST
+0000047: 00                                         ; i32 literal
+0000048: 2d                                         ; OPCODE_F64_LOAD_MEM
+0000049: 00                                         ; load access byte
+000004a: 0a                                         ; OPCODE_I32_CONST
+000004b: 00                                         ; i32 literal
+0000011: 3900                                       ; FIXUP func body size
+000004c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0038 002a 000a 0020 000a 0022 000a 0021  
-0000020: 000a 0023 000a 002b 000a 0024 000a 0026  
-0000030: 000a 0028 000a 0025 000a 0027 000a 0029  
-0000040: 000a 002c 000a 002d 000a 0006            
+0000010: 0039 0000 2a00 0a00 2000 0a00 2200 0a00  
+0000020: 2100 0a00 2300 0a00 2b00 0a00 2400 0a00  
+0000030: 2600 0a00 2800 0a00 2500 0a00 2700 0a00  
+0000040: 2900 0a00 2c00 0a00 2d00 0a00 06         
 ;;; STDOUT ;;)

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -12,16 +12,22 @@
 000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
 000000d: 01                                         ; num functions
 ; function 0
-000000e: 04                                         ; func flags
+000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
-0000011: 0100                                       ; num local i32
-0000013: 0200                                       ; num local i64
-0000015: 0300                                       ; num local f32
-0000017: 0400                                       ; num local f64
-0000019: 0000                                       ; func body size
-0000019: 0000                                       ; FIXUP func body size
-000001b: 06                                         ; WASM_BINARY_SECTION_END
+0000011: 0000                                       ; func body size
+0000013: 00                                         ; local decl count
+0000014: 01                                         ; local i32 count
+0000015: 01                                         ; type i32
+0000016: 02                                         ; local i64 count
+0000017: 02                                         ; type i64
+0000018: 03                                         ; local f32 count
+0000019: 03                                         ; type f32
+000001a: 04                                         ; local f64 count
+000001b: 04                                         ; type f64
+0000013: 04                                         ; local decl count
+0000011: 0900                                       ; FIXUP func body size
+000001c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0061 736d 0a00 0000 0101 0000 0201 0400  
-0000010: 0001 0002 0003 0004 0000 0006            
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 0009 0004 0101 0202 0303 0404 06         
 ;;; STDOUT ;;)

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -15,16 +15,15 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 00                                         ; local decl count
-0000014: 01                                         ; local i32 count
-0000015: 01                                         ; type i32
-0000016: 02                                         ; local i64 count
-0000017: 02                                         ; type i64
-0000018: 03                                         ; local f32 count
-0000019: 03                                         ; type f32
-000001a: 04                                         ; local f64 count
-000001b: 04                                         ; type f64
 0000013: 04                                         ; local decl count
+0000014: 01                                         ; local i32 count
+0000015: 01                                         ; WASM_TYPE_I32
+0000016: 02                                         ; local i64 count
+0000017: 02                                         ; WASM_TYPE_I64
+0000018: 03                                         ; local f32 count
+0000019: 03                                         ; WASM_TYPE_F32
+000001a: 04                                         ; local f64 count
+000001b: 04                                         ; WASM_TYPE_F64
 0000011: 0900                                       ; FIXUP func body size
 000001c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -62,11 +62,12 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 02                                         ; num expressions (byte 1)
-0000015: 01                                         ; OPCODE_BLOCK
-0000016: ff                                         ; num expressions (byte 0)
-0000017: 00                                         ; OPCODE_NOP
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 02                                         ; num expressions (byte 1)
+0000016: 01                                         ; OPCODE_BLOCK
+0000017: ff                                         ; num expressions (byte 0)
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
 000001a: 00                                         ; OPCODE_NOP
@@ -321,26 +322,27 @@
 0000113: 00                                         ; OPCODE_NOP
 0000114: 00                                         ; OPCODE_NOP
 0000115: 00                                         ; OPCODE_NOP
-0000116: 01                                         ; OPCODE_BLOCK
-0000117: 05                                         ; num expressions (byte 0)
-0000118: 00                                         ; OPCODE_NOP
-0000119: 06                                         ; OPCODE_BR
-000011a: 02                                         ; break depth
-000011b: 00                                         ; OPCODE_NOP
-000011c: 06                                         ; OPCODE_BR
-000011d: 01                                         ; break depth
-000011e: 00                                         ; OPCODE_NOP
-000011f: 06                                         ; OPCODE_BR
-0000120: 02                                         ; break depth
-0000121: 00                                         ; OPCODE_NOP
-0000122: 06                                         ; OPCODE_BR
-0000123: 01                                         ; break depth
-0000124: 00                                         ; OPCODE_NOP
-0000011: 1201                                       ; FIXUP func body size
-0000125: 06                                         ; WASM_BINARY_SECTION_END
+0000116: 00                                         ; OPCODE_NOP
+0000117: 01                                         ; OPCODE_BLOCK
+0000118: 05                                         ; num expressions (byte 0)
+0000119: 00                                         ; OPCODE_NOP
+000011a: 06                                         ; OPCODE_BR
+000011b: 02                                         ; break depth
+000011c: 00                                         ; OPCODE_NOP
+000011d: 06                                         ; OPCODE_BR
+000011e: 01                                         ; break depth
+000011f: 00                                         ; OPCODE_NOP
+0000120: 06                                         ; OPCODE_BR
+0000121: 02                                         ; break depth
+0000122: 00                                         ; OPCODE_NOP
+0000123: 06                                         ; OPCODE_BR
+0000124: 01                                         ; break depth
+0000125: 00                                         ; OPCODE_NOP
+0000011: 1301                                       ; FIXUP func body size
+0000126: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0012 0102 0201 ff00 0000 0000 0000 0000  
+0000010: 0013 0100 0202 01ff 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -356,6 +358,6 @@
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000110: 0000 0000 0000 0105 0006 0200 0601 0006  
-0000120: 0200 0601 0006                           
+0000110: 0000 0000 0000 0001 0500 0602 0006 0100  
+0000120: 0602 0006 0100 06                        
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -63,7 +63,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 02                                         ; num expressions (byte 1)
 0000016: 01                                         ; OPCODE_BLOCK

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -59,7 +59,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 02                                         ; num expressions (byte 1)
 0000016: 01                                         ; OPCODE_BLOCK

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -58,11 +58,12 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 02                                         ; num expressions (byte 1)
-0000015: 01                                         ; OPCODE_BLOCK
-0000016: ff                                         ; num expressions (byte 0)
-0000017: 00                                         ; OPCODE_NOP
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 02                                         ; num expressions (byte 1)
+0000016: 01                                         ; OPCODE_BLOCK
+0000017: ff                                         ; num expressions (byte 0)
 0000018: 00                                         ; OPCODE_NOP
 0000019: 00                                         ; OPCODE_NOP
 000001a: 00                                         ; OPCODE_NOP
@@ -317,15 +318,16 @@
 0000113: 00                                         ; OPCODE_NOP
 0000114: 00                                         ; OPCODE_NOP
 0000115: 00                                         ; OPCODE_NOP
-0000116: 01                                         ; OPCODE_BLOCK
-0000117: 02                                         ; num expressions (byte 0)
-0000118: 00                                         ; OPCODE_NOP
+0000116: 00                                         ; OPCODE_NOP
+0000117: 01                                         ; OPCODE_BLOCK
+0000118: 02                                         ; num expressions (byte 0)
 0000119: 00                                         ; OPCODE_NOP
-0000011: 0701                                       ; FIXUP func body size
-000011a: 06                                         ; WASM_BINARY_SECTION_END
+000011a: 00                                         ; OPCODE_NOP
+0000011: 0801                                       ; FIXUP func body size
+000011b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0007 0102 0201 ff00 0000 0000 0000 0000  
+0000010: 0008 0100 0202 01ff 0000 0000 0000 0000  
 0000020: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000030: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000040: 0000 0000 0000 0000 0000 0000 0000 0000  
@@ -341,5 +343,5 @@
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000110: 0000 0000 0000 0102 0000 06              
+0000110: 0000 0000 0000 0001 0200 0006            
 ;;; STDOUT ;;)

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -19,7 +19,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 02                                         ; num expressions
 0000016: 00                                         ; OPCODE_NOP

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -18,13 +18,15 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 02                                         ; OPCODE_LOOP
-0000014: 02                                         ; num expressions
-0000015: 00                                         ; OPCODE_NOP
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; OPCODE_LOOP
+0000015: 02                                         ; num expressions
 0000016: 00                                         ; OPCODE_NOP
-0000011: 0400                                       ; FIXUP func body size
-0000017: 06                                         ; WASM_BINARY_SECTION_END
+0000017: 00                                         ; OPCODE_NOP
+0000011: 0500                                       ; FIXUP func body size
+0000018: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0004 0002 0200 0006                      
+0000010: 0005 0000 0202 0000 06                   
 ;;; STDOUT ;;)

--- a/test/dump/memory-size.txt
+++ b/test/dump/memory-size.txt
@@ -21,10 +21,12 @@
 0000012: 00                                         ; func flags
 0000013: 0000                                       ; func signature index
 0000015: 0000                                       ; func body size
-0000017: 3b                                         ; OPCODE_MEMORY_SIZE
-0000015: 0100                                       ; FIXUP func body size
-0000018: 06                                         ; WASM_BINARY_SECTION_END
+0000017: 00                                         ; local decl count
+0000017: 00                                         ; local decl count
+0000018: 3b                                         ; OPCODE_MEMORY_SIZE
+0000015: 0200                                       ; FIXUP func body size
+0000019: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0001 0101 0101 0001  
-0000010: 0201 0000 0001 003b 06                   
+0000010: 0201 0000 0002 0000 3b06                 
 ;;; STDOUT ;;)

--- a/test/dump/memory-size.txt
+++ b/test/dump/memory-size.txt
@@ -22,7 +22,6 @@
 0000013: 0000                                       ; func signature index
 0000015: 0000                                       ; func body size
 0000017: 00                                         ; local decl count
-0000017: 00                                         ; local decl count
 0000018: 3b                                         ; OPCODE_MEMORY_SIZE
 0000015: 0200                                       ; FIXUP func body size
 0000019: 06                                         ; WASM_BINARY_SECTION_END

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -15,10 +15,12 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 00                                         ; OPCODE_NOP
-0000011: 0100                                       ; FIXUP func body size
-0000014: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 00                                         ; OPCODE_NOP
+0000011: 0200                                       ; FIXUP func body size
+0000015: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0001 0000 06                             
+0000010: 0002 0000 0006                           
 ;;; STDOUT ;;)

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -16,7 +16,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 00                                         ; OPCODE_NOP
 0000011: 0200                                       ; FIXUP func body size
 0000015: 06                                         ; WASM_BINARY_SECTION_END

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -20,7 +20,6 @@
 0000013: 0000                                       ; func signature index
 0000015: 0000                                       ; func body size
 0000017: 00                                         ; local decl count
-0000017: 00                                         ; local decl count
 0000015: 0100                                       ; FIXUP func body size
 0000018: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -19,9 +19,11 @@
 0000012: 00                                         ; func flags
 0000013: 0000                                       ; func signature index
 0000015: 0000                                       ; func body size
-0000015: 0000                                       ; FIXUP func body size
-0000017: 06                                         ; WASM_BINARY_SECTION_END
+0000017: 00                                         ; local decl count
+0000017: 00                                         ; local decl count
+0000015: 0100                                       ; FIXUP func body size
+0000018: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0400 0102 0304  
-0000010: 0201 0000 0000 0006                      
+0000010: 0201 0000 0001 0000 06                   
 ;;; STDOUT ;;)

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -28,7 +28,6 @@
 0000015: 0000                                       ; func signature index
 0000017: 0000                                       ; func body size
 0000019: 00                                         ; local decl count
-0000019: 00                                         ; local decl count
 000001a: 0a                                         ; OPCODE_I32_CONST
 000001b: 00                                         ; i32 literal
 0000017: 0300                                       ; FIXUP func body size
@@ -36,7 +35,6 @@
 000001c: 00                                         ; func flags
 000001d: 0100                                       ; func signature index
 000001f: 0000                                       ; func body size
-0000021: 00                                         ; local decl count
 0000021: 00                                         ; local decl count
 0000022: 0b                                         ; OPCODE_I64_CONST
 0000023: 00                                         ; i64 literal
@@ -46,7 +44,6 @@
 0000025: 0200                                       ; func signature index
 0000027: 0000                                       ; func body size
 0000029: 00                                         ; local decl count
-0000029: 00                                         ; local decl count
 000002a: 0d                                         ; OPCODE_F32_CONST
 000002b: 0000 0000                                  ; f32 literal
 0000027: 0600                                       ; FIXUP func body size
@@ -54,7 +51,6 @@
 000002f: 00                                         ; func flags
 0000030: 0300                                       ; func signature index
 0000032: 0000                                       ; func body size
-0000034: 00                                         ; local decl count
 0000034: 00                                         ; local decl count
 0000035: 0c                                         ; OPCODE_F64_CONST
 0000036: 0000 0000 0000 0000                        ; f64 literal

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -27,34 +27,42 @@
 0000014: 00                                         ; func flags
 0000015: 0000                                       ; func signature index
 0000017: 0000                                       ; func body size
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-0000017: 0200                                       ; FIXUP func body size
+0000019: 00                                         ; local decl count
+0000019: 00                                         ; local decl count
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+0000017: 0300                                       ; FIXUP func body size
 ; function 1
-000001b: 00                                         ; func flags
-000001c: 0100                                       ; func signature index
-000001e: 0000                                       ; func body size
-0000020: 0b                                         ; OPCODE_I64_CONST
-0000021: 00                                         ; i64 literal
-000001e: 0200                                       ; FIXUP func body size
+000001c: 00                                         ; func flags
+000001d: 0100                                       ; func signature index
+000001f: 0000                                       ; func body size
+0000021: 00                                         ; local decl count
+0000021: 00                                         ; local decl count
+0000022: 0b                                         ; OPCODE_I64_CONST
+0000023: 00                                         ; i64 literal
+000001f: 0300                                       ; FIXUP func body size
 ; function 2
-0000022: 00                                         ; func flags
-0000023: 0200                                       ; func signature index
-0000025: 0000                                       ; func body size
-0000027: 0d                                         ; OPCODE_F32_CONST
-0000028: 0000 0000                                  ; f32 literal
-0000025: 0500                                       ; FIXUP func body size
+0000024: 00                                         ; func flags
+0000025: 0200                                       ; func signature index
+0000027: 0000                                       ; func body size
+0000029: 00                                         ; local decl count
+0000029: 00                                         ; local decl count
+000002a: 0d                                         ; OPCODE_F32_CONST
+000002b: 0000 0000                                  ; f32 literal
+0000027: 0600                                       ; FIXUP func body size
 ; function 3
-000002c: 00                                         ; func flags
-000002d: 0300                                       ; func signature index
-000002f: 0000                                       ; func body size
-0000031: 0c                                         ; OPCODE_F64_CONST
-0000032: 0000 0000 0000 0000                        ; f64 literal
-000002f: 0900                                       ; FIXUP func body size
-000003a: 06                                         ; WASM_BINARY_SECTION_END
+000002f: 00                                         ; func flags
+0000030: 0300                                       ; func signature index
+0000032: 0000                                       ; func body size
+0000034: 00                                         ; local decl count
+0000034: 00                                         ; local decl count
+0000035: 0c                                         ; OPCODE_F64_CONST
+0000036: 0000 0000 0000 0000                        ; f64 literal
+0000032: 0a00                                       ; FIXUP func body size
+000003e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0104 0001 0002 0003  
-0000010: 0004 0204 0000 0002 000a 0000 0100 0200  
-0000020: 0b00 0002 0005 000d 0000 0000 0003 0009  
-0000030: 000c 0000 0000 0000 0000 06              
+0000010: 0004 0204 0000 0003 0000 0a00 0001 0003  
+0000020: 0000 0b00 0002 0006 0000 0d00 0000 0000  
+0000030: 0300 0a00 000c 0000 0000 0000 0000 06    
 ;;; STDOUT ;;)

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -20,18 +20,23 @@
 0000010: 00                                         ; func flags
 0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
-0000015: 14                                         ; OPCODE_RETURN
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 2a                                         ; i32 literal
-0000013: 0300                                       ; FIXUP func body size
+0000015: 00                                         ; local decl count
+0000015: 00                                         ; local decl count
+0000016: 14                                         ; OPCODE_RETURN
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 2a                                         ; i32 literal
+0000013: 0400                                       ; FIXUP func body size
 ; function 1
-0000018: 00                                         ; func flags
-0000019: 0100                                       ; func signature index
-000001b: 0000                                       ; func body size
-000001d: 14                                         ; OPCODE_RETURN
-000001b: 0100                                       ; FIXUP func body size
-000001e: 06                                         ; WASM_BINARY_SECTION_END
+0000019: 00                                         ; func flags
+000001a: 0100                                       ; func signature index
+000001c: 0000                                       ; func body size
+000001e: 00                                         ; local decl count
+000001e: 00                                         ; local decl count
+000001f: 14                                         ; OPCODE_RETURN
+000001c: 0200                                       ; FIXUP func body size
+0000020: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0102 0001 0000 0202  
-0000010: 0000 0003 0014 0a2a 0001 0001 0014 06    
+0000010: 0000 0004 0000 140a 2a00 0100 0200 0014  
+0000020: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -21,7 +21,6 @@
 0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
 0000015: 00                                         ; local decl count
-0000015: 00                                         ; local decl count
 0000016: 14                                         ; OPCODE_RETURN
 0000017: 0a                                         ; OPCODE_I32_CONST
 0000018: 2a                                         ; i32 literal
@@ -30,7 +29,6 @@
 0000019: 00                                         ; func flags
 000001a: 0100                                       ; func signature index
 000001c: 0000                                       ; func body size
-000001e: 00                                         ; local decl count
 000001e: 00                                         ; local decl count
 000001f: 14                                         ; OPCODE_RETURN
 000001c: 0200                                       ; FIXUP func body size

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -19,40 +19,42 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 05                                         ; OPCODE_SELECT
-0000014: 0a                                         ; OPCODE_I32_CONST
-0000015: 02                                         ; i32 literal
-0000016: 0a                                         ; OPCODE_I32_CONST
-0000017: 03                                         ; i32 literal
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 01                                         ; i32 literal
-000001a: 05                                         ; OPCODE_SELECT
-000001b: 0b                                         ; OPCODE_I64_CONST
-000001c: 02                                         ; i64 literal
-000001d: 0b                                         ; OPCODE_I64_CONST
-000001e: 03                                         ; i64 literal
-000001f: 0a                                         ; OPCODE_I32_CONST
-0000020: 01                                         ; i32 literal
-0000021: 05                                         ; OPCODE_SELECT
-0000022: 0d                                         ; OPCODE_F32_CONST
-0000023: 0000 0040                                  ; f32 literal
-0000027: 0d                                         ; OPCODE_F32_CONST
-0000028: 0000 4040                                  ; f32 literal
-000002c: 0a                                         ; OPCODE_I32_CONST
-000002d: 01                                         ; i32 literal
-000002e: 05                                         ; OPCODE_SELECT
-000002f: 0c                                         ; OPCODE_F64_CONST
-0000030: 0000 0000 0000 0040                        ; f64 literal
-0000038: 0c                                         ; OPCODE_F64_CONST
-0000039: 0000 0000 0000 0840                        ; f64 literal
-0000041: 0a                                         ; OPCODE_I32_CONST
-0000042: 01                                         ; i32 literal
-0000011: 3000                                       ; FIXUP func body size
-0000043: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 05                                         ; OPCODE_SELECT
+0000015: 0a                                         ; OPCODE_I32_CONST
+0000016: 02                                         ; i32 literal
+0000017: 0a                                         ; OPCODE_I32_CONST
+0000018: 03                                         ; i32 literal
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 01                                         ; i32 literal
+000001b: 05                                         ; OPCODE_SELECT
+000001c: 0b                                         ; OPCODE_I64_CONST
+000001d: 02                                         ; i64 literal
+000001e: 0b                                         ; OPCODE_I64_CONST
+000001f: 03                                         ; i64 literal
+0000020: 0a                                         ; OPCODE_I32_CONST
+0000021: 01                                         ; i32 literal
+0000022: 05                                         ; OPCODE_SELECT
+0000023: 0d                                         ; OPCODE_F32_CONST
+0000024: 0000 0040                                  ; f32 literal
+0000028: 0d                                         ; OPCODE_F32_CONST
+0000029: 0000 4040                                  ; f32 literal
+000002d: 0a                                         ; OPCODE_I32_CONST
+000002e: 01                                         ; i32 literal
+000002f: 05                                         ; OPCODE_SELECT
+0000030: 0c                                         ; OPCODE_F64_CONST
+0000031: 0000 0000 0000 0040                        ; f64 literal
+0000039: 0c                                         ; OPCODE_F64_CONST
+000003a: 0000 0000 0000 0840                        ; f64 literal
+0000042: 0a                                         ; OPCODE_I32_CONST
+0000043: 01                                         ; i32 literal
+0000011: 3100                                       ; FIXUP func body size
+0000044: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0030 0005 0a02 0a03 0a01 050b 020b 030a  
-0000020: 0105 0d00 0000 400d 0000 4040 0a01 050c  
-0000030: 0000 0000 0000 0040 0c00 0000 0000 0008  
-0000040: 400a 0106                                
+0000010: 0031 0000 050a 020a 030a 0105 0b02 0b03  
+0000020: 0a01 050d 0000 0040 0d00 0040 400a 0105  
+0000030: 0c00 0000 0000 0000 400c 0000 0000 0000  
+0000040: 0840 0a01 06                             
 ;;; STDOUT ;;)

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -20,7 +20,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 05                                         ; OPCODE_SELECT
 0000015: 0a                                         ; OPCODE_I32_CONST
 0000016: 02                                         ; i32 literal

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -28,14 +28,13 @@
 0000010: 00                                         ; func flags
 0000011: 0000                                       ; func signature index
 0000013: 0000                                       ; func body size
-0000015: 00                                         ; local decl count
-0000016: 01                                         ; local i32 count
-0000017: 01                                         ; type i32
-0000018: 01                                         ; local i64 count
-0000019: 02                                         ; type i64
-000001a: 02                                         ; local f32 count
-000001b: 03                                         ; type f32
 0000015: 03                                         ; local decl count
+0000016: 01                                         ; local i32 count
+0000017: 01                                         ; WASM_TYPE_I32
+0000018: 01                                         ; local i64 count
+0000019: 02                                         ; WASM_TYPE_I64
+000001a: 02                                         ; local f32 count
+000001b: 03                                         ; WASM_TYPE_F32
 000001c: 0f                                         ; OPCODE_SET_LOCAL
 000001d: 00                                         ; remapped local index
 000001e: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -25,42 +25,46 @@
 000000e: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
 000000f: 01                                         ; num functions
 ; function 0
-0000010: 04                                         ; func flags
+0000010: 00                                         ; func flags
 0000011: 0000                                       ; func signature index
-0000013: 0100                                       ; num local i32
-0000015: 0100                                       ; num local i64
-0000017: 0200                                       ; num local f32
-0000019: 0000                                       ; num local f64
-000001b: 0000                                       ; func body size
-000001d: 0f                                         ; OPCODE_SET_LOCAL
-000001e: 00                                         ; remapped local index
-000001f: 0a                                         ; OPCODE_I32_CONST
-0000020: 00                                         ; i32 literal
-0000021: 0f                                         ; OPCODE_SET_LOCAL
-0000022: 01                                         ; remapped local index
-0000023: 0d                                         ; OPCODE_F32_CONST
-0000024: 0000 0000                                  ; f32 literal
-0000028: 0f                                         ; OPCODE_SET_LOCAL
-0000029: 03                                         ; remapped local index
-000002a: 0b                                         ; OPCODE_I64_CONST
-000002b: 00                                         ; i64 literal
-000002c: 0f                                         ; OPCODE_SET_LOCAL
-000002d: 04                                         ; remapped local index
-000002e: 0d                                         ; OPCODE_F32_CONST
-000002f: 0000 0000                                  ; f32 literal
-0000033: 0f                                         ; OPCODE_SET_LOCAL
-0000034: 02                                         ; remapped local index
-0000035: 0a                                         ; OPCODE_I32_CONST
-0000036: 00                                         ; i32 literal
-0000037: 0f                                         ; OPCODE_SET_LOCAL
-0000038: 05                                         ; remapped local index
-0000039: 0d                                         ; OPCODE_F32_CONST
-000003a: 0000 0000                                  ; f32 literal
-000001b: 2100                                       ; FIXUP func body size
-000003e: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 0000                                       ; func body size
+0000015: 00                                         ; local decl count
+0000016: 01                                         ; local i32 count
+0000017: 01                                         ; type i32
+0000018: 01                                         ; local i64 count
+0000019: 02                                         ; type i64
+000001a: 02                                         ; local f32 count
+000001b: 03                                         ; type f32
+0000015: 03                                         ; local decl count
+000001c: 0f                                         ; OPCODE_SET_LOCAL
+000001d: 00                                         ; remapped local index
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: 0f                                         ; OPCODE_SET_LOCAL
+0000021: 01                                         ; remapped local index
+0000022: 0d                                         ; OPCODE_F32_CONST
+0000023: 0000 0000                                  ; f32 literal
+0000027: 0f                                         ; OPCODE_SET_LOCAL
+0000028: 03                                         ; remapped local index
+0000029: 0b                                         ; OPCODE_I64_CONST
+000002a: 00                                         ; i64 literal
+000002b: 0f                                         ; OPCODE_SET_LOCAL
+000002c: 04                                         ; remapped local index
+000002d: 0d                                         ; OPCODE_F32_CONST
+000002e: 0000 0000                                  ; f32 literal
+0000032: 0f                                         ; OPCODE_SET_LOCAL
+0000033: 02                                         ; remapped local index
+0000034: 0a                                         ; OPCODE_I32_CONST
+0000035: 00                                         ; i32 literal
+0000036: 0f                                         ; OPCODE_SET_LOCAL
+0000037: 05                                         ; remapped local index
+0000038: 0d                                         ; OPCODE_F32_CONST
+0000039: 0000 0000                                  ; f32 literal
+0000013: 2800                                       ; FIXUP func body size
+000003d: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0200 0103 0201  
-0000010: 0400 0001 0001 0002 0000 0021 000f 000a  
-0000020: 000f 010d 0000 0000 0f03 0b00 0f04 0d00  
-0000030: 0000 000f 020a 000f 050d 0000 0000 06    
+0000010: 0000 0028 0003 0101 0102 0203 0f00 0a00  
+0000020: 0f01 0d00 0000 000f 030b 000f 040d 0000  
+0000030: 0000 0f02 0a00 0f05 0d00 0000 0006       
 ;;; STDOUT ;;)

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -28,16 +28,15 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 00                                         ; local decl count
-0000014: 02                                         ; local i32 count
-0000015: 01                                         ; type i32
-0000016: 02                                         ; local i64 count
-0000017: 02                                         ; type i64
-0000018: 02                                         ; local f32 count
-0000019: 03                                         ; type f32
-000001a: 02                                         ; local f64 count
-000001b: 04                                         ; type f64
 0000013: 04                                         ; local decl count
+0000014: 02                                         ; local i32 count
+0000015: 01                                         ; WASM_TYPE_I32
+0000016: 02                                         ; local i64 count
+0000017: 02                                         ; WASM_TYPE_I64
+0000018: 02                                         ; local f32 count
+0000019: 03                                         ; WASM_TYPE_F32
+000001a: 02                                         ; local f64 count
+000001b: 04                                         ; WASM_TYPE_F64
 000001c: 0f                                         ; OPCODE_SET_LOCAL
 000001d: 06                                         ; remapped local index
 000001e: 0c                                         ; OPCODE_F64_CONST

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -25,51 +25,58 @@
 000000c: 02                                         ; WASM_BINARY_SECTION_FUNCTIONS
 000000d: 01                                         ; num functions
 ; function 0
-000000e: 04                                         ; func flags
+000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
-0000011: 0200                                       ; num local i32
-0000013: 0200                                       ; num local i64
-0000015: 0200                                       ; num local f32
-0000017: 0200                                       ; num local f64
-0000019: 0000                                       ; func body size
-000001b: 0f                                         ; OPCODE_SET_LOCAL
-000001c: 06                                         ; remapped local index
-000001d: 0c                                         ; OPCODE_F64_CONST
-000001e: 0000 0000 0000 0000                        ; f64 literal
-0000026: 0f                                         ; OPCODE_SET_LOCAL
-0000027: 04                                         ; remapped local index
-0000028: 0d                                         ; OPCODE_F32_CONST
-0000029: 0000 0000                                  ; f32 literal
-000002d: 0f                                         ; OPCODE_SET_LOCAL
-000002e: 02                                         ; remapped local index
-000002f: 0b                                         ; OPCODE_I64_CONST
-0000030: 00                                         ; i64 literal
-0000031: 0f                                         ; OPCODE_SET_LOCAL
-0000032: 00                                         ; remapped local index
-0000033: 0a                                         ; OPCODE_I32_CONST
-0000034: 00                                         ; i32 literal
-0000035: 0f                                         ; OPCODE_SET_LOCAL
-0000036: 01                                         ; remapped local index
-0000037: 0a                                         ; OPCODE_I32_CONST
-0000038: 00                                         ; i32 literal
-0000039: 0f                                         ; OPCODE_SET_LOCAL
-000003a: 05                                         ; remapped local index
-000003b: 0d                                         ; OPCODE_F32_CONST
-000003c: 0000 0000                                  ; f32 literal
-0000040: 0f                                         ; OPCODE_SET_LOCAL
-0000041: 07                                         ; remapped local index
-0000042: 0c                                         ; OPCODE_F64_CONST
-0000043: 0000 0000 0000 0000                        ; f64 literal
-000004b: 0f                                         ; OPCODE_SET_LOCAL
-000004c: 03                                         ; remapped local index
-000004d: 0b                                         ; OPCODE_I64_CONST
-000004e: 00                                         ; i64 literal
-0000019: 3400                                       ; FIXUP func body size
-000004f: 06                                         ; WASM_BINARY_SECTION_END
+0000011: 0000                                       ; func body size
+0000013: 00                                         ; local decl count
+0000014: 02                                         ; local i32 count
+0000015: 01                                         ; type i32
+0000016: 02                                         ; local i64 count
+0000017: 02                                         ; type i64
+0000018: 02                                         ; local f32 count
+0000019: 03                                         ; type f32
+000001a: 02                                         ; local f64 count
+000001b: 04                                         ; type f64
+0000013: 04                                         ; local decl count
+000001c: 0f                                         ; OPCODE_SET_LOCAL
+000001d: 06                                         ; remapped local index
+000001e: 0c                                         ; OPCODE_F64_CONST
+000001f: 0000 0000 0000 0000                        ; f64 literal
+0000027: 0f                                         ; OPCODE_SET_LOCAL
+0000028: 04                                         ; remapped local index
+0000029: 0d                                         ; OPCODE_F32_CONST
+000002a: 0000 0000                                  ; f32 literal
+000002e: 0f                                         ; OPCODE_SET_LOCAL
+000002f: 02                                         ; remapped local index
+0000030: 0b                                         ; OPCODE_I64_CONST
+0000031: 00                                         ; i64 literal
+0000032: 0f                                         ; OPCODE_SET_LOCAL
+0000033: 00                                         ; remapped local index
+0000034: 0a                                         ; OPCODE_I32_CONST
+0000035: 00                                         ; i32 literal
+0000036: 0f                                         ; OPCODE_SET_LOCAL
+0000037: 01                                         ; remapped local index
+0000038: 0a                                         ; OPCODE_I32_CONST
+0000039: 00                                         ; i32 literal
+000003a: 0f                                         ; OPCODE_SET_LOCAL
+000003b: 05                                         ; remapped local index
+000003c: 0d                                         ; OPCODE_F32_CONST
+000003d: 0000 0000                                  ; f32 literal
+0000041: 0f                                         ; OPCODE_SET_LOCAL
+0000042: 07                                         ; remapped local index
+0000043: 0c                                         ; OPCODE_F64_CONST
+0000044: 0000 0000 0000 0000                        ; f64 literal
+000004c: 0f                                         ; OPCODE_SET_LOCAL
+000004d: 03                                         ; remapped local index
+000004e: 0b                                         ; OPCODE_I64_CONST
+000004f: 00                                         ; i64 literal
+0000011: 3d00                                       ; FIXUP func body size
+0000050: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
-0000000: 0061 736d 0a00 0000 0101 0000 0201 0400  
-0000010: 0002 0002 0002 0002 0034 000f 060c 0000  
-0000020: 0000 0000 0000 0f04 0d00 0000 000f 020b  
-0000030: 000f 000a 000f 010a 000f 050d 0000 0000  
-0000040: 0f07 0c00 0000 0000 0000 000f 030b 0006  
+0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
+0000010: 003d 0004 0201 0202 0203 0204 0f06 0c00  
+0000020: 0000 0000 0000 000f 040d 0000 0000 0f02  
+0000030: 0b00 0f00 0a00 0f01 0a00 0f05 0d00 0000  
+0000040: 000f 070c 0000 0000 0000 0000 0f03 0b00  
+0000050: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -50,7 +50,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 2e                                         ; OPCODE_I32_STORE_MEM8
 0000015: 00                                         ; store access byte
 0000016: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -49,187 +49,189 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 2e                                         ; OPCODE_I32_STORE_MEM8
-0000014: 00                                         ; store access byte
-0000015: 0a                                         ; OPCODE_I32_CONST
-0000016: 00                                         ; i32 literal
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 00                                         ; i32 literal
-0000019: 2e                                         ; OPCODE_I32_STORE_MEM8
-000001a: 00                                         ; store access byte
-000001b: 0a                                         ; OPCODE_I32_CONST
-000001c: 00                                         ; i32 literal
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 00                                         ; i32 literal
-000001f: 2e                                         ; OPCODE_I32_STORE_MEM8
-0000020: 00                                         ; store access byte
-0000021: 0a                                         ; OPCODE_I32_CONST
-0000022: 00                                         ; i32 literal
-0000023: 0a                                         ; OPCODE_I32_CONST
-0000024: 00                                         ; i32 literal
-0000025: 2e                                         ; OPCODE_I32_STORE_MEM8
-0000026: 00                                         ; store access byte
-0000027: 0a                                         ; OPCODE_I32_CONST
-0000028: 00                                         ; i32 literal
-0000029: 0a                                         ; OPCODE_I32_CONST
-000002a: 00                                         ; i32 literal
-000002b: 2f                                         ; OPCODE_I32_STORE_MEM16
-000002c: 80                                         ; store access byte
-000002d: 0a                                         ; OPCODE_I32_CONST
-000002e: 00                                         ; i32 literal
-000002f: 0a                                         ; OPCODE_I32_CONST
-0000030: 00                                         ; i32 literal
-0000031: 2f                                         ; OPCODE_I32_STORE_MEM16
-0000032: 00                                         ; store access byte
-0000033: 0a                                         ; OPCODE_I32_CONST
-0000034: 00                                         ; i32 literal
-0000035: 0a                                         ; OPCODE_I32_CONST
-0000036: 00                                         ; i32 literal
-0000037: 2f                                         ; OPCODE_I32_STORE_MEM16
-0000038: 00                                         ; store access byte
-0000039: 0a                                         ; OPCODE_I32_CONST
-000003a: 00                                         ; i32 literal
-000003b: 0a                                         ; OPCODE_I32_CONST
-000003c: 00                                         ; i32 literal
-000003d: 2f                                         ; OPCODE_I32_STORE_MEM16
-000003e: 00                                         ; store access byte
-000003f: 0a                                         ; OPCODE_I32_CONST
-0000040: 00                                         ; i32 literal
-0000041: 0a                                         ; OPCODE_I32_CONST
-0000042: 00                                         ; i32 literal
-0000043: 33                                         ; OPCODE_I32_STORE_MEM
-0000044: 80                                         ; store access byte
-0000045: 0a                                         ; OPCODE_I32_CONST
-0000046: 00                                         ; i32 literal
-0000047: 0a                                         ; OPCODE_I32_CONST
-0000048: 00                                         ; i32 literal
-0000049: 33                                         ; OPCODE_I32_STORE_MEM
-000004a: 80                                         ; store access byte
-000004b: 0a                                         ; OPCODE_I32_CONST
-000004c: 00                                         ; i32 literal
-000004d: 0a                                         ; OPCODE_I32_CONST
-000004e: 00                                         ; i32 literal
-000004f: 33                                         ; OPCODE_I32_STORE_MEM
-0000050: 00                                         ; store access byte
-0000051: 0a                                         ; OPCODE_I32_CONST
-0000052: 00                                         ; i32 literal
-0000053: 0a                                         ; OPCODE_I32_CONST
-0000054: 00                                         ; i32 literal
-0000055: 33                                         ; OPCODE_I32_STORE_MEM
-0000056: 00                                         ; store access byte
-0000057: 0a                                         ; OPCODE_I32_CONST
-0000058: 00                                         ; i32 literal
-0000059: 0a                                         ; OPCODE_I32_CONST
-000005a: 00                                         ; i32 literal
-000005b: 34                                         ; OPCODE_I64_STORE_MEM
-000005c: 80                                         ; store access byte
-000005d: 0a                                         ; OPCODE_I32_CONST
-000005e: 00                                         ; i32 literal
-000005f: 0b                                         ; OPCODE_I64_CONST
-0000060: 00                                         ; i64 literal
-0000061: 34                                         ; OPCODE_I64_STORE_MEM
-0000062: 80                                         ; store access byte
-0000063: 0a                                         ; OPCODE_I32_CONST
-0000064: 00                                         ; i32 literal
-0000065: 0b                                         ; OPCODE_I64_CONST
-0000066: 00                                         ; i64 literal
-0000067: 34                                         ; OPCODE_I64_STORE_MEM
-0000068: 80                                         ; store access byte
-0000069: 0a                                         ; OPCODE_I32_CONST
-000006a: 00                                         ; i32 literal
-000006b: 0b                                         ; OPCODE_I64_CONST
-000006c: 00                                         ; i64 literal
-000006d: 34                                         ; OPCODE_I64_STORE_MEM
-000006e: 00                                         ; store access byte
-000006f: 0a                                         ; OPCODE_I32_CONST
-0000070: 00                                         ; i32 literal
-0000071: 0b                                         ; OPCODE_I64_CONST
-0000072: 00                                         ; i64 literal
-0000073: 30                                         ; OPCODE_I64_STORE_MEM8
-0000074: 00                                         ; store access byte
-0000075: 0a                                         ; OPCODE_I32_CONST
-0000076: 00                                         ; i32 literal
-0000077: 0b                                         ; OPCODE_I64_CONST
-0000078: 00                                         ; i64 literal
-0000079: 30                                         ; OPCODE_I64_STORE_MEM8
-000007a: 00                                         ; store access byte
-000007b: 0a                                         ; OPCODE_I32_CONST
-000007c: 00                                         ; i32 literal
-000007d: 0b                                         ; OPCODE_I64_CONST
-000007e: 00                                         ; i64 literal
-000007f: 30                                         ; OPCODE_I64_STORE_MEM8
-0000080: 00                                         ; store access byte
-0000081: 0a                                         ; OPCODE_I32_CONST
-0000082: 00                                         ; i32 literal
-0000083: 0b                                         ; OPCODE_I64_CONST
-0000084: 00                                         ; i64 literal
-0000085: 30                                         ; OPCODE_I64_STORE_MEM8
-0000086: 00                                         ; store access byte
-0000087: 0a                                         ; OPCODE_I32_CONST
-0000088: 00                                         ; i32 literal
-0000089: 0b                                         ; OPCODE_I64_CONST
-000008a: 00                                         ; i64 literal
-000008b: 31                                         ; OPCODE_I64_STORE_MEM16
-000008c: 80                                         ; store access byte
-000008d: 0a                                         ; OPCODE_I32_CONST
-000008e: 00                                         ; i32 literal
-000008f: 0b                                         ; OPCODE_I64_CONST
-0000090: 00                                         ; i64 literal
-0000091: 31                                         ; OPCODE_I64_STORE_MEM16
-0000092: 00                                         ; store access byte
-0000093: 0a                                         ; OPCODE_I32_CONST
-0000094: 00                                         ; i32 literal
-0000095: 0b                                         ; OPCODE_I64_CONST
-0000096: 00                                         ; i64 literal
-0000097: 31                                         ; OPCODE_I64_STORE_MEM16
-0000098: 00                                         ; store access byte
-0000099: 0a                                         ; OPCODE_I32_CONST
-000009a: 00                                         ; i32 literal
-000009b: 0b                                         ; OPCODE_I64_CONST
-000009c: 00                                         ; i64 literal
-000009d: 31                                         ; OPCODE_I64_STORE_MEM16
-000009e: 00                                         ; store access byte
-000009f: 0a                                         ; OPCODE_I32_CONST
-00000a0: 00                                         ; i32 literal
-00000a1: 0b                                         ; OPCODE_I64_CONST
-00000a2: 00                                         ; i64 literal
-00000a3: 34                                         ; OPCODE_I64_STORE_MEM
-00000a4: 80                                         ; store access byte
-00000a5: 0a                                         ; OPCODE_I32_CONST
-00000a6: 00                                         ; i32 literal
-00000a7: 0b                                         ; OPCODE_I64_CONST
-00000a8: 00                                         ; i64 literal
-00000a9: 34                                         ; OPCODE_I64_STORE_MEM
-00000aa: 80                                         ; store access byte
-00000ab: 0a                                         ; OPCODE_I32_CONST
-00000ac: 00                                         ; i32 literal
-00000ad: 0b                                         ; OPCODE_I64_CONST
-00000ae: 00                                         ; i64 literal
-00000af: 34                                         ; OPCODE_I64_STORE_MEM
-00000b0: 80                                         ; store access byte
-00000b1: 0a                                         ; OPCODE_I32_CONST
-00000b2: 00                                         ; i32 literal
-00000b3: 0b                                         ; OPCODE_I64_CONST
-00000b4: 00                                         ; i64 literal
-00000b5: 34                                         ; OPCODE_I64_STORE_MEM
-00000b6: 00                                         ; store access byte
-00000b7: 0a                                         ; OPCODE_I32_CONST
-00000b8: 00                                         ; i32 literal
-00000b9: 0b                                         ; OPCODE_I64_CONST
-00000ba: 00                                         ; i64 literal
-0000011: a800                                       ; FIXUP func body size
-00000bb: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000015: 00                                         ; store access byte
+0000016: 0a                                         ; OPCODE_I32_CONST
+0000017: 00                                         ; i32 literal
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 00                                         ; i32 literal
+000001a: 2e                                         ; OPCODE_I32_STORE_MEM8
+000001b: 00                                         ; store access byte
+000001c: 0a                                         ; OPCODE_I32_CONST
+000001d: 00                                         ; i32 literal
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000021: 00                                         ; store access byte
+0000022: 0a                                         ; OPCODE_I32_CONST
+0000023: 00                                         ; i32 literal
+0000024: 0a                                         ; OPCODE_I32_CONST
+0000025: 00                                         ; i32 literal
+0000026: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000027: 00                                         ; store access byte
+0000028: 0a                                         ; OPCODE_I32_CONST
+0000029: 00                                         ; i32 literal
+000002a: 0a                                         ; OPCODE_I32_CONST
+000002b: 00                                         ; i32 literal
+000002c: 2f                                         ; OPCODE_I32_STORE_MEM16
+000002d: 80                                         ; store access byte
+000002e: 0a                                         ; OPCODE_I32_CONST
+000002f: 00                                         ; i32 literal
+0000030: 0a                                         ; OPCODE_I32_CONST
+0000031: 00                                         ; i32 literal
+0000032: 2f                                         ; OPCODE_I32_STORE_MEM16
+0000033: 00                                         ; store access byte
+0000034: 0a                                         ; OPCODE_I32_CONST
+0000035: 00                                         ; i32 literal
+0000036: 0a                                         ; OPCODE_I32_CONST
+0000037: 00                                         ; i32 literal
+0000038: 2f                                         ; OPCODE_I32_STORE_MEM16
+0000039: 00                                         ; store access byte
+000003a: 0a                                         ; OPCODE_I32_CONST
+000003b: 00                                         ; i32 literal
+000003c: 0a                                         ; OPCODE_I32_CONST
+000003d: 00                                         ; i32 literal
+000003e: 2f                                         ; OPCODE_I32_STORE_MEM16
+000003f: 00                                         ; store access byte
+0000040: 0a                                         ; OPCODE_I32_CONST
+0000041: 00                                         ; i32 literal
+0000042: 0a                                         ; OPCODE_I32_CONST
+0000043: 00                                         ; i32 literal
+0000044: 33                                         ; OPCODE_I32_STORE_MEM
+0000045: 80                                         ; store access byte
+0000046: 0a                                         ; OPCODE_I32_CONST
+0000047: 00                                         ; i32 literal
+0000048: 0a                                         ; OPCODE_I32_CONST
+0000049: 00                                         ; i32 literal
+000004a: 33                                         ; OPCODE_I32_STORE_MEM
+000004b: 80                                         ; store access byte
+000004c: 0a                                         ; OPCODE_I32_CONST
+000004d: 00                                         ; i32 literal
+000004e: 0a                                         ; OPCODE_I32_CONST
+000004f: 00                                         ; i32 literal
+0000050: 33                                         ; OPCODE_I32_STORE_MEM
+0000051: 00                                         ; store access byte
+0000052: 0a                                         ; OPCODE_I32_CONST
+0000053: 00                                         ; i32 literal
+0000054: 0a                                         ; OPCODE_I32_CONST
+0000055: 00                                         ; i32 literal
+0000056: 33                                         ; OPCODE_I32_STORE_MEM
+0000057: 00                                         ; store access byte
+0000058: 0a                                         ; OPCODE_I32_CONST
+0000059: 00                                         ; i32 literal
+000005a: 0a                                         ; OPCODE_I32_CONST
+000005b: 00                                         ; i32 literal
+000005c: 34                                         ; OPCODE_I64_STORE_MEM
+000005d: 80                                         ; store access byte
+000005e: 0a                                         ; OPCODE_I32_CONST
+000005f: 00                                         ; i32 literal
+0000060: 0b                                         ; OPCODE_I64_CONST
+0000061: 00                                         ; i64 literal
+0000062: 34                                         ; OPCODE_I64_STORE_MEM
+0000063: 80                                         ; store access byte
+0000064: 0a                                         ; OPCODE_I32_CONST
+0000065: 00                                         ; i32 literal
+0000066: 0b                                         ; OPCODE_I64_CONST
+0000067: 00                                         ; i64 literal
+0000068: 34                                         ; OPCODE_I64_STORE_MEM
+0000069: 80                                         ; store access byte
+000006a: 0a                                         ; OPCODE_I32_CONST
+000006b: 00                                         ; i32 literal
+000006c: 0b                                         ; OPCODE_I64_CONST
+000006d: 00                                         ; i64 literal
+000006e: 34                                         ; OPCODE_I64_STORE_MEM
+000006f: 00                                         ; store access byte
+0000070: 0a                                         ; OPCODE_I32_CONST
+0000071: 00                                         ; i32 literal
+0000072: 0b                                         ; OPCODE_I64_CONST
+0000073: 00                                         ; i64 literal
+0000074: 30                                         ; OPCODE_I64_STORE_MEM8
+0000075: 00                                         ; store access byte
+0000076: 0a                                         ; OPCODE_I32_CONST
+0000077: 00                                         ; i32 literal
+0000078: 0b                                         ; OPCODE_I64_CONST
+0000079: 00                                         ; i64 literal
+000007a: 30                                         ; OPCODE_I64_STORE_MEM8
+000007b: 00                                         ; store access byte
+000007c: 0a                                         ; OPCODE_I32_CONST
+000007d: 00                                         ; i32 literal
+000007e: 0b                                         ; OPCODE_I64_CONST
+000007f: 00                                         ; i64 literal
+0000080: 30                                         ; OPCODE_I64_STORE_MEM8
+0000081: 00                                         ; store access byte
+0000082: 0a                                         ; OPCODE_I32_CONST
+0000083: 00                                         ; i32 literal
+0000084: 0b                                         ; OPCODE_I64_CONST
+0000085: 00                                         ; i64 literal
+0000086: 30                                         ; OPCODE_I64_STORE_MEM8
+0000087: 00                                         ; store access byte
+0000088: 0a                                         ; OPCODE_I32_CONST
+0000089: 00                                         ; i32 literal
+000008a: 0b                                         ; OPCODE_I64_CONST
+000008b: 00                                         ; i64 literal
+000008c: 31                                         ; OPCODE_I64_STORE_MEM16
+000008d: 80                                         ; store access byte
+000008e: 0a                                         ; OPCODE_I32_CONST
+000008f: 00                                         ; i32 literal
+0000090: 0b                                         ; OPCODE_I64_CONST
+0000091: 00                                         ; i64 literal
+0000092: 31                                         ; OPCODE_I64_STORE_MEM16
+0000093: 00                                         ; store access byte
+0000094: 0a                                         ; OPCODE_I32_CONST
+0000095: 00                                         ; i32 literal
+0000096: 0b                                         ; OPCODE_I64_CONST
+0000097: 00                                         ; i64 literal
+0000098: 31                                         ; OPCODE_I64_STORE_MEM16
+0000099: 00                                         ; store access byte
+000009a: 0a                                         ; OPCODE_I32_CONST
+000009b: 00                                         ; i32 literal
+000009c: 0b                                         ; OPCODE_I64_CONST
+000009d: 00                                         ; i64 literal
+000009e: 31                                         ; OPCODE_I64_STORE_MEM16
+000009f: 00                                         ; store access byte
+00000a0: 0a                                         ; OPCODE_I32_CONST
+00000a1: 00                                         ; i32 literal
+00000a2: 0b                                         ; OPCODE_I64_CONST
+00000a3: 00                                         ; i64 literal
+00000a4: 34                                         ; OPCODE_I64_STORE_MEM
+00000a5: 80                                         ; store access byte
+00000a6: 0a                                         ; OPCODE_I32_CONST
+00000a7: 00                                         ; i32 literal
+00000a8: 0b                                         ; OPCODE_I64_CONST
+00000a9: 00                                         ; i64 literal
+00000aa: 34                                         ; OPCODE_I64_STORE_MEM
+00000ab: 80                                         ; store access byte
+00000ac: 0a                                         ; OPCODE_I32_CONST
+00000ad: 00                                         ; i32 literal
+00000ae: 0b                                         ; OPCODE_I64_CONST
+00000af: 00                                         ; i64 literal
+00000b0: 34                                         ; OPCODE_I64_STORE_MEM
+00000b1: 80                                         ; store access byte
+00000b2: 0a                                         ; OPCODE_I32_CONST
+00000b3: 00                                         ; i32 literal
+00000b4: 0b                                         ; OPCODE_I64_CONST
+00000b5: 00                                         ; i64 literal
+00000b6: 34                                         ; OPCODE_I64_STORE_MEM
+00000b7: 00                                         ; store access byte
+00000b8: 0a                                         ; OPCODE_I32_CONST
+00000b9: 00                                         ; i32 literal
+00000ba: 0b                                         ; OPCODE_I64_CONST
+00000bb: 00                                         ; i64 literal
+0000011: a900                                       ; FIXUP func body size
+00000bc: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 00a8 002e 000a 000a 002e 000a 000a 002e  
-0000020: 000a 000a 002e 000a 000a 002f 800a 000a  
-0000030: 002f 000a 000a 002f 000a 000a 002f 000a  
-0000040: 000a 0033 800a 000a 0033 800a 000a 0033  
-0000050: 000a 000a 0033 000a 000a 0034 800a 000b  
-0000060: 0034 800a 000b 0034 800a 000b 0034 000a  
-0000070: 000b 0030 000a 000b 0030 000a 000b 0030  
-0000080: 000a 000b 0030 000a 000b 0031 800a 000b  
-0000090: 0031 000a 000b 0031 000a 000b 0031 000a  
-00000a0: 000b 0034 800a 000b 0034 800a 000b 0034  
-00000b0: 800a 000b 0034 000a 000b 0006            
+0000010: 00a9 0000 2e00 0a00 0a00 2e00 0a00 0a00  
+0000020: 2e00 0a00 0a00 2e00 0a00 0a00 2f80 0a00  
+0000030: 0a00 2f00 0a00 0a00 2f00 0a00 0a00 2f00  
+0000040: 0a00 0a00 3380 0a00 0a00 3380 0a00 0a00  
+0000050: 3300 0a00 0a00 3300 0a00 0a00 3480 0a00  
+0000060: 0b00 3480 0a00 0b00 3480 0a00 0b00 3400  
+0000070: 0a00 0b00 3000 0a00 0b00 3000 0a00 0b00  
+0000080: 3000 0a00 0b00 3000 0a00 0b00 3180 0a00  
+0000090: 0b00 3100 0a00 0b00 3100 0a00 0b00 3100  
+00000a0: 0a00 0b00 3480 0a00 0b00 3480 0a00 0b00  
+00000b0: 3480 0a00 0b00 3400 0a00 0b00 06         
 ;;; STDOUT ;;)

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -24,67 +24,69 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 2e                                         ; OPCODE_I32_STORE_MEM8
-0000014: 00                                         ; store access byte
-0000015: 0a                                         ; OPCODE_I32_CONST
-0000016: 00                                         ; i32 literal
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 00                                         ; i32 literal
-0000019: 2f                                         ; OPCODE_I32_STORE_MEM16
-000001a: 00                                         ; store access byte
-000001b: 0a                                         ; OPCODE_I32_CONST
-000001c: 00                                         ; i32 literal
-000001d: 0a                                         ; OPCODE_I32_CONST
-000001e: 00                                         ; i32 literal
-000001f: 33                                         ; OPCODE_I32_STORE_MEM
-0000020: 00                                         ; store access byte
-0000021: 0a                                         ; OPCODE_I32_CONST
-0000022: 00                                         ; i32 literal
-0000023: 0a                                         ; OPCODE_I32_CONST
-0000024: 00                                         ; i32 literal
-0000025: 34                                         ; OPCODE_I64_STORE_MEM
-0000026: 00                                         ; store access byte
-0000027: 0a                                         ; OPCODE_I32_CONST
-0000028: 00                                         ; i32 literal
-0000029: 0b                                         ; OPCODE_I64_CONST
-000002a: 00                                         ; i64 literal
-000002b: 30                                         ; OPCODE_I64_STORE_MEM8
-000002c: 00                                         ; store access byte
-000002d: 0a                                         ; OPCODE_I32_CONST
-000002e: 00                                         ; i32 literal
-000002f: 0b                                         ; OPCODE_I64_CONST
-0000030: 00                                         ; i64 literal
-0000031: 31                                         ; OPCODE_I64_STORE_MEM16
-0000032: 00                                         ; store access byte
-0000033: 0a                                         ; OPCODE_I32_CONST
-0000034: 00                                         ; i32 literal
-0000035: 0b                                         ; OPCODE_I64_CONST
-0000036: 00                                         ; i64 literal
-0000037: 32                                         ; OPCODE_I64_STORE_MEM32
-0000038: 00                                         ; store access byte
-0000039: 0a                                         ; OPCODE_I32_CONST
-000003a: 00                                         ; i32 literal
-000003b: 0b                                         ; OPCODE_I64_CONST
-000003c: 00                                         ; i64 literal
-000003d: 35                                         ; OPCODE_F32_STORE_MEM
-000003e: 00                                         ; store access byte
-000003f: 0a                                         ; OPCODE_I32_CONST
-0000040: 00                                         ; i32 literal
-0000041: 0d                                         ; OPCODE_F32_CONST
-0000042: 0000 0000                                  ; f32 literal
-0000046: 36                                         ; OPCODE_F64_STORE_MEM
-0000047: 00                                         ; store access byte
-0000048: 0a                                         ; OPCODE_I32_CONST
-0000049: 00                                         ; i32 literal
-000004a: 0c                                         ; OPCODE_F64_CONST
-000004b: 0000 0000 0000 0000                        ; f64 literal
-0000011: 4000                                       ; FIXUP func body size
-0000053: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 2e                                         ; OPCODE_I32_STORE_MEM8
+0000015: 00                                         ; store access byte
+0000016: 0a                                         ; OPCODE_I32_CONST
+0000017: 00                                         ; i32 literal
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 00                                         ; i32 literal
+000001a: 2f                                         ; OPCODE_I32_STORE_MEM16
+000001b: 00                                         ; store access byte
+000001c: 0a                                         ; OPCODE_I32_CONST
+000001d: 00                                         ; i32 literal
+000001e: 0a                                         ; OPCODE_I32_CONST
+000001f: 00                                         ; i32 literal
+0000020: 33                                         ; OPCODE_I32_STORE_MEM
+0000021: 00                                         ; store access byte
+0000022: 0a                                         ; OPCODE_I32_CONST
+0000023: 00                                         ; i32 literal
+0000024: 0a                                         ; OPCODE_I32_CONST
+0000025: 00                                         ; i32 literal
+0000026: 34                                         ; OPCODE_I64_STORE_MEM
+0000027: 00                                         ; store access byte
+0000028: 0a                                         ; OPCODE_I32_CONST
+0000029: 00                                         ; i32 literal
+000002a: 0b                                         ; OPCODE_I64_CONST
+000002b: 00                                         ; i64 literal
+000002c: 30                                         ; OPCODE_I64_STORE_MEM8
+000002d: 00                                         ; store access byte
+000002e: 0a                                         ; OPCODE_I32_CONST
+000002f: 00                                         ; i32 literal
+0000030: 0b                                         ; OPCODE_I64_CONST
+0000031: 00                                         ; i64 literal
+0000032: 31                                         ; OPCODE_I64_STORE_MEM16
+0000033: 00                                         ; store access byte
+0000034: 0a                                         ; OPCODE_I32_CONST
+0000035: 00                                         ; i32 literal
+0000036: 0b                                         ; OPCODE_I64_CONST
+0000037: 00                                         ; i64 literal
+0000038: 32                                         ; OPCODE_I64_STORE_MEM32
+0000039: 00                                         ; store access byte
+000003a: 0a                                         ; OPCODE_I32_CONST
+000003b: 00                                         ; i32 literal
+000003c: 0b                                         ; OPCODE_I64_CONST
+000003d: 00                                         ; i64 literal
+000003e: 35                                         ; OPCODE_F32_STORE_MEM
+000003f: 00                                         ; store access byte
+0000040: 0a                                         ; OPCODE_I32_CONST
+0000041: 00                                         ; i32 literal
+0000042: 0d                                         ; OPCODE_F32_CONST
+0000043: 0000 0000                                  ; f32 literal
+0000047: 36                                         ; OPCODE_F64_STORE_MEM
+0000048: 00                                         ; store access byte
+0000049: 0a                                         ; OPCODE_I32_CONST
+000004a: 00                                         ; i32 literal
+000004b: 0c                                         ; OPCODE_F64_CONST
+000004c: 0000 0000 0000 0000                        ; f64 literal
+0000011: 4100                                       ; FIXUP func body size
+0000054: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0040 002e 000a 000a 002f 000a 000a 0033  
-0000020: 000a 000a 0034 000a 000b 0030 000a 000b  
-0000030: 0031 000a 000b 0032 000a 000b 0035 000a  
-0000040: 000d 0000 0000 3600 0a00 0c00 0000 0000  
-0000050: 0000 0006                                
+0000010: 0041 0000 2e00 0a00 0a00 2f00 0a00 0a00  
+0000020: 3300 0a00 0a00 3400 0a00 0b00 3000 0a00  
+0000030: 0b00 3100 0a00 0b00 3200 0a00 0b00 3500  
+0000040: 0a00 0d00 0000 0036 000a 000c 0000 0000  
+0000050: 0000 0000 06                             
 ;;; STDOUT ;;)

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -25,7 +25,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 2e                                         ; OPCODE_I32_STORE_MEM8
 0000015: 00                                         ; store access byte
 0000016: 0a                                         ; OPCODE_I32_CONST

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -29,20 +29,17 @@
 0000016: 0000                                       ; func signature index
 0000018: 0000                                       ; func body size
 000001a: 00                                         ; local decl count
-000001a: 00                                         ; local decl count
 0000018: 0100                                       ; FIXUP func body size
 ; function 1
 000001b: 00                                         ; func flags
 000001c: 0100                                       ; func signature index
 000001e: 0000                                       ; func body size
 0000020: 00                                         ; local decl count
-0000020: 00                                         ; local decl count
 000001e: 0100                                       ; FIXUP func body size
 ; function 2
 0000021: 00                                         ; func flags
 0000022: 0200                                       ; func signature index
 0000024: 0000                                       ; func body size
-0000026: 00                                         ; local decl count
 0000026: 00                                         ; local decl count
 0000027: 0c                                         ; OPCODE_F64_CONST
 0000028: 0000 0000 0000 0000                        ; f64 literal

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -28,29 +28,35 @@
 0000015: 00                                         ; func flags
 0000016: 0000                                       ; func signature index
 0000018: 0000                                       ; func body size
-0000018: 0000                                       ; FIXUP func body size
+000001a: 00                                         ; local decl count
+000001a: 00                                         ; local decl count
+0000018: 0100                                       ; FIXUP func body size
 ; function 1
-000001a: 00                                         ; func flags
-000001b: 0100                                       ; func signature index
-000001d: 0000                                       ; func body size
-000001d: 0000                                       ; FIXUP func body size
+000001b: 00                                         ; func flags
+000001c: 0100                                       ; func signature index
+000001e: 0000                                       ; func body size
+0000020: 00                                         ; local decl count
+0000020: 00                                         ; local decl count
+000001e: 0100                                       ; FIXUP func body size
 ; function 2
-000001f: 00                                         ; func flags
-0000020: 0200                                       ; func signature index
-0000022: 0000                                       ; func body size
-0000024: 0c                                         ; OPCODE_F64_CONST
-0000025: 0000 0000 0000 0000                        ; f64 literal
-0000022: 0900                                       ; FIXUP func body size
-000002d: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-000002e: 04                                         ; num function table entries
-000002f: 0000                                       ; function table entry
-0000031: 0000                                       ; function table entry
-0000033: 0100                                       ; function table entry
-0000035: 0200                                       ; function table entry
-0000037: 06                                         ; WASM_BINARY_SECTION_END
+0000021: 00                                         ; func flags
+0000022: 0200                                       ; func signature index
+0000024: 0000                                       ; func body size
+0000026: 00                                         ; local decl count
+0000026: 00                                         ; local decl count
+0000027: 0c                                         ; OPCODE_F64_CONST
+0000028: 0000 0000 0000 0000                        ; f64 literal
+0000024: 0a00                                       ; FIXUP func body size
+0000030: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+0000031: 04                                         ; num function table entries
+0000032: 0000                                       ; function table entry
+0000034: 0000                                       ; function table entry
+0000036: 0100                                       ; function table entry
+0000038: 0200                                       ; function table entry
+000003a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0103 0100 0102 0001  
-0000010: 0200 0402 0300 0000 0000 0001 0000 0000  
-0000020: 0200 0900 0c00 0000 0000 0000 0005 0400  
-0000030: 0000 0001 0002 0006                      
+0000010: 0200 0402 0300 0000 0100 0000 0100 0100  
+0000020: 0000 0200 0a00 000c 0000 0000 0000 0000  
+0000030: 0504 0000 0000 0100 0200 06              
 ;;; STDOUT ;;)

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -40,7 +40,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 5a                                         ; OPCODE_BOOL_NOT
 0000015: 57                                         ; OPCODE_I32_CLZ
 0000016: 58                                         ; OPCODE_I32_CTZ

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -39,40 +39,42 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 5a                                         ; OPCODE_BOOL_NOT
-0000014: 57                                         ; OPCODE_I32_CLZ
-0000015: 58                                         ; OPCODE_I32_CTZ
-0000016: 59                                         ; OPCODE_I32_POPCNT
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 00                                         ; i32 literal
-0000019: 72                                         ; OPCODE_I64_CLZ
-000001a: 73                                         ; OPCODE_I64_CTZ
-000001b: 74                                         ; OPCODE_I64_POPCNT
-000001c: 0b                                         ; OPCODE_I64_CONST
-000001d: 00                                         ; i64 literal
-000001e: 7c                                         ; OPCODE_F32_NEG
-000001f: 7b                                         ; OPCODE_F32_ABS
-0000020: 82                                         ; OPCODE_F32_SQRT
-0000021: 7e                                         ; OPCODE_F32_CEIL
-0000022: 7f                                         ; OPCODE_F32_FLOOR
-0000023: 80                                         ; OPCODE_F32_TRUNC
-0000024: 81                                         ; OPCODE_F32_NEAREST_INT
-0000025: 0d                                         ; OPCODE_F32_CONST
-0000026: 0000 0000                                  ; f32 literal
-000002a: 90                                         ; OPCODE_F64_NEG
-000002b: 8f                                         ; OPCODE_F64_ABS
-000002c: 96                                         ; OPCODE_F64_SQRT
-000002d: 92                                         ; OPCODE_F64_CEIL
-000002e: 93                                         ; OPCODE_F64_FLOOR
-000002f: 94                                         ; OPCODE_F64_TRUNC
-0000030: 95                                         ; OPCODE_F64_NEAREST_INT
-0000031: 0c                                         ; OPCODE_F64_CONST
-0000032: 0000 0000 0000 0000                        ; f64 literal
-0000011: 2700                                       ; FIXUP func body size
-000003a: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 5a                                         ; OPCODE_BOOL_NOT
+0000015: 57                                         ; OPCODE_I32_CLZ
+0000016: 58                                         ; OPCODE_I32_CTZ
+0000017: 59                                         ; OPCODE_I32_POPCNT
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 00                                         ; i32 literal
+000001a: 72                                         ; OPCODE_I64_CLZ
+000001b: 73                                         ; OPCODE_I64_CTZ
+000001c: 74                                         ; OPCODE_I64_POPCNT
+000001d: 0b                                         ; OPCODE_I64_CONST
+000001e: 00                                         ; i64 literal
+000001f: 7c                                         ; OPCODE_F32_NEG
+0000020: 7b                                         ; OPCODE_F32_ABS
+0000021: 82                                         ; OPCODE_F32_SQRT
+0000022: 7e                                         ; OPCODE_F32_CEIL
+0000023: 7f                                         ; OPCODE_F32_FLOOR
+0000024: 80                                         ; OPCODE_F32_TRUNC
+0000025: 81                                         ; OPCODE_F32_NEAREST_INT
+0000026: 0d                                         ; OPCODE_F32_CONST
+0000027: 0000 0000                                  ; f32 literal
+000002b: 90                                         ; OPCODE_F64_NEG
+000002c: 8f                                         ; OPCODE_F64_ABS
+000002d: 96                                         ; OPCODE_F64_SQRT
+000002e: 92                                         ; OPCODE_F64_CEIL
+000002f: 93                                         ; OPCODE_F64_FLOOR
+0000030: 94                                         ; OPCODE_F64_TRUNC
+0000031: 95                                         ; OPCODE_F64_NEAREST_INT
+0000032: 0c                                         ; OPCODE_F64_CONST
+0000033: 0000 0000 0000 0000                        ; f64 literal
+0000011: 2800                                       ; FIXUP func body size
+000003b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0027 005a 5758 590a 0072 7374 0b00 7c7b  
-0000020: 827e 7f80 810d 0000 0000 908f 9692 9394  
-0000030: 950c 0000 0000 0000 0000 06              
+0000010: 0028 0000 5a57 5859 0a00 7273 740b 007c  
+0000020: 7b82 7e7f 8081 0d00 0000 0090 8f96 9293  
+0000030: 9495 0c00 0000 0000 0000 0006            
 ;;; STDOUT ;;)

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -17,7 +17,6 @@
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
 0000013: 00                                         ; local decl count
-0000013: 00                                         ; local decl count
 0000014: 15                                         ; OPCODE_UNREACHABLE
 0000011: 0200                                       ; FIXUP func body size
 0000015: 06                                         ; WASM_BINARY_SECTION_END

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -16,10 +16,12 @@
 000000e: 00                                         ; func flags
 000000f: 0000                                       ; func signature index
 0000011: 0000                                       ; func body size
-0000013: 15                                         ; OPCODE_UNREACHABLE
-0000011: 0100                                       ; FIXUP func body size
-0000014: 06                                         ; WASM_BINARY_SECTION_END
+0000013: 00                                         ; local decl count
+0000013: 00                                         ; local decl count
+0000014: 15                                         ; OPCODE_UNREACHABLE
+0000011: 0200                                       ; FIXUP func body size
+0000015: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0001 0015 06                             
+0000010: 0002 0000 1506                           
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -6,7 +6,7 @@
 
 ;;; STDERR ;;)
 (;; STDOUT ;;;
-WasmModule::Instantiate(): Compiling WASM function #4:<?> failed:Result = ExprSelect[1] expected type <end>, found ExprI32Const of type i32 @+0
+WasmModule::Instantiate(): Compiling WASM function #4:<?> failed:Result = ExprSelect[1] expected type <end>, found ExprI32Const of type i32 @+1
 
   var module = _WASMEXP_.instantiateModule(u8a.buffer, ffi);
                          ^


### PR DESCRIPTION
PTAL. The dump tests don't pass, since they assert on bytes. I wasn't sure how to update them. Depends on V8 CL: https://codereview.chromium.org/1763433002/