### PR TITLE
Add options to build without GTest submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,13 @@ add_executable(sexpr-wasm ${SEXPR_WASM_SRCS})
 add_dependencies(everything sexpr-wasm)
 
 # hexfloat-test
+option(BUILD_TESTS "Build GTest-based tests" ON)
 find_package(Threads)
-if (CMAKE_USE_PTHREADS_INIT)
+if (BUILD_TESTS AND CMAKE_USE_PTHREADS_INIT)
+  if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/gtest/googletest)
+    message(FATAL_ERROR "Can't find third_party/gtest. Run git submodule update --init, or disable with CMake -DBUILD_TESTS=OFF.")
+  endif ()
+
   set(HEXFLOAT_TEST_SRCS
     src/wasm-literal.c
     test/hexfloat.cc
@@ -141,7 +146,7 @@ endif ()
 # test running
 find_package(PythonInterp 2.7 REQUIRED)
 set(RUN_TESTS_PY ${SEXPR_WASM_SOURCE_DIR}/test/run-tests.py)
-add_custom_target(test
+add_custom_target(run-tests
   COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} -e $<TARGET_FILE:sexpr-wasm>
   DEPENDS sexpr-wasm
   WORKING_DIRECTORY ${SEXPR_WASM_SOURCE_DIR}
@@ -161,12 +166,14 @@ if (COMPILER_IS_CLANG)
 
   macro(add_sanitizer SANITIZER_NAME FLAGS)
     add_sanitizer_exe(sexpr-wasm-${SANITIZER_NAME} ${FLAGS} "${SEXPR_WASM_SRCS}")
-    add_sanitizer_exe(hexfloat_test-${SANITIZER_NAME} ${FLAGS} "${HEXFLOAT_TEST_SRCS}")
+    if (BUILD_TESTS)
+      add_sanitizer_exe(hexfloat_test-${SANITIZER_NAME} ${FLAGS} "${HEXFLOAT_TEST_SRCS}")
+    endif ()
 
     add_custom_target(all-${SANITIZER_NAME}
       DEPENDS sexpr-wasm-${SANITIZER_NAME} hexfloat_test-${SANITIZER_NAME})
 
-    add_custom_target(test-${SANITIZER_NAME}
+    add_custom_target(run-tests-${SANITIZER_NAME}
       COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY}
           -e $<TARGET_FILE:sexpr-wasm-${SANITIZER_NAME}>
       DEPENDS sexpr-wasm-${SANITIZER_NAME}

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ GCC_I686_DEBUG_DIR := out/gcc-i686/Debug
 GCC_I686_RELEASE_DIR := out/gcc-i686/Release
 CLANG_DEBUG_DIR := out/clang/Debug
 CLANG_RELEASE_DIR := out/clang/Release
+CLANG_DEBUG_NO_TESTS_DIR := out/clang/Debug-no-tests
 
 DEBUG_FLAG := -DCMAKE_BUILD_TYPE=Debug
 RELEASE_FLAG := -DCMAKE_BUILD_TYPE=Release
@@ -48,6 +49,7 @@ GCC_I686_DEBUG_PREFIX := gcc-i686-debug
 GCC_I686_RELEASE_PREFIX := gcc-i686-release
 CLANG_DEBUG_PREFIX := clang-debug
 CLANG_RELEASE_PREFIX := clang-release
+CLANG_DEBUG_NO_TESTS_PREFIX := clang-debug-no-tests
 
 NO_SUFFIX :=
 ASAN_SUFFIX := -asan
@@ -91,7 +93,7 @@ endef
 define TEST
 .PHONY: test-$$($(1)_$(2)_PREFIX)$$($(3)_SUFFIX)
 test-$$($(1)_$(2)_PREFIX)$$($(3)_SUFFIX): $$($(1)_$(2)_DIR)/$$(BUILD_FILE)
-	$$(BUILD) -C $$($(1)_$(2)_DIR) test$$($(3)_SUFFIX)
+	$$(BUILD) -C $$($(1)_$(2)_DIR) run-tests$$($(3)_SUFFIX)
 endef
 
 .PHONY: all
@@ -140,3 +142,8 @@ $(foreach SANITIZER,$(SANITIZERS), \
 $(eval $(call CMAKE,GCC,DEBUG_NO_FLEX_BISON,-DRUN_FLEX_BISON=OFF))
 $(eval $(call EXE,GCC,DEBUG_NO_FLEX_BISON,NO))
 $(eval $(call TEST,GCC,DEBUG_NO_FLEX_BISON,NO))
+
+# One-off build target for running w/out gtest
+$(eval $(call CMAKE,CLANG,DEBUG_NO_TESTS,-DBUILD_TESTS=OFF))
+$(eval $(call EXE,CLANG,DEBUG_NO_TESTS,NO))
+$(eval $(call TEST,CLANG,DEBUG_NO_TESTS,NO))

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -21,9 +21,12 @@ set -o errexit
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source ${SCRIPT_DIR}/travis-common.sh
 
-# Build without flex/bison to test prebuilt C sources
 if [ ${CC} = "gcc" ]; then
+  # Build without flex/bison to test prebuilt C sources
   make gcc-debug-no-flex-bison
+elif [ ${CC} = "clang" ]; then
+  # Test building without GTest submodule
+  make clang-debug-no-tests
 fi
 
 for COMPILER in ${COMPILERS}; do


### PR DESCRIPTION
This is used by the Wasm waterfall.