### PR TITLE
Teach test scripts about ch.exe

### DIFF
--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -30,6 +30,7 @@ DOWNLOAD_D8_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'd8')
 BUILT_SM_EXE = os.path.join(REPO_ROOT_DIR, 'third_party', 'gecko-dev', 'js',
                             'src', 'build_OPT.OBJ', 'js', 'src', 'js')
 DOWNLOAD_SM_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'js')
+DOWNLOAD_CHAKRA_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'ch')
 DEFAULT_WASM_WAST_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'wasm-wast')
 DEFAULT_WASM_INTERP_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'wasm-interp')
 
@@ -40,6 +41,7 @@ if IS_WINDOWS:
   DOWNLOAD_D8_EXE += '.exe'
   BUILT_SM_EXE += '.exe'
   DOWNLOAD_SM_EXE += '.exe'
+  DOWNLOAD_CHAKRA_EXE += '.exe'
   DEFAULT_WASM_WAST_EXE += '.exe'
   DEFAULT_WASM_INTERP_EXE += '.exe'
 
@@ -74,4 +76,4 @@ def GetWasmInterpExecutable(override=None):
 
 def GetJSExecutable(override=None):
   return FindExeWithFallback('js',
-      [BUILT_D8_EXE, BUILT_SM_EXE, DOWNLOAD_D8_EXE, DOWNLOAD_SM_EXE], override)
+      [BUILT_D8_EXE, BUILT_SM_EXE, DOWNLOAD_D8_EXE, DOWNLOAD_SM_EXE, DOWNLOAD_CHAKRA_EXE], override)

--- a/test/run-js.py
+++ b/test/run-js.py
@@ -51,18 +51,22 @@ def GetExeBasename(exe):
 
 def GetJSExecutable(options):
   exe = find_exe.GetJSExecutable(options.js_executable)
-  if GetExeBasename(exe) == 'd8':
+  basename = GetExeBasename(exe)
+  if basename == 'd8':
     return utils.Executable(exe,
+                            basename=basename,
                             clean_stdout=CleanD8Stdout,
                             clean_stderr=CleanD8Stderr,
                             error_cmdline=options.error_cmdline)
   else:
-    return utils.Executable(exe, error_cmdline=options.error_cmdline)
+    return utils.Executable(exe, basename=basename, error_cmdline=options.error_cmdline)
 
 
 def RunJS(js, js_file, out_file):
-  if GetExeBasename(js.exe) == 'd8':
+  if js.basename == 'd8':
     js.RunWithArgs('--expose-wasm', js_file, '--', out_file)
+  elif js.basename == 'ch':
+    js.RunWithArgs('-on:WasmLazyTrap', js_file, '-args', out_file, '-endargs')
   else:
     js.RunWithArgs(js_file, out_file)
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
-/* polyfill from SM to D8 */
+/* polyfill from SM/CH to D8 */
 if (typeof arguments == 'undefined') {
-  arguments = scriptArgs;
+  if (typeof scriptArgs != 'undefined') {
+    arguments = scriptArgs;
+  } else if(typeof WScript != 'undefined') {
+    arguments = WScript.Arguments || [];
+  }
+}
+
+if (typeof quit == 'undefined') {
+  if (typeof WScript != 'undefined') {
+    quit = WScript.quit;
+  }
 }
 
 if (typeof readbuffer == 'undefined') {

--- a/test/utils.py
+++ b/test/utils.py
@@ -37,6 +37,7 @@ class Executable(object):
     self.exe = exe
     self.before_args = list(before_args)
     self.after_args = []
+    self.basename = kwargs.get('basename', os.path.basename(exe)).replace('.exe', '')
     self.error_cmdline = kwargs.get('error_cmdline', True)
     self.clean_stdout = kwargs.get('clean_stdout')
     self.clean_stderr = kwargs.get('clean_stderr')
@@ -45,9 +46,9 @@ class Executable(object):
     cmd = [self.exe] + self.before_args + list(args) + self.after_args
     cmd_str = ' '.join(cmd)
 
-    err_cmd_str = cmd_str
+    err_cmd_str = cmd_str.replace('.exe', '')
     if not self.error_cmdline:
-      err_cmd_str = os.path.basename(self.exe)
+      err_cmd_str = self.basename
 
     stdout = ''
     stderr = ''

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
-/* polyfill from SM to D8 */
+/* polyfill from SM/CH to D8 */
 if (typeof arguments == 'undefined') {
-  arguments = scriptArgs;
+  if (typeof scriptArgs != 'undefined') {
+    arguments = scriptArgs;
+  } else if(typeof WScript != 'undefined') {
+    arguments = WScript.Arguments || [];
+  }
+}
+
+if (typeof quit == 'undefined') {
+  if (typeof WScript != 'undefined') {
+    quit = WScript.quit;
+  }
 }
 
 if (typeof readbuffer == 'undefined') {


### PR DESCRIPTION
Added support for ch.exe (run-js.py and polyfills in js scripts)
Todo, currently no script to build/download ch.exe it has to be built separately.