### PR TITLE
Emit explicit arities for calls, breaks, & return

### DIFF
--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -583,22 +583,20 @@ static void write_expr(WasmWriteContext* ctx,
       WasmLabelNode* node = find_label_by_var(ctx->top_label, &expr->br.var);
       assert(node);
       out_opcode(ws, WASM_OPCODE_BR);
+      out_u32_leb128(ws, expr->br.expr != NULL, "break arity");
       out_u8(ws, ctx->max_depth - node->depth - 1, "break depth");
       if (expr->br.expr)
         write_expr(ctx, module, func, expr->br.expr);
-      else
-        out_opcode(ws, WASM_OPCODE_NOP);
       break;
     }
     case WASM_EXPR_TYPE_BR_IF: {
       WasmLabelNode* node = find_label_by_var(ctx->top_label, &expr->br_if.var);
       assert(node);
       out_opcode(ws, WASM_OPCODE_BR_IF);
+      out_u32_leb128(ws, expr->br_if.expr != NULL, "break arity");
       out_u8(ws, ctx->max_depth - node->depth - 1, "break depth");
       if (expr->br_if.expr)
         write_expr(ctx, module, func, expr->br_if.expr);
-      else
-        out_opcode(ws, WASM_OPCODE_NOP);
       write_expr(ctx, module, func, expr->br_if.cond);
       break;
     }
@@ -606,6 +604,7 @@ static void write_expr(WasmWriteContext* ctx,
       int index = wasm_get_func_index_by_var(module, &expr->call.var);
       assert(index >= 0 && index < module->funcs.size);
       out_opcode(ws, WASM_OPCODE_CALL_FUNCTION);
+      out_u32_leb128(ws, expr->call.args.size, "call arity");
       out_u32_leb128(ws, index, "func index");
       write_expr_list(ctx, module, func, &expr->call.args);
       break;
@@ -614,6 +613,7 @@ static void write_expr(WasmWriteContext* ctx,
       int index = wasm_get_import_index_by_var(module, &expr->call.var);
       assert(index >= 0 && index < module->imports.size);
       out_opcode(ws, WASM_OPCODE_CALL_IMPORT);
+      out_u32_leb128(ws, expr->call.args.size, "call arity");
       out_u32_leb128(ws, index, "import index");
       write_expr_list(ctx, module, func, &expr->call.args);
       break;
@@ -623,6 +623,7 @@ static void write_expr(WasmWriteContext* ctx,
           wasm_get_func_type_index_by_var(module, &expr->call_indirect.var);
       assert(index >= 0 && index < module->func_types.size);
       out_opcode(ws, WASM_OPCODE_CALL_INDIRECT);
+      out_u32_leb128(ws, expr->call_indirect.args.size, "call arity");
       out_u32_leb128(ws, index, "signature index");
       write_expr(ctx, module, func, expr->call_indirect.expr);
       write_expr_list(ctx, module, func, &expr->call_indirect.args);
@@ -738,6 +739,7 @@ static void write_expr(WasmWriteContext* ctx,
       break;
     case WASM_EXPR_TYPE_RETURN:
       out_opcode(ws, WASM_OPCODE_RETURN);
+      out_u32_leb128(ws, expr->br.expr != NULL, "return arity");
       if (expr->return_.expr)
         write_expr(ctx, module, func, expr->return_.expr);
       break;

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -324,11 +324,11 @@
 0000118: 03                                         ; num expressions (byte 0)
 0000119: 00                                         ; OPCODE_NOP
 000011a: 06                                         ; OPCODE_BR
-000011b: 01                                         ; break depth
-000011c: 00                                         ; OPCODE_NOP
+000011b: 00                                         ; break arity
+000011c: 01                                         ; break depth
 000011d: 06                                         ; OPCODE_BR
-000011e: 01                                         ; break depth
-000011f: 00                                         ; OPCODE_NOP
+000011e: 00                                         ; break arity
+000011f: 01                                         ; break depth
 0000011: 0d01                                       ; FIXUP func body size
 0000120: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
@@ -349,6 +349,6 @@
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000110: 0000 0000 0000 0001 0300 0601 0006 0100  
+0000110: 0000 0000 0000 0001 0300 0600 0106 0001  
 0000120: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -34,15 +34,15 @@
 000001c: 01                                         ; OPCODE_BLOCK
 000001d: 02                                         ; num expressions
 000001e: 06                                         ; OPCODE_BR
-000001f: 00                                         ; break depth
-0000020: 00                                         ; OPCODE_NOP
+000001f: 00                                         ; break arity
+0000020: 00                                         ; break depth
 0000021: 06                                         ; OPCODE_BR
-0000022: 04                                         ; break depth
-0000023: 00                                         ; OPCODE_NOP
+0000022: 00                                         ; break arity
+0000023: 04                                         ; break depth
 0000011: 1100                                       ; FIXUP func body size
 0000024: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
 0000010: 0011 0000 0101 0201 0102 0a00 0102 0600  
-0000020: 0006 0400 06                             
+0000020: 0006 0004 06                             
 ;;; STDOUT ;;)

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -37,24 +37,24 @@
 000001c: 01                                         ; OPCODE_BLOCK
 000001d: 05                                         ; num expressions
 000001e: 06                                         ; OPCODE_BR
-000001f: 00                                         ; break depth
-0000020: 00                                         ; OPCODE_NOP
+000001f: 00                                         ; break arity
+0000020: 00                                         ; break depth
 0000021: 06                                         ; OPCODE_BR
-0000022: 00                                         ; break depth
-0000023: 00                                         ; OPCODE_NOP
+0000022: 00                                         ; break arity
+0000023: 00                                         ; break depth
 0000024: 06                                         ; OPCODE_BR
-0000025: 01                                         ; break depth
-0000026: 00                                         ; OPCODE_NOP
+0000025: 00                                         ; break arity
+0000026: 01                                         ; break depth
 0000027: 06                                         ; OPCODE_BR
-0000028: 02                                         ; break depth
-0000029: 00                                         ; OPCODE_NOP
+0000028: 00                                         ; break arity
+0000029: 02                                         ; break depth
 000002a: 06                                         ; OPCODE_BR
-000002b: 03                                         ; break depth
-000002c: 00                                         ; OPCODE_NOP
+000002b: 00                                         ; break arity
+000002c: 03                                         ; break depth
 0000011: 1a00                                       ; FIXUP func body size
 000002d: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
 0000010: 001a 0000 0101 0201 0102 0a00 0105 0600  
-0000020: 0006 0000 0601 0006 0200 0603 0006       
+0000020: 0006 0000 0600 0106 0002 0600 0306       
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -30,23 +30,24 @@
 0000019: 01                                         ; OPCODE_BLOCK
 000001a: 01                                         ; num expressions
 000001b: 06                                         ; OPCODE_BR
-000001c: 01                                         ; break depth
-000001d: 00                                         ; OPCODE_NOP
+000001c: 00                                         ; break arity
+000001d: 01                                         ; break depth
 000001e: 03                                         ; OPCODE_IF
 000001f: 0a                                         ; OPCODE_I32_CONST
 0000020: 03                                         ; i32 literal
 0000021: 01                                         ; OPCODE_BLOCK
 0000022: 01                                         ; num expressions
 0000023: 06                                         ; OPCODE_BR
-0000024: 02                                         ; break depth
-0000025: 0a                                         ; OPCODE_I32_CONST
-0000026: 04                                         ; i32 literal
-0000027: 0a                                         ; OPCODE_I32_CONST
-0000028: 05                                         ; i32 literal
-0000011: 1600                                       ; FIXUP func body size
-0000029: 06                                         ; WASM_BINARY_SECTION_END
+0000024: 01                                         ; break arity
+0000025: 02                                         ; break depth
+0000026: 0a                                         ; OPCODE_I32_CONST
+0000027: 04                                         ; i32 literal
+0000028: 0a                                         ; OPCODE_I32_CONST
+0000029: 05                                         ; i32 literal
+0000011: 1700                                       ; FIXUP func body size
+000002a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
-0000010: 0016 0000 0203 030a 0101 0106 0100 030a  
-0000020: 0301 0106 020a 040a 0506                 
+0000010: 0017 0000 0203 030a 0101 0106 0001 030a  
+0000020: 0301 0106 0102 0a04 0a05 06              
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -29,20 +29,20 @@
 0000019: 01                                         ; OPCODE_BLOCK
 000001a: 01                                         ; num expressions
 000001b: 06                                         ; OPCODE_BR
-000001c: 02                                         ; break depth
-000001d: 00                                         ; OPCODE_NOP
+000001c: 00                                         ; break arity
+000001d: 02                                         ; break depth
 000001e: 03                                         ; OPCODE_IF
 000001f: 0a                                         ; OPCODE_I32_CONST
 0000020: 02                                         ; i32 literal
 0000021: 01                                         ; OPCODE_BLOCK
 0000022: 01                                         ; num expressions
 0000023: 06                                         ; OPCODE_BR
-0000024: 01                                         ; break depth
-0000025: 00                                         ; OPCODE_NOP
+0000024: 00                                         ; break arity
+0000025: 01                                         ; break depth
 0000011: 1300                                       ; FIXUP func body size
 0000026: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 0013 0000 0202 030a 0101 0106 0200 030a  
-0000020: 0201 0106 0100 06                        
+0000010: 0013 0000 0202 030a 0101 0106 0002 030a  
+0000020: 0201 0106 0001 06                        
 ;;; STDOUT ;;)

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -27,11 +27,11 @@
 0000019: 01                                         ; OPCODE_BLOCK
 000001a: 01                                         ; num expressions
 000001b: 06                                         ; OPCODE_BR
-000001c: 01                                         ; break depth
-000001d: 00                                         ; OPCODE_NOP
+000001c: 00                                         ; break arity
+000001d: 01                                         ; break depth
 0000011: 0b00                                       ; FIXUP func body size
 000001e: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
-0000010: 000b 0000 0201 030a 0101 0106 0100 06    
+0000010: 000b 0000 0201 030a 0101 0106 0001 06    
 ;;; STDOUT ;;)

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -21,8 +21,8 @@
 0000014: 02                                         ; OPCODE_LOOP
 0000015: 01                                         ; num expressions
 0000016: 07                                         ; OPCODE_BR_IF
-0000017: 00                                         ; break depth
-0000018: 00                                         ; OPCODE_NOP
+0000017: 00                                         ; break arity
+0000018: 00                                         ; break depth
 0000019: 0a                                         ; OPCODE_I32_CONST
 000001a: 00                                         ; i32 literal
 0000011: 0800                                       ; FIXUP func body size

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -21,8 +21,8 @@
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 07                                         ; OPCODE_BR_IF
-0000017: 00                                         ; break depth
-0000018: 00                                         ; OPCODE_NOP
+0000017: 00                                         ; break arity
+0000018: 00                                         ; break depth
 0000019: 0a                                         ; OPCODE_I32_CONST
 000001a: 01                                         ; i32 literal
 0000011: 0800                                       ; FIXUP func body size

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -46,8 +46,8 @@
 0000027: 0a                                         ; OPCODE_I32_CONST
 0000028: 02                                         ; i32 literal
 0000029: 06                                         ; OPCODE_BR
-000002a: 01                                         ; break depth
-000002b: 00                                         ; OPCODE_NOP
+000002a: 00                                         ; break arity
+000002b: 01                                         ; break depth
 000002c: 0a                                         ; OPCODE_I32_CONST
 000002d: 03                                         ; i32 literal
 0000011: 1b00                                       ; FIXUP func body size
@@ -55,5 +55,5 @@
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0201 0000  
 0000010: 001b 0000 0101 0104 0101 0802 0000 0001  
-0000020: 0000 000a 000a 010a 0206 0100 0a03 06    
+0000020: 0000 000a 000a 010a 0206 0001 0a03 06    
 ;;; STDOUT ;;)

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -19,12 +19,13 @@
 0000012: 0000                                       ; func body size
 0000014: 00                                         ; local decl count
 0000015: 12                                         ; OPCODE_CALL_FUNCTION
-0000016: 00                                         ; func index
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 01                                         ; i32 literal
-0000012: 0500                                       ; FIXUP func body size
-0000019: 06                                         ; WASM_BINARY_SECTION_END
+0000016: 01                                         ; call arity
+0000017: 00                                         ; func index
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 01                                         ; i32 literal
+0000012: 0600                                       ; FIXUP func body size
+000001a: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0100 0102 0100  
-0000010: 0000 0500 0012 000a 0106                 
+0000010: 0000 0600 0012 0100 0a01 06              
 ;;; STDOUT ;;)

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -36,25 +36,27 @@
 0000021: 0000                                       ; func body size
 0000023: 00                                         ; local decl count
 0000024: 1f                                         ; OPCODE_CALL_IMPORT
-0000025: 00                                         ; import index
-0000026: 0a                                         ; OPCODE_I32_CONST
-0000027: 01                                         ; i32 literal
-0000028: 0d                                         ; OPCODE_F32_CONST
-0000029: 0000 0040                                  ; f32 literal
-000002d: 12                                         ; OPCODE_CALL_FUNCTION
-000002e: 00                                         ; func index
-0000021: 0c00                                       ; FIXUP func body size
-000002f: 06                                         ; WASM_BINARY_SECTION_END
+0000025: 02                                         ; call arity
+0000026: 00                                         ; import index
+0000027: 0a                                         ; OPCODE_I32_CONST
+0000028: 01                                         ; i32 literal
+0000029: 0d                                         ; OPCODE_F32_CONST
+000002a: 0000 0040                                  ; f32 literal
+000002e: 12                                         ; OPCODE_CALL_FUNCTION
+000002f: 00                                         ; call arity
+0000030: 00                                         ; func index
+0000021: 0e00                                       ; FIXUP func body size
+0000031: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-0000014: 3000 0000                                  ; FIXUP import module name offset
-0000030: 666f 6f                                    ; import module name
-0000033: 00                                         ; \0
-0000018: 3400 0000                                  ; FIXUP import function name offset
-0000034: 6261 72                                    ; import function name
-0000037: 00                                         ; \0
+0000014: 3200 0000                                  ; FIXUP import module name offset
+0000032: 666f 6f                                    ; import module name
+0000035: 00                                         ; \0
+0000018: 3600 0000                                  ; FIXUP import function name offset
+0000036: 6261 72                                    ; import function name
+0000039: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0102 0201 0103 0001  
-0000010: 0801 0000 3000 0000 3400 0000 0201 0001  
-0000020: 000c 0000 1f00 0a01 0d00 0000 4012 0006  
-0000030: 666f 6f00 6261 7200                      
+0000010: 0801 0000 3200 0000 3600 0000 0201 0001  
+0000020: 000e 0000 1f02 000a 010d 0000 0040 1200  
+0000030: 0006 666f 6f00 6261 7200                 
 ;;; STDOUT ;;)

--- a/test/dump/callindirect-after-import.txt
+++ b/test/dump/callindirect-after-import.txt
@@ -53,27 +53,28 @@
 0000029: 0000                                       ; func body size
 000002b: 00                                         ; local decl count
 000002c: 13                                         ; OPCODE_CALL_INDIRECT
-000002d: 00                                         ; signature index
-000002e: 0a                                         ; OPCODE_I32_CONST
-000002f: 00                                         ; i32 literal
-0000030: 0d                                         ; OPCODE_F32_CONST
-0000031: 0000 803f                                  ; f32 literal
-0000029: 0a00                                       ; FIXUP func body size
-0000035: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-0000036: 01                                         ; num function table entries
-0000037: 0000                                       ; function table entry
-0000039: 06                                         ; WASM_BINARY_SECTION_END
+000002d: 01                                         ; call arity
+000002e: 00                                         ; signature index
+000002f: 0a                                         ; OPCODE_I32_CONST
+0000030: 00                                         ; i32 literal
+0000031: 0d                                         ; OPCODE_F32_CONST
+0000032: 0000 803f                                  ; f32 literal
+0000029: 0b00                                       ; FIXUP func body size
+0000036: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+0000037: 01                                         ; num function table entries
+0000038: 0000                                       ; function table entry
+000003a: 06                                         ; WASM_BINARY_SECTION_END
 ; import 0
-0000015: 3a00 0000                                  ; FIXUP import module name offset
-000003a: 666f 6f                                    ; import module name
-000003d: 00                                         ; \0
-0000019: 3e00 0000                                  ; FIXUP import function name offset
-000003e: 6261 72                                    ; import function name
-0000041: 00                                         ; \0
+0000015: 3b00 0000                                  ; FIXUP import module name offset
+000003b: 666f 6f                                    ; import module name
+000003e: 00                                         ; \0
+0000019: 3f00 0000                                  ; FIXUP import function name offset
+000003f: 6261 72                                    ; import function name
+0000042: 00                                         ; \0
 ;; dump
 0000000: 0061 736d 0a00 0000 0103 0100 0300 0100  
-0000010: 0008 0101 003a 0000 003e 0000 0002 0200  
-0000020: 0000 0200 0000 0002 000a 0000 1300 0a00  
-0000030: 0d00 0080 3f05 0100 0006 666f 6f00 6261  
-0000040: 7200                                     
+0000010: 0008 0101 003b 0000 003f 0000 0002 0200  
+0000020: 0000 0200 0000 0002 000b 0000 1301 000a  
+0000030: 000d 0000 803f 0501 0000 0666 6f6f 0062  
+0000040: 6172 00                                  
 ;;; STDOUT ;;)

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -21,17 +21,19 @@
 0000012: 0000                                       ; func body size
 0000014: 00                                         ; local decl count
 0000015: 13                                         ; OPCODE_CALL_INDIRECT
-0000016: 00                                         ; signature index
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 00                                         ; i32 literal
-0000019: 0a                                         ; OPCODE_I32_CONST
-000001a: 00                                         ; i32 literal
-0000012: 0700                                       ; FIXUP func body size
-000001b: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
-000001c: 01                                         ; num function table entries
-000001d: 0000                                       ; function table entry
-000001f: 06                                         ; WASM_BINARY_SECTION_END
+0000016: 01                                         ; call arity
+0000017: 00                                         ; signature index
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 00                                         ; i32 literal
+000001a: 0a                                         ; OPCODE_I32_CONST
+000001b: 00                                         ; i32 literal
+0000012: 0800                                       ; FIXUP func body size
+000001c: 05                                         ; WASM_BINARY_SECTION_FUNCTION_TABLE
+000001d: 01                                         ; num function table entries
+000001e: 0000                                       ; function table entry
+0000020: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0100 0102 0100  
-0000010: 0000 0700 0013 000a 000a 0005 0100 0006  
+0000010: 0000 0800 0013 0100 0a00 0a00 0501 0000  
+0000020: 06                                       
 ;;; STDOUT ;;)

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -21,12 +21,13 @@
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 01                                         ; num expressions
 0000016: 06                                         ; OPCODE_BR
-0000017: 00                                         ; break depth
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 01                                         ; i32 literal
-0000011: 0700                                       ; FIXUP func body size
-000001a: 06                                         ; WASM_BINARY_SECTION_END
+0000017: 01                                         ; break arity
+0000018: 00                                         ; break depth
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 01                                         ; i32 literal
+0000011: 0800                                       ; FIXUP func body size
+000001b: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
-0000010: 0007 0000 0101 0600 0a01 06              
+0000010: 0008 0000 0101 0601 000a 0106            
 ;;; STDOUT ;;)

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -22,16 +22,17 @@
 0000014: 01                                         ; OPCODE_BLOCK
 0000015: 02                                         ; num expressions
 0000016: 07                                         ; OPCODE_BR_IF
-0000017: 00                                         ; break depth
-0000018: 0a                                         ; OPCODE_I32_CONST
-0000019: 2a                                         ; i32 literal
-000001a: 0a                                         ; OPCODE_I32_CONST
-000001b: 00                                         ; i32 literal
-000001c: 0a                                         ; OPCODE_I32_CONST
-000001d: 1d                                         ; i32 literal
-0000011: 0b00                                       ; FIXUP func body size
-000001e: 06                                         ; WASM_BINARY_SECTION_END
+0000017: 01                                         ; break arity
+0000018: 00                                         ; break depth
+0000019: 0a                                         ; OPCODE_I32_CONST
+000001a: 2a                                         ; i32 literal
+000001b: 0a                                         ; OPCODE_I32_CONST
+000001c: 00                                         ; i32 literal
+000001d: 0a                                         ; OPCODE_I32_CONST
+000001e: 1d                                         ; i32 literal
+0000011: 0c00                                       ; FIXUP func body size
+000001f: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0001 0201 0000  
-0000010: 000b 0000 0102 0700 0a2a 0a00 0a1d 06    
+0000010: 000c 0000 0102 0701 000a 2a0a 000a 1d06  
 ;;; STDOUT ;;)

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -49,14 +49,16 @@
 0000034: 01                                         ; OPCODE_BLOCK
 0000035: 01                                         ; num expressions
 0000036: 14                                         ; OPCODE_RETURN
-0000037: 01                                         ; OPCODE_BLOCK
-0000038: 01                                         ; num expressions
-0000039: 14                                         ; OPCODE_RETURN
-000002e: 0a00                                       ; FIXUP func body size
-000003a: 06                                         ; WASM_BINARY_SECTION_END
+0000037: 01                                         ; return arity
+0000038: 01                                         ; OPCODE_BLOCK
+0000039: 01                                         ; num expressions
+000003a: 14                                         ; OPCODE_RETURN
+000003b: 00                                         ; return arity
+000002e: 0c00                                       ; FIXUP func body size
+000003c: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0101 0000 0202 0000  
 0000010: 0018 0000 030a 0101 0100 040a 0001 010d  
-0000020: 0000 803f 0101 0d00 0000 4000 0000 0a00  
-0000030: 0004 0a01 0101 1401 0114 06              
+0000020: 0000 803f 0101 0d00 0000 4000 0000 0c00  
+0000030: 0004 0a01 0101 1401 0101 1400 06         
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -326,17 +326,17 @@
 0000118: 05                                         ; num expressions (byte 0)
 0000119: 00                                         ; OPCODE_NOP
 000011a: 06                                         ; OPCODE_BR
-000011b: 02                                         ; break depth
-000011c: 00                                         ; OPCODE_NOP
+000011b: 00                                         ; break arity
+000011c: 02                                         ; break depth
 000011d: 06                                         ; OPCODE_BR
-000011e: 01                                         ; break depth
-000011f: 00                                         ; OPCODE_NOP
+000011e: 00                                         ; break arity
+000011f: 01                                         ; break depth
 0000120: 06                                         ; OPCODE_BR
-0000121: 02                                         ; break depth
-0000122: 00                                         ; OPCODE_NOP
+0000121: 00                                         ; break arity
+0000122: 02                                         ; break depth
 0000123: 06                                         ; OPCODE_BR
-0000124: 01                                         ; break depth
-0000125: 00                                         ; OPCODE_NOP
+0000124: 00                                         ; break arity
+0000125: 01                                         ; break depth
 0000011: 1301                                       ; FIXUP func body size
 0000126: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
@@ -357,6 +357,6 @@
 00000e0: 0000 0000 0000 0000 0000 0000 0000 0000  
 00000f0: 0000 0000 0000 0000 0000 0000 0000 0000  
 0000100: 0000 0000 0000 0000 0000 0000 0000 0000  
-0000110: 0000 0000 0000 0001 0500 0602 0006 0100  
-0000120: 0602 0006 0100 06                        
+0000110: 0000 0000 0000 0001 0500 0600 0206 0001  
+0000120: 0600 0206 0001 06                        
 ;;; STDOUT ;;)

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -22,19 +22,21 @@
 0000013: 0000                                       ; func body size
 0000015: 00                                         ; local decl count
 0000016: 14                                         ; OPCODE_RETURN
-0000017: 0a                                         ; OPCODE_I32_CONST
-0000018: 2a                                         ; i32 literal
-0000013: 0400                                       ; FIXUP func body size
+0000017: 00                                         ; return arity
+0000018: 0a                                         ; OPCODE_I32_CONST
+0000019: 2a                                         ; i32 literal
+0000013: 0500                                       ; FIXUP func body size
 ; function 1
-0000019: 00                                         ; func flags
-000001a: 0100                                       ; func signature index
-000001c: 0000                                       ; func body size
-000001e: 00                                         ; local decl count
-000001f: 14                                         ; OPCODE_RETURN
-000001c: 0200                                       ; FIXUP func body size
-0000020: 06                                         ; WASM_BINARY_SECTION_END
+000001a: 00                                         ; func flags
+000001b: 0100                                       ; func signature index
+000001d: 0000                                       ; func body size
+000001f: 00                                         ; local decl count
+0000020: 14                                         ; OPCODE_RETURN
+0000021: 00                                         ; return arity
+000001d: 0300                                       ; FIXUP func body size
+0000022: 06                                         ; WASM_BINARY_SECTION_END
 ;; dump
 0000000: 0061 736d 0a00 0000 0102 0001 0000 0202  
-0000010: 0000 0004 0000 140a 2a00 0100 0200 0014  
-0000020: 06                                       
+0000010: 0000 0005 0000 1400 0a2a 0001 0003 0000  
+0000020: 1400 06                                  
 ;;; STDOUT ;;)


### PR DESCRIPTION
To be landed in sync with matching changes to V8, see:

https://codereview.chromium.org/1749993003/
https://codereview.chromium.org/1777513002/
