### PR TITLE
fix bugs found by afl and asan

### DIFF
--- a/src/prebuilt/wasm-ast-parser-gen.c
+++ b/src/prebuilt/wasm-ast-parser-gen.c
@@ -3509,7 +3509,7 @@ static void dup_text_list(WasmAllocator* allocator,
      * iterate through the string once. */
     const char* src = node->text.start + 1;
     const char* end = node->text.start + node->text.length - 1;
-    size_t size = end - src;
+    size_t size = (end > src) ? (end - src) : 0;
     total_size += size;
   }
   char* result = wasm_alloc(allocator, total_size, 1);

--- a/src/wasm-ast-parser.y
+++ b/src/wasm-ast-parser.y
@@ -1158,7 +1158,7 @@ static void dup_text_list(WasmAllocator* allocator,
      * iterate through the string once. */
     const char* src = node->text.start + 1;
     const char* end = node->text.start + node->text.length - 1;
-    size_t size = end - src;
+    size_t size = (end > src) ? (end - src) : 0;
     total_size += size;
   }
   char* result = wasm_alloc(allocator, total_size, 1);

--- a/src/wasm-interp.c
+++ b/src/wasm-interp.c
@@ -397,10 +397,11 @@ static WasmResult read_module(WasmAllocator* allocator,
   WasmResult result;
   void* data;
   size_t size;
+  WASM_ZERO_MEMORY(*out_module);
+  WASM_ZERO_MEMORY(*out_thread);
   result = wasm_read_file(allocator, module_filename, &data, &size);
   if (WASM_SUCCEEDED(result)) {
     WasmAllocator* memory_allocator = &g_wasm_libc_allocator;
-    WASM_ZERO_MEMORY(*out_module);
     result = wasm_read_binary_interpreter(allocator, memory_allocator, data,
                                           size, &s_read_binary_options,
                                           &s_error_handler, out_module);
@@ -412,7 +413,6 @@ static WasmResult read_module(WasmAllocator* allocator,
       }
 
       set_all_import_callbacks_to_default(out_module);
-      WASM_ZERO_MEMORY(*out_thread);
       result = wasm_init_interpreter_thread(allocator, out_module, out_thread,
                                             &s_thread_options);
     }

--- a/src/wasm-stack-allocator.c
+++ b/src/wasm-stack-allocator.c
@@ -62,6 +62,7 @@ static WasmStackAllocatorChunk* allocate_chunk(
     size_t max_avail,
     const char* file,
     int line) {
+  assert(max_avail < SIZE_MAX - sizeof(WasmStackAllocatorChunk));
   size_t real_size = max_avail + sizeof(WasmStackAllocatorChunk);
   /* common case of allocating a chunk of exactly CHUNK_SIZE */
   if (real_size == CHUNK_SIZE) {
@@ -100,6 +101,7 @@ static void* stack_alloc(WasmAllocator* allocator,
   WasmStackAllocator* stack_allocator = (WasmStackAllocator*)allocator;
   assert(is_power_of_two(align));
   WasmStackAllocatorChunk* chunk = stack_allocator->last;
+  assert(size < SIZE_MAX - align + 1);
   size_t alloc_size = size + align - 1;
   void* result;
   if (alloc_size >= CHUNK_MAX_AVAIL) {

--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -1,0 +1,17 @@
+;;; ERROR: 1
+;;; TOOL: run-gen-wasm-interp
+magic
+version
+section("memory") {
+  initial[0]
+  max[1]
+  export[0]
+}
+section("data") {
+  count[1] addr[0] data[str("overflow")]
+}
+(;; STDERR ;;;
+Error running "wasm-interp":
+error: @0x00000024: on_data_segment callback failed
+
+;;; STDERR ;;)

--- a/test/binary/bad-function-body-size.txt
+++ b/test/binary/bad-function-body-size.txt
@@ -1,0 +1,19 @@
+;;; ERROR: 1
+;;; TOOL: run-gen-wasm-interp
+magic
+version
+section("type") { count[1] function params[0] results[1] i32 }
+section("function") { count[1] sig[0] }
+section("code") {
+  count[1]
+  0x01 ;; malformed 1 byte function body size (should be 5)
+    locals[0]
+    i32.const
+    leb_i32(42)
+    return arity[1]
+}
+(;; STDERR ;;;
+Error running "wasm-interp":
+error: @0x00000028: end_function_body callback failed
+
+;;; STDERR ;;)

--- a/test/run-gen-wasm-interp.py
+++ b/test/run-gen-wasm-interp.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 WebAssembly Community Group participants
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import os
+import subprocess
+import sys
+
+import find_exe
+import utils
+from utils import Error
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+GEN_WASM_PY = os.path.join(SCRIPT_DIR, 'gen-wasm.py')
+
+
+def main(args):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-o', '--out-dir', metavar='PATH',
+                      help='output directory for files.')
+  parser.add_argument('--wasm-interp-executable', metavar='PATH',
+                      help='override wasm-interp executable.')
+  parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
+                      action='store_true')
+  parser.add_argument('--no-error-cmdline',
+                      help='don\'t display the subprocess\'s commandline when' +
+                          ' an error occurs', dest='error_cmdline',
+                      action='store_false')
+  parser.add_argument('--run-all-exports', action='store_true')
+  parser.add_argument('--spec', action='store_true')
+  parser.add_argument('--use-libc-allocator', action='store_true')
+  parser.add_argument('file', help='test file.')
+  options = parser.parse_args(args)
+
+  gen_wasm = utils.Executable(
+      sys.executable, GEN_WASM_PY, error_cmdline=options.error_cmdline)
+
+  wasm_interp = utils.Executable(find_exe.GetWasmInterpExecutable(
+      options.wasm_interp_executable),
+      error_cmdline=options.error_cmdline)
+  wasm_interp.AppendOptionalArgs({
+    '--run-all-exports': options.run_all_exports,
+    '--spec': options.spec,
+    '--trace': options.verbose,
+    '--use-libc-allocator': options.use_libc_allocator
+  })
+
+  with utils.TempDirectory(options.out_dir, 'run-gen-wasm-interp-') as out_dir:
+    out_file = utils.ChangeDir(utils.ChangeExt(options.file, '.wasm'), out_dir)
+    gen_wasm.RunWithArgs(options.file, '-o', out_file)
+    wasm_interp.RunWithArgs(out_file)
+
+  return 0
+
+
+if __name__ == '__main__':
+  try:
+    sys.exit(main(sys.argv[1:]))
+  except Error as e:
+    sys.stderr.write(str(e) + '\n')
+    sys.exit(1)
+

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -98,6 +98,14 @@ TOOLS = {
       '--wasm-wast-executable=%(wasm-wast)s',
       '--no-error-cmdline',
     ])
+  },
+  'run-gen-wasm-interp': {
+    'EXE': 'test/run-gen-wasm-interp.py',
+    'FLAGS': ' '.join([
+      '--wasm-interp-executable=%(wasm-interp)s',
+      '--run-all-exports',
+      '--no-error-cmdline',
+    ])
   }
 }
 


### PR DESCRIPTION
There were a couple of integer underflows and overflows that could result in out-of-bounds memory accesses, and some uninitialized memory that could result in bad calls to the free pointer of the memory allocator.