### PR TITLE
functions have an implicit block scope

### DIFF
--- a/src/wasm-ast-checker.c
+++ b/src/wasm-ast-checker.c
@@ -740,8 +740,15 @@ static void check_func(Context* ctx,
 
   check_duplicate_bindings(ctx, &func->param_bindings, "parameter");
   check_duplicate_bindings(ctx, &func->local_bindings, "local");
-  check_expr_list(ctx, &func->loc, func->first_expr, wasm_get_result_type(func),
+  WasmType result_type = wasm_get_result_type(func);
+  /* The function has an implicit label; branching to it is equivalent to the
+   * returning from the function. */
+  LabelNode node;
+  WasmLabel label = wasm_empty_string_slice();
+  push_label(ctx, &func->loc, &node, &label, result_type, "func");
+  check_expr_list(ctx, &func->loc, func->first_expr, result_type,
                   " of function result");
+  pop_label(ctx);
   ctx->current_func = NULL;
 }
 

--- a/src/wasm-ast-writer.c
+++ b/src/wasm-ast-writer.c
@@ -599,6 +599,7 @@ static void write_func(Context* ctx,
                         &func->local_bindings);
   }
   write_newline(ctx, NO_FORCE_NEWLINE);
+  ctx->depth = 1; /* for the implicit "return" label */
   write_expr_list(ctx, func->first_expr);
   write_close_newline(ctx);
 }

--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -760,8 +760,12 @@ static void write_func_locals(WasmContext* ctx,
 static void write_func(WasmContext* ctx,
                        const WasmModule* module,
                        const WasmFunc* func) {
+  WasmLabelNode node;
+  WasmLabel label = wasm_empty_string_slice();
   write_func_locals(ctx, module, func, &func->local_types);
+  push_label(ctx, &node, &label);
   write_expr_list(ctx, module, func, func->first_expr);
+  pop_label(ctx, &label);
 }
 
 static void write_module(WasmContext* ctx, const WasmModule* module) {

--- a/src/wasm-common.c
+++ b/src/wasm-common.c
@@ -46,6 +46,13 @@ uint32_t wasm_get_opcode_alignment(WasmOpcode opcode, uint32_t alignment) {
   return alignment;
 }
 
+WasmStringSlice wasm_empty_string_slice(void) {
+  WasmStringSlice result;
+  result.start = "";
+  result.length = 0;
+  return result;
+}
+
 WasmBool wasm_string_slices_are_equal(const WasmStringSlice* a,
                                       const WasmStringSlice* b) {
   return a->start && b->start && a->length == b->length &&

--- a/src/wasm-common.h
+++ b/src/wasm-common.h
@@ -346,6 +346,7 @@ WasmBool wasm_is_naturally_aligned(WasmOpcode opcode, uint32_t alignment);
  * |opcode|, else return |alignment| */
 uint32_t wasm_get_opcode_alignment(WasmOpcode opcode, uint32_t alignment);
 
+WasmStringSlice wasm_empty_string_slice(void);
 WasmBool wasm_string_slices_are_equal(const WasmStringSlice*,
                                       const WasmStringSlice*);
 void wasm_destroy_string_slice(struct WasmAllocator*, WasmStringSlice*);

--- a/test/interp/spec/br.txt
+++ b/test/interp/spec/br.txt
@@ -10,15 +10,15 @@ assert_invalid error:
     (block (br 0 (i64.const 1)) (i32.const 1))
                  ^
 assert_invalid error:
-  third_party/testsuite/br.wast:354:36: label variable out of range (max 0)
+  third_party/testsuite/br.wast:354:36: label variable out of range (max 1)
   (module (func $unbound-label (br 1)))
                                    ^
 assert_invalid error:
-  third_party/testsuite/br.wast:358:57: label variable out of range (max 2)
+  third_party/testsuite/br.wast:358:57: label variable out of range (max 3)
   (module (func $unbound-nested-label (block (block (br 5)))))
                                                         ^
 assert_invalid error:
-  third_party/testsuite/br.wast:362:34: label variable out of range (max 0)
+  third_party/testsuite/br.wast:362:34: label variable out of range (max 1)
   (module (func $large-label (br 0x100000001)))
                                  ^^^^^^^^^^^
 64/64 tests passed.

--- a/test/interp/spec/br_if.txt
+++ b/test/interp/spec/br_if.txt
@@ -78,15 +78,15 @@ assert_invalid error:
     (block (br_if 0 (i32.const 0) (i64.const 0)) (i32.const 1))
                                   ^
 assert_invalid error:
-  third_party/testsuite/br_if.wast:280:39: label variable out of range (max 0)
+  third_party/testsuite/br_if.wast:280:39: label variable out of range (max 1)
   (module (func $unbound-label (br_if 1 (i32.const 1))))
                                       ^
 assert_invalid error:
-  third_party/testsuite/br_if.wast:284:60: label variable out of range (max 2)
+  third_party/testsuite/br_if.wast:284:60: label variable out of range (max 3)
   (module (func $unbound-nested-label (block (block (br_if 5 (i32.const 1))))))
                                                            ^
 assert_invalid error:
-  third_party/testsuite/br_if.wast:288:37: label variable out of range (max 0)
+  third_party/testsuite/br_if.wast:288:37: label variable out of range (max 1)
   (module (func $large-label (br_if 0x100000001 (i32.const 1))))
                                     ^^^^^^^^^^^
 50/50 tests passed.

--- a/test/interp/spec/br_table.txt
+++ b/test/interp/spec/br_table.txt
@@ -34,35 +34,27 @@ assert_invalid error:
     (block (br_table 0 0 (i32.const 0) (i64.const 0)) (i32.const 1))
                                        ^
 assert_invalid error:
-  third_party/testsuite/br_table.wast:1299:22: label variable out of range (max 1)
+  third_party/testsuite/br_table.wast:1299:22: label variable out of range (max 2)
     (block (br_table 2 1 (i32.const 1)))
                      ^
 assert_invalid error:
-  third_party/testsuite/br_table.wast:1299:24: label variable out of range (max 1)
-    (block (br_table 2 1 (i32.const 1)))
-                       ^
-assert_invalid error:
-  third_party/testsuite/br_table.wast:1305:31: label variable out of range (max 2)
+  third_party/testsuite/br_table.wast:1305:31: label variable out of range (max 3)
     (block (block (br_table 0 5 (i32.const 1))))
                               ^
 assert_invalid error:
-  third_party/testsuite/br_table.wast:1311:24: label variable out of range (max 1)
+  third_party/testsuite/br_table.wast:1311:24: label variable out of range (max 2)
     (block (br_table 0 0x100000001 0 (i32.const 1)))
                        ^^^^^^^^^^^
 assert_invalid error:
-  third_party/testsuite/br_table.wast:1318:22: label variable out of range (max 1)
-    (block (br_table 1 2 (i32.const 1)))
-                     ^
-assert_invalid error:
-  third_party/testsuite/br_table.wast:1318:24: label variable out of range (max 1)
+  third_party/testsuite/br_table.wast:1318:24: label variable out of range (max 2)
     (block (br_table 1 2 (i32.const 1)))
                        ^
 assert_invalid error:
-  third_party/testsuite/br_table.wast:1324:31: label variable out of range (max 2)
+  third_party/testsuite/br_table.wast:1324:31: label variable out of range (max 3)
     (block (block (br_table 0 5 (i32.const 1))))
                               ^
 assert_invalid error:
-  third_party/testsuite/br_table.wast:1330:26: label variable out of range (max 1)
+  third_party/testsuite/br_table.wast:1330:26: label variable out of range (max 2)
     (block (br_table 0 0 0x100000001 (i32.const 1)))
                          ^^^^^^^^^^^
 146/146 tests passed.

--- a/test/interp/spec/func.txt
+++ b/test/interp/spec/func.txt
@@ -1,0 +1,117 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/func.wast
+(;; STDOUT ;;;
+assert_invalid error:
+  third_party/testsuite/func.wast:283:65: type mismatch of function result. got i32, expected i64
+  (module (func $type-local-num-vs-num (result i64) (local i32) (get_local 0)))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/func.wast:287:61: type mismatch of convert op. got f32, expected i32
+  (module (func $type-local-num-vs-num (local f32) (i32.eqz (get_local 0))))
+                                                            ^
+assert_invalid error:
+  third_party/testsuite/func.wast:291:65: type mismatch of unary op. got i64, expected f64
+  (module (func $type-local-num-vs-num (local f64 i64) (f64.neg (get_local 1))))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/func.wast:299:65: type mismatch of function result. got i32, expected i64
+  (module (func $type-param-num-vs-num (param i32) (result i64) (get_local 0)))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/func.wast:303:61: type mismatch of convert op. got f32, expected i32
+  (module (func $type-param-num-vs-num (param f32) (i32.eqz (get_local 0))))
+                                                            ^
+assert_invalid error:
+  third_party/testsuite/func.wast:307:65: type mismatch of unary op. got i64, expected f64
+  (module (func $type-param-num-vs-num (param f64 i64) (f64.neg (get_local 1))))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/func.wast:315:12: type mismatch of function result. got void, expected i32
+  (module (func $type-empty-i32 (result i32)))
+           ^^^^
+assert_invalid error:
+  third_party/testsuite/func.wast:319:12: type mismatch of function result. got void, expected i64
+  (module (func $type-empty-i64 (result i64)))
+           ^^^^
+assert_invalid error:
+  third_party/testsuite/func.wast:323:12: type mismatch of function result. got void, expected f32
+  (module (func $type-empty-f32 (result f32)))
+           ^^^^
+assert_invalid error:
+  third_party/testsuite/func.wast:327:12: type mismatch of function result. got void, expected f64
+  (module (func $type-empty-f64 (result f64)))
+           ^^^^
+assert_invalid error:
+  third_party/testsuite/func.wast:333:5: type mismatch in nop. got void, expected i32
+    (nop)
+    ^
+assert_invalid error:
+  third_party/testsuite/func.wast:339:5: type mismatch of function result. got f32, expected i32
+    (f32.const 0)
+    ^
+assert_invalid error:
+  third_party/testsuite/func.wast:345:28: type mismatch in nop. got void, expected i32
+    (return (i32.const 1)) (nop)
+                           ^
+assert_invalid error:
+  third_party/testsuite/func.wast:351:28: type mismatch of function result. got f32, expected i32
+    (return (i32.const 1)) (f32.const 0)
+                           ^
+assert_invalid error:
+  third_party/testsuite/func.wast:357:26: type mismatch in nop. got void, expected i32
+    (br 0 (i32.const 1)) (nop)
+                         ^
+assert_invalid error:
+  third_party/testsuite/func.wast:363:26: type mismatch of function result. got f32, expected i32
+    (br 0 (i32.const 1)) (f32.const 0)
+                         ^
+assert_invalid error:
+  third_party/testsuite/func.wast:370:5: type mismatch of return. got void, expected i32
+    (return)
+    ^
+assert_invalid error:
+  third_party/testsuite/func.wast:376:5: type mismatch of return. got void, expected i32
+    (return) (i32.const 1)
+    ^
+assert_invalid error:
+  third_party/testsuite/func.wast:382:13: type mismatch of return. got i64, expected i32
+    (return (i64.const 1)) (i32.const 1)
+            ^
+assert_invalid error:
+  third_party/testsuite/func.wast:388:13: type mismatch of return. got i64, expected i32
+    (return (i64.const 1)) (return (i32.const 1))
+            ^
+assert_invalid error:
+  third_party/testsuite/func.wast:394:36: type mismatch of return. got f64, expected i32
+    (return (i32.const 1)) (return (f64.const 1))
+                                   ^
+assert_invalid error:
+  third_party/testsuite/func.wast:401:5: type mismatch of br value. got void, expected i32
+    (br 0)
+    ^
+assert_invalid error:
+  third_party/testsuite/func.wast:407:5: type mismatch of br value. got void, expected i32
+    (br 0) (i32.const 1)
+    ^
+assert_invalid error:
+  third_party/testsuite/func.wast:413:11: type mismatch of br value. got i64, expected i32
+    (br 0 (i64.const 1)) (i32.const 1)
+          ^
+assert_invalid error:
+  third_party/testsuite/func.wast:419:11: type mismatch of br value. got i64, expected i32
+    (br 0 (i64.const 1)) (br 0 (i32.const 1))
+          ^
+assert_invalid error:
+  third_party/testsuite/func.wast:425:32: type mismatch of br value. got f64, expected i32
+    (br 0 (i32.const 1)) (br 0 (f64.const 1))
+                               ^
+assert_invalid error:
+  third_party/testsuite/func.wast:432:12: type mismatch of br value. got void, expected i32
+    (block (br 1)) (br 0 (i32.const 1))
+           ^
+assert_invalid error:
+  third_party/testsuite/func.wast:438:18: type mismatch of br value. got i64, expected i32
+    (block (br 1 (i64.const 1))) (br 0 (i32.const 1))
+                 ^
+78/78 tests passed.
+;;; STDOUT ;;)

--- a/test/interp/spec/get_local.txt
+++ b/test/interp/spec/get_local.txt
@@ -1,0 +1,53 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/get_local.wast
+(;; STDOUT ;;;
+assert_invalid error:
+  third_party/testsuite/get_local.wast:92:65: type mismatch of function result. got i32, expected i64
+  (module (func $type-local-num-vs-num (result i64) (local i32) (get_local 0)))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:96:61: type mismatch of convert op. got f32, expected i32
+  (module (func $type-local-num-vs-num (local f32) (i32.eqz (get_local 0))))
+                                                            ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:100:65: type mismatch of unary op. got i64, expected f64
+  (module (func $type-local-num-vs-num (local f64 i64) (f64.neg (get_local 1))))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:108:65: type mismatch of function result. got i32, expected i64
+  (module (func $type-param-num-vs-num (param i32) (result i64) (get_local 0)))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:112:61: type mismatch of convert op. got f32, expected i32
+  (module (func $type-param-num-vs-num (param f32) (i32.eqz (get_local 0))))
+                                                            ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:116:65: type mismatch of unary op. got i64, expected f64
+  (module (func $type-param-num-vs-num (param f64 i64) (f64.neg (get_local 1))))
+                                                                ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:124:59: local variable out of range (max 2)
+  (module (func $unbound-local (local i32 i64) (get_local 3)))
+                                                          ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:128:57: local variable out of range (max 2)
+  (module (func $large-local (local i32 i64) (get_local 14324343)))
+                                                        ^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:133:59: local variable out of range (max 2)
+  (module (func $unbound-param (param i32 i64) (get_local 2)))
+                                                          ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:137:57: local variable out of range (max 2)
+  (module (func $large-param (local i32 i64) (get_local 714324343)))
+                                                        ^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:142:71: local variable out of range (max 3)
+  (module (func $unbound-mixed (param i32) (local i32 i64) (get_local 3)))
+                                                                      ^
+assert_invalid error:
+  third_party/testsuite/get_local.wast:146:69: local variable out of range (max 3)
+  (module (func $large-mixed (param i64) (local i32 i64) (get_local 214324343)))
+                                                                    ^^^^^^^^^
+10/10 tests passed.
+;;; STDOUT ;;)

--- a/test/interp/spec/of_string-overflow-hex-u32.fail.txt
+++ b/test/interp/spec/of_string-overflow-hex-u32.fail.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/of_string-overflow-hex-u32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/of_string-overflow-hex-u32.fail.wast:1:26: invalid literal "0x100000000"
+(module (func (i32.const 0x100000000)))
+                         ^^^^^^^^^^^
+
+;;; STDERR ;;)

--- a/test/interp/spec/of_string-overflow-hex-u64.fail.txt
+++ b/test/interp/spec/of_string-overflow-hex-u64.fail.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/of_string-overflow-hex-u64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/of_string-overflow-hex-u64.fail.wast:1:26: invalid literal "0x10000000000000000"
+(module (func (i64.const 0x10000000000000000)))
+                         ^^^^^^^^^^^^^^^^^^^
+
+;;; STDERR ;;)

--- a/test/interp/spec/of_string-overflow-s32.fail.txt
+++ b/test/interp/spec/of_string-overflow-s32.fail.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/of_string-overflow-s32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/of_string-overflow-s32.fail.wast:1:26: invalid literal "-2147483649"
+(module (func (i32.const -2147483649)))
+                         ^^^^^^^^^^^
+
+;;; STDERR ;;)

--- a/test/interp/spec/of_string-overflow-s64.fail.txt
+++ b/test/interp/spec/of_string-overflow-s64.fail.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/of_string-overflow-s64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/of_string-overflow-s64.fail.wast:1:26: invalid literal "-9223372036854775809"
+(module (func (i64.const -9223372036854775809)))
+                         ^^^^^^^^^^^^^^^^^^^^
+
+;;; STDERR ;;)

--- a/test/interp/spec/of_string-overflow-u32.fail.txt
+++ b/test/interp/spec/of_string-overflow-u32.fail.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/of_string-overflow-u32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/of_string-overflow-u32.fail.wast:1:26: invalid literal "4294967296"
+(module (func (i32.const 4294967296)))
+                         ^^^^^^^^^^
+
+;;; STDERR ;;)

--- a/test/interp/spec/of_string-overflow-u64.fail.txt
+++ b/test/interp/spec/of_string-overflow-u64.fail.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/of_string-overflow-u64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/of_string-overflow-u64.fail.wast:1:26: invalid literal "18446744073709551616"
+(module (func (i64.const 18446744073709551616)))
+                         ^^^^^^^^^^^^^^^^^^^^
+
+;;; STDERR ;;)

--- a/test/interp/spec/switch.txt
+++ b/test/interp/spec/switch.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/switch.wast
 (;; STDOUT ;;;
 assert_invalid error:
-  third_party/testsuite/switch.wast:155:41: label variable out of range (max 0)
+  third_party/testsuite/switch.wast:155:41: label variable out of range (max 1)
 (assert_invalid (module (func (br_table 3 (i32.const 0)))) "unknown label")
                                         ^
 26/26 tests passed.

--- a/test/parse/expr/bad-br-bad-depth.txt
+++ b/test/parse/expr/bad-br-bad-depth.txt
@@ -1,11 +1,11 @@
 ;;; ERROR: 1
 (module
-  (func
+  (func      ;; 2 (implicit)
     (block   ;; 1
       (block ;; 0
-        (br 2)))))
+        (br 3)))))
 (;; STDERR ;;;
-parse/expr/bad-br-bad-depth.txt:6:13: label variable out of range (max 2)
-        (br 2)))))
+parse/expr/bad-br-bad-depth.txt:6:13: label variable out of range (max 3)
+        (br 3)))))
             ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-defined-later.txt
+++ b/test/parse/expr/bad-br-defined-later.txt
@@ -1,9 +1,10 @@
 ;;; ERROR: 1
-(module (func
-  (br 0)
-  (block (nop))))
+(module
+  (func
+    (br 1)
+    (block (nop))))
 (;; STDERR ;;;
-parse/expr/bad-br-defined-later.txt:3:7: label variable out of range (max 0)
-  (br 0)
-      ^
+parse/expr/bad-br-defined-later.txt:4:9: label variable out of range (max 1)
+    (br 1)
+        ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-no-label.txt
+++ b/test/parse/expr/bad-br-no-label.txt
@@ -1,7 +1,0 @@
-;;; ERROR: 1
-(module (func (br 0)))
-(;; STDERR ;;;
-parse/expr/bad-br-no-label.txt:2:19: label variable out of range (max 0)
-(module (func (br 0)))
-                  ^
-;;; STDERR ;;)

--- a/test/parse/expr/bad-br-undefined.txt
+++ b/test/parse/expr/bad-br-undefined.txt
@@ -1,7 +1,7 @@
 ;;; ERROR: 1
-(module (func (br 0)))
+(module (func (br 1)))
 (;; STDERR ;;;
-parse/expr/bad-br-undefined.txt:2:19: label variable out of range (max 0)
-(module (func (br 0)))
+parse/expr/bad-br-undefined.txt:2:19: label variable out of range (max 1)
+(module (func (br 1)))
                   ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-brtable-bad-depth.txt
+++ b/test/parse/expr/bad-brtable-bad-depth.txt
@@ -1,10 +1,10 @@
 ;;; ERROR: 1
 (module
-  (func
-    (block
-      (br_table 1 (i32.const 0)))))
+  (func    ;; depth 1 (implicit)
+    (block ;; depth 0
+      (br_table 2 (i32.const 0)))))
 (;; STDERR ;;;
-parse/expr/bad-brtable-bad-depth.txt:5:17: label variable out of range (max 1)
-      (br_table 1 (i32.const 0)))))
+parse/expr/bad-brtable-bad-depth.txt:5:17: label variable out of range (max 2)
+      (br_table 2 (i32.const 0)))))
                 ^
 ;;; STDERR ;;)


### PR DESCRIPTION
`(func (br 0))` is valid, because the function introduces an implicit
block scope. This change also updates the testsuite (which has tests for
this behavior).