### PR TITLE
Fix build for Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,10 @@ target_link_libraries(wasm-wast libwasm)
 # wasm-interp
 add_executable(wasm-interp src/wasm-interp.c)
 add_dependencies(everything wasm-interp)
-target_link_libraries(wasm-interp libwasm m)
+target_link_libraries(wasm-interp libwasm)
+if (COMPILER_IS_CLANG OR COMPILER_IS_GNU)
+  target_link_libraries(wasm-interp m)
+endif ()
 
 # stuff that requires squirrel
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/squirrel/squirrel)
@@ -275,7 +278,10 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/squirrel/squirrel)
   # wasm-interp-sq
   add_executable(wasm-interp-sq src/wasm-interp-sq.c)
   add_dependencies(everything wasm-interp-sq)
-  target_link_libraries(wasm-interp-sq libwasm libsquirrel m)
+  target_link_libraries(wasm-interp-sq libwasm libsquirrel)
+  if (COMPILER_IS_CLANG OR COMPILER_IS_GNU)
+    target_link_libraries(wasm-interp-sq m)
+  endif ()
 endif ()
 
 

--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -845,9 +845,9 @@ static void write_module(WasmContext* ctx, const WasmModule* module) {
   if (module->memory) {
     WasmBool export_memory = module->export_memory != NULL;
     begin_section(ctx, WASM_SECTION_NAME_MEMORY, leb_size_guess);
-    write_u32_leb128(&ctx->stream, module->memory->initial_pages,
+    write_u32_leb128(&ctx->stream, (uint32_t)module->memory->initial_pages,
                      "min mem pages");
-    write_u32_leb128(&ctx->stream, module->memory->max_pages, "max mem pages");
+    write_u32_leb128(&ctx->stream, (uint32_t)module->memory->max_pages, "max mem pages");
     wasm_write_u8(&ctx->stream, export_memory, "export mem");
     end_section(ctx);
   }

--- a/src/wasm-config.h.in
+++ b/src/wasm-config.h.in
@@ -131,18 +131,25 @@ __inline unsigned long wasm_clz_u64(unsigned __int64 mask) {
 }
 
 __inline unsigned long wasm_ctz_u32(unsigned long mask) {
-  unsigned long index;
-  _BitScanForward(&index, mask);
-  return sizeof(unsigned long) * 8 - (index + 1);
+    unsigned long index;
+    _BitScanForward(&index, mask);
+    return index;
 }
 
 __inline unsigned long wasm_ctz_u64(unsigned __int64 mask) {
 #if _M_X64
-  unsigned long index;
-  _BitScanForward64(&index, mask);
-  return sizeof(unsigned __int64) * 8 - (index + 1);
+    unsigned long index;
+    _BitScanForward64(&index, mask);
+    return index;
 #elif _M_IX86
-  /* TODO(binji): implement */
+    unsigned long low_mask = (unsigned long)mask;
+    if (low_mask) {
+        return wasm_ctz_u32(low_mask);
+    }
+    unsigned long high_mask;
+    memcpy(&high_mask, (unsigned char*)&mask + sizeof(unsigned long),
+           sizeof(unsigned long));
+    return sizeof(unsigned long) * 8 + wasm_ctz_u32(high_mask);
 #else
 #error unexpected architecture
 #endif
@@ -151,12 +158,19 @@ __inline unsigned long wasm_ctz_u64(unsigned __int64 mask) {
 
 #define wasm_popcount_u32 __popcnt
 #if _M_X64
-#define wasm_popcount_u64 __popcnt64
 #elif _M_IX86
-/* TODO(binji): implement */
+__inline unsigned __int64 __popcnt64(unsigned __int64 value) {
+    unsigned long high_value;
+    unsigned long low_value;
+    memcpy(&high_value, (unsigned char*)&value + sizeof(unsigned long),
+           sizeof(unsigned long));
+    memcpy(&low_value, &value, sizeof(unsigned long));
+    return wasm_popcount_u32(high_value) + wasm_popcount_u32(low_value);
+}
 #else
 #error unexpected architecture
 #endif
+#define wasm_popcount_u64 __popcnt64
 
 /* print format specifier for size_t */
 #if SIZEOF_SIZE_T == 4

--- a/src/wasm-interpreter.c
+++ b/src/wasm-interpreter.c
@@ -366,7 +366,7 @@ DEFINE_BITCAST(bitcast_u64_to_f64, uint64_t, double)
 
 #define GOTO(offset) pc = &istream[offset]
 
-#define PUSH_CALL(o)                                 \
+#define PUSH_CALL()                                  \
   do {                                               \
     TRAP_IF(cs_top >= cs_end, CALL_STACK_EXHAUSTED); \
     (*cs_top++) = (pc - istream);                    \


### PR DESCRIPTION
Fix implementation of ctz64, clz64 & popcnt64 for Win32
Fixed a few warnings in msvc.
The current ctz implementation for 32 & 64 bits were incorrect as `_BitScanForward` has the same result as `__builtin_ctz`. I don't know why we used to do `return sizeof(unsigned long) * 8 - (index + 1);`

I haven't fully tested the with the product yet. I mostly focused on making sure the ctz/clz/popcnt implementations were correct.
