### PR TITLE
add flags to turn off AST checking in sexpr-wasm

### DIFF
--- a/src/wasm-ast-checker.h
+++ b/src/wasm-ast-checker.h
@@ -25,10 +25,20 @@ struct WasmModule;
 struct WasmScript;
 
 WASM_EXTERN_C_BEGIN
+/* Only check that names are valid; this is useful if you want to generate
+ * invalid binaries (so they can be validated by the consumer). */
+WasmResult wasm_check_names(WasmAstLexer*,
+                            const struct WasmScript*,
+                            WasmSourceErrorHandler*);
+
+/* perform all checks on the AST; the module is valid if and only if this
+ * function succeeds. */
 WasmResult wasm_check_ast(WasmAstLexer*,
                           const struct WasmScript*,
                           WasmSourceErrorHandler*);
 
+/* Run the assert_invalid spec tests. These always contain an invalid module.
+ * This function succeeds if and only if the contained module is invalid. */
 WasmResult wasm_check_assert_invalid(
     struct WasmAllocator*,
     WasmAstLexer*,

--- a/src/wasm-binary-writer-spec.c
+++ b/src/wasm-binary-writer-spec.c
@@ -278,6 +278,9 @@ static void write_commands(Context* ctx, WasmScript* script) {
       num_assert_funcs = 0;
       ++num_modules;
     } else {
+      if (!last_module)
+        continue;
+
       const char* format = NULL;
       WasmCommandInvoke* invoke = NULL;
       switch (command->type) {

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -1,0 +1,53 @@
+;;; FLAGS: -v --no-check
+(module
+  (func (result i64)
+    (i32.add
+      (f32.const 1)
+      (f64.const 2)))
+  (export "foo" 0))
+(;; STDOUT ;;;
+0000000: 0061 736d                                  ; WASM_BINARY_MAGIC
+0000004: 0b00 0000                                  ; WASM_BINARY_VERSION
+; section "type"
+0000008: 04                                         ; string length
+0000009: 7479 7065                                  ; section id: "type"
+000000d: 00                                         ; section size (guess)
+000000e: 01                                         ; num types
+; type 0
+000000f: 40                                         ; function form
+0000010: 00                                         ; num params
+0000011: 01                                         ; num results
+0000012: 02                                         ; result_type
+000000d: 05                                         ; FIXUP section size
+; section "function"
+0000013: 08                                         ; string length
+0000014: 6675 6e63 7469 6f6e                        ; section id: "function"
+000001c: 00                                         ; section size (guess)
+000001d: 01                                         ; num functions
+000001e: 00                                         ; function 0 signature index
+000001c: 02                                         ; FIXUP section size
+; section "export"
+000001f: 06                                         ; string length
+0000020: 6578 706f 7274                             ; section id: "export"
+0000026: 00                                         ; section size (guess)
+0000027: 01                                         ; num exports
+0000028: 00                                         ; export func index
+0000029: 03                                         ; string length
+000002a: 666f 6f                                  foo  ; export name
+0000026: 06                                         ; FIXUP section size
+; section "code"
+000002d: 04                                         ; string length
+000002e: 636f 6465                                  ; section id: "code"
+0000032: 00                                         ; section size (guess)
+0000033: 01                                         ; num functions
+; function body 0
+0000034: 00                                         ; func body size (guess)
+0000035: 00                                         ; local decl count
+0000036: 13                                         ; OPCODE_F32_CONST
+0000037: 0000 803f                                  ; f32 literal
+000003b: 12                                         ; OPCODE_F64_CONST
+000003c: 0000 0000 0000 0040                        ; f64 literal
+0000044: 40                                         ; OPCODE_I32_ADD
+0000034: 10                                         ; FIXUP func body size
+0000032: 12                                         ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/help/sexpr-wasm.txt
+++ b/test/help/sexpr-wasm.txt
@@ -31,4 +31,6 @@ options:
       --no-canonicalize-leb128s        Write all LEB128 sizes as 5-bytes instead of their minimal size
       --no-remap-locals                If set, function locals are written in source order, instead of packing them to reduce size
       --debug-names                    Write debug names to the generated binary file
+      --no-check                       Don't check for invalid modules
+      --no-check-assert-invalid        Don't run the assert_invalid checks
 ;;; STDOUT ;;)

--- a/test/parse/assert/nocheck-assertinvalid.txt
+++ b/test/parse/assert/nocheck-assertinvalid.txt
@@ -1,0 +1,10 @@
+;;; FLAGS: --spec --no-check-assert-invalid
+
+;; normally would fail because the module is valid.
+(assert_invalid
+  (module) "foo")
+
+;; normally would print a message displaying why the module was invalid.
+(assert_invalid
+  (module
+    (func (result i32) (i64.const 1))) "bar")

--- a/test/typecheck/nocheck.txt
+++ b/test/typecheck/nocheck.txt
@@ -1,0 +1,4 @@
+;;; FLAGS: --no-check
+(module
+  (func (result i32)
+    (nop)))  ;;; this is a typecheck error, but succeeds because of --no-check


### PR DESCRIPTION
* `--no-check` disables all checking except for validating names (without
  which you couldn't generate a binary file).
* `--no-check-assert-invalid` skips running the `assert_invalid` checks
  in spec test files.