### PR TITLE
Make return arity 1 only if function return type is not void

### DIFF
--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -650,7 +650,8 @@ static void write_expr(WasmContext* ctx,
     case WASM_EXPR_TYPE_RETURN:
       write_expr_opt(ctx, module, func, expr->return_.expr);
       write_opcode(&ctx->stream, WASM_OPCODE_RETURN);
-      wasm_write_u8(&ctx->stream, expr->return_.expr ? 1 : 0, "return arity");
+      int has_return_value = func->decl.sig.result_type != WASM_TYPE_VOID;
+      wasm_write_u8(&ctx->stream, has_return_value ? 1 : 0, "return arity");
       break;
     case WASM_EXPR_TYPE_SELECT:
       write_expr(ctx, module, func, expr->select.true_);

--- a/test/spec/functions.txt
+++ b/test/spec/functions.txt
@@ -1,14 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-js-spec
 ;;; STDIN_FILE: third_party/testsuite/functions.wast
-(;; STDERR ;;;
-Error running "d8":
-
-;;; STDERR ;;)
 (;; STDOUT ;;;
-WasmModule::Instantiate(): Compiling WASM function #6:<?> failed:Result = arity mismatch in return @+2
-
-  var module = Wasm.instantiateModule(u8a, ffi);
-                    ^
-
+10/10 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
Fixes #82 
Determine the arity of the return opcode from the return type instead of the presence of an expression next to it.
Fix the faulty baseline for spec/functions.txt