### PR TITLE
WasmFuncDeclaration does not always set `sig`

### DIFF
--- a/src/wasm-apply-names.c
+++ b/src/wasm-apply-names.c
@@ -115,9 +115,10 @@ static WasmResult use_name_for_param_and_local_var(Context* ctx,
                                                    WasmVar* var) {
   int local_index = wasm_get_local_index_by_var(func, var);
   assert(local_index >= 0 &&
-         (size_t)local_index < wasm_get_num_params_and_locals(func));
+         (size_t)local_index <
+             wasm_get_num_params_and_locals(ctx->module, func));
 
-  uint32_t num_params = wasm_get_num_params(func);
+  uint32_t num_params = wasm_get_num_params(ctx->module, func);
   WasmStringSlice* name;
   if ((uint32_t)local_index < num_params) {
     /* param */

--- a/src/wasm-ast-parser-lexer-shared.c
+++ b/src/wasm-ast-parser-lexer-shared.c
@@ -51,7 +51,7 @@ void wasm_ast_format_error(WasmSourceErrorHandler* error_handler,
   size_t source_line_length = 0;
   int source_line_column_offset = 0;
   size_t source_line_max_length = error_handler->source_line_max_length;
-  if (loc) {
+  if (loc && lexer) {
     source_line = alloca(source_line_max_length + 1);
     WasmResult result = wasm_ast_lexer_get_source_line(
         lexer, loc, source_line_max_length, source_line, &source_line_length,

--- a/src/wasm-ast-writer.c
+++ b/src/wasm-ast-writer.c
@@ -587,9 +587,9 @@ static void write_func(Context* ctx,
   if (wasm_decl_has_signature(&func->decl)) {
     write_type_bindings(ctx, "param", func, &func->decl.sig.param_types,
                         &func->param_bindings);
-    if (wasm_get_result_type(func) != WASM_TYPE_VOID) {
+    if (wasm_get_result_type(module, func) != WASM_TYPE_VOID) {
       write_open_space(ctx, "result");
-      write_type(ctx, wasm_get_result_type(func), NEXT_CHAR_NONE);
+      write_type(ctx, wasm_get_result_type(module, func), NEXT_CHAR_NONE);
       write_close_space(ctx);
     }
   }

--- a/src/wasm-binary-reader-ast.c
+++ b/src/wasm-binary-reader-ast.c
@@ -53,7 +53,7 @@
   do {                                                                    \
     assert(wasm_decl_has_func_type(&ctx->current_func->decl));            \
     uint32_t max_local_index =                                            \
-        wasm_get_num_params_and_locals(ctx->current_func);                \
+        wasm_get_num_params_and_locals(ctx->module, ctx->current_func);   \
     if ((local_index) >= max_local_index) {                               \
       print_error(ctx, "invalid local_index: %d (max %d)", (local_index), \
                   max_local_index);                                       \
@@ -990,7 +990,7 @@ static WasmResult on_local_names_count(uint32_t index,
   WasmModule* module = ctx->module;
   assert(index < module->funcs.size);
   WasmFunc* func = module->funcs.data[index];
-  uint32_t num_params_and_locals = wasm_get_num_params_and_locals(func);
+  uint32_t num_params_and_locals = wasm_get_num_params_and_locals(module, func);
   if (count > num_params_and_locals) {
     print_error(ctx, "expected local name count (%d) <= local count (%d)",
                 count, num_params_and_locals);
@@ -1006,7 +1006,7 @@ static WasmResult on_local_name(uint32_t func_index,
   Context* ctx = user_data;
   WasmModule* module = ctx->module;
   WasmFunc* func = module->funcs.data[func_index];
-  uint32_t num_params = wasm_get_num_params(func);
+  uint32_t num_params = wasm_get_num_params(module, func);
   WasmStringSlice new_name;
   dup_name(ctx, &name, &new_name);
   WasmBindingHash* bindings;

--- a/src/wasm-binary-writer-spec.c
+++ b/src/wasm-binary-writer-spec.c
@@ -309,7 +309,7 @@ static void write_commands(Context* ctx, WasmScript* script) {
       int func_index = wasm_get_func_index_by_var(last_module, &export->var);
       assert(func_index >= 0 && (size_t)func_index < last_module->funcs.size);
       WasmFunc* callee = last_module->funcs.data[func_index];
-      WasmType result_type = wasm_get_result_type(callee);
+      WasmType result_type = wasm_get_result_type(last_module, callee);
       /* these pointers will be invalidated later, so we can't use them */
       export = NULL;
       callee = NULL;

--- a/test/parse/func/bad-sig-result-type-mismatch.txt
+++ b/test/parse/func/bad-sig-result-type-mismatch.txt
@@ -3,10 +3,10 @@
   (type $t (func (param i32) (result f32)))
   (func (type $t) (param i32) (result i64)))
 (;; STDERR ;;;
-parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch of function signature result. got i64, expected f32
+parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch between function result and function type result. got i64, expected f32
   (func (type $t) (param i32) (result i64)))
    ^^^^
-parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch of function result. got void, expected i64
+parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch of function result. got void, expected f32
   (func (type $t) (param i32) (result i64)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-not-void.txt
+++ b/test/parse/func/bad-sig-result-type-not-void.txt
@@ -3,10 +3,7 @@
   (type $t (func (param i32)))
   (func (type $t) (param i32) (result f32)))
 (;; STDERR ;;;
-parse/func/bad-sig-result-type-not-void.txt:4:4: type mismatch of function signature result. got f32, expected void
-  (func (type $t) (param i32) (result f32)))
-   ^^^^
-parse/func/bad-sig-result-type-not-void.txt:4:4: type mismatch of function result. got void, expected f32
+parse/func/bad-sig-result-type-not-void.txt:4:4: type mismatch between function result and function type result. got f32, expected void
   (func (type $t) (param i32) (result f32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-void.txt
+++ b/test/parse/func/bad-sig-result-type-void.txt
@@ -3,7 +3,10 @@
   (type $t (func (param i32) (result f32)))
   (func (type $t) (param i32)))
 (;; STDERR ;;;
-parse/func/bad-sig-result-type-void.txt:4:4: type mismatch of function signature result. got void, expected f32
+parse/func/bad-sig-result-type-void.txt:4:4: type mismatch between function result and function type result. got void, expected f32
+  (func (type $t) (param i32)))
+   ^^^^
+parse/func/bad-sig-result-type-void.txt:4:4: type mismatch of function result. got void, expected f32
   (func (type $t) (param i32)))
    ^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
Prior to this change, the AST parser would always set `sig`, even if the
function had no explicit signature (i.e. it used a function type
variable instead).

This is OK, but it makes the flag confusing.
`WASM_FUNC_DECLARATION_FLAG_HAS_SIGNATURE` will be clear and
`wasm_decl_has_signature` will return false, but `sig` will be valid.

This change makes it so `sig` is only set when there is an explicit
signature. The correct way to get the function signature is to call
`wasm_decl_get_signature`, which will check whether there is a func
type, and if not, will check for an explicit function signature.