### PR TITLE
use the wasm-wast verbose flag

### DIFF
--- a/src/wasm-binary-reader.h
+++ b/src/wasm-binary-reader.h
@@ -26,9 +26,10 @@
 struct WasmAllocator;
 
 #define WASM_READ_BINARY_OPTIONS_DEFAULT \
-  { WASM_FALSE }
+  { NULL, WASM_FALSE }
 
 typedef struct WasmReadBinaryOptions {
+  struct WasmStream* log_stream;
   WasmBool read_debug_names;
 } WasmReadBinaryOptions;
 

--- a/src/wasm-wast.c
+++ b/src/wasm-wast.c
@@ -28,6 +28,7 @@
 #include "wasm-generate-names.h"
 #include "wasm-option-parser.h"
 #include "wasm-stack-allocator.h"
+#include "wasm-stream.h"
 #include "wasm-writer.h"
 
 #define PROGRAM_NAME "wasm-wast"
@@ -42,6 +43,9 @@ static WasmBool s_generate_names;
 
 static WasmBinaryErrorHandler s_error_handler =
     WASM_BINARY_ERROR_HANDLER_DEFAULT;
+
+static WasmFileWriter s_log_stream_writer;
+static WasmStream s_log_stream;
 
 #define NOPE WASM_OPTION_NO_ARGUMENT
 #define YEP WASM_OPTION_HAS_ARGUMENT
@@ -88,6 +92,9 @@ static void on_option(struct WasmOptionParser* parser,
   switch (option->id) {
     case FLAG_VERBOSE:
       s_verbose++;
+      wasm_init_file_writer_existing(&s_log_stream_writer, stdout);
+      wasm_init_stream(&s_log_stream, &s_log_stream_writer.base, NULL);
+      s_read_binary_options.log_stream = &s_log_stream;
       break;
 
     case FLAG_HELP:


### PR DESCRIPTION
The `--verbose` flag has been there for a while, but wasn't hooked up to
anything. Now it displays info while reading from the binary file, which
could be useful for debugging.