### PR TITLE
update testsuite, handle implicit func types

### DIFF
--- a/src/prebuilt/wasm-ast-lexer-gen.c
+++ b/src/prebuilt/wasm-ast-lexer-gen.c
@@ -6010,7 +6010,6 @@ WasmAstLexer* wasm_new_ast_file_lexer(WasmAllocator* allocator,
   lexer->source.file = fopen(filename, "rb");
   if (!lexer->source.file) {
     wasm_destroy_ast_lexer(lexer);
-    wasm_free(allocator, lexer);
     return NULL;
   }
   return lexer;

--- a/src/prebuilt/wasm-ast-parser-gen.c
+++ b/src/prebuilt/wasm-ast-parser-gen.c
@@ -138,6 +138,11 @@ static WasmResult parse_const(WasmType type, WasmLiteralType literal_type,
 static void dup_text_list(WasmAllocator*, WasmTextList* text_list,
                           void** out_data, size_t* out_size);
 
+static WasmBool is_empty_signature(WasmFuncSignature* sig);
+
+static void append_implicit_func_declaration(WasmAllocator*, WasmLocation*,
+                                             WasmModule*, WasmFuncDeclaration*);
+
 typedef struct BinaryErrorCallbackData {
   WasmLocation* loc;
   WasmAstLexer* lexer;
@@ -150,7 +155,7 @@ static void on_read_binary_error(uint32_t offset, const char* error,
 #define wasm_ast_parser_lex wasm_ast_lexer_lex
 
 
-#line 154 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:339  */
+#line 159 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -281,7 +286,7 @@ int wasm_ast_parser_parse (WasmAstLexer* lexer, WasmAstParser* parser);
 
 /* Copy the second part of user declarations.  */
 
-#line 285 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:358  */
+#line 290 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -586,19 +591,19 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   187,   187,   193,   206,   207,   213,   214,   218,   222,
-     229,   233,   237,   244,   256,   263,   264,   270,   274,   290,
-     297,   298,   302,   303,   313,   314,   325,   328,   331,   336,
-     341,   347,   353,   361,   366,   372,   378,   384,   389,   393,
-     400,   407,   413,   419,   426,   430,   435,   442,   450,   462,
-     467,   473,   479,   485,   490,   493,   497,   503,   504,   507,
-     511,   519,   520,   525,   526,   532,   538,   548,   554,   560,
-     570,   573,   634,   643,   653,   661,   673,   674,   681,   685,
-     698,   706,   707,   714,   726,   737,   743,   752,   756,   763,
-     767,   774,   782,   789,   800,   807,   813,   816,   852,   870,
-     887,   895,   903,   921,   929,   940,   945,   954,   978,   984,
-     991,   997,  1005,  1012,  1022,  1023,  1031,  1043,  1044,  1047,
-    1048,  1055,  1064
+       0,   192,   192,   198,   211,   212,   218,   219,   223,   227,
+     234,   238,   242,   249,   261,   268,   269,   275,   279,   295,
+     302,   303,   307,   308,   318,   319,   330,   333,   336,   341,
+     346,   352,   358,   366,   371,   377,   383,   389,   394,   398,
+     405,   412,   418,   424,   431,   435,   440,   447,   455,   467,
+     472,   478,   484,   490,   495,   498,   502,   508,   509,   512,
+     516,   524,   525,   530,   531,   537,   543,   553,   559,   565,
+     575,   578,   633,   642,   652,   659,   670,   671,   678,   682,
+     695,   703,   704,   711,   723,   734,   740,   749,   753,   760,
+     764,   771,   779,   785,   795,   802,   808,   811,   850,   871,
+     888,   896,   904,   922,   930,   941,   975,   984,  1008,  1014,
+    1021,  1027,  1035,  1042,  1052,  1053,  1061,  1073,  1074,  1077,
+    1078,  1085,  1094
 };
 #endif
 
@@ -1392,201 +1397,201 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 59: /* text_list  */
-#line 154 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 159 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_text_list(parser->allocator, &((*yyvaluep).text_list)); }
-#line 1398 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1403 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 60: /* value_type_list  */
-#line 157 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 162 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_type_vector(parser->allocator, &((*yyvaluep).types)); }
-#line 1404 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1409 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 61: /* func_type  */
-#line 167 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 172 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_func_signature(parser->allocator, &((*yyvaluep).func_sig)); }
-#line 1410 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1415 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 62: /* literal  */
-#line 156 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 161 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_string_slice(parser->allocator, &((*yyvaluep).literal).text); }
-#line 1416 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1421 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 63: /* var  */
-#line 158 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 163 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_var(parser->allocator, &((*yyvaluep).var)); }
-#line 1422 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1427 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 64: /* var_list  */
-#line 159 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 164 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_var_vector_and_elements(parser->allocator, &((*yyvaluep).vars)); }
-#line 1428 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1433 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 65: /* bind_var  */
-#line 155 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 160 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_string_slice(parser->allocator, &((*yyvaluep).text)); }
-#line 1434 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1439 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 66: /* quoted_text  */
-#line 155 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 160 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_string_slice(parser->allocator, &((*yyvaluep).text)); }
-#line 1440 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1445 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 67: /* segment_contents  */
-#line 164 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 169 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_segment(parser->allocator, &((*yyvaluep).segment)); }
-#line 1446 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1451 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 68: /* labeling  */
-#line 155 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 160 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_string_slice(parser->allocator, &((*yyvaluep).text)); }
-#line 1452 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1457 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 71: /* expr  */
-#line 160 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 165 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_expr(parser->allocator, ((*yyvaluep).expr)); }
-#line 1458 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1463 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 72: /* expr1  */
-#line 160 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 165 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_expr(parser->allocator, ((*yyvaluep).expr)); }
-#line 1464 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1469 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 73: /* expr_opt  */
-#line 160 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 165 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_expr(parser->allocator, ((*yyvaluep).expr)); }
-#line 1470 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1475 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 74: /* non_empty_expr_list  */
-#line 161 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 166 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_expr_list(parser->allocator, ((*yyvaluep).expr_list).first); }
-#line 1476 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1481 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 75: /* expr_list  */
-#line 161 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 166 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_expr_list(parser->allocator, ((*yyvaluep).expr_list).first); }
-#line 1482 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1487 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 76: /* func_fields  */
-#line 162 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 167 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_func_fields(parser->allocator, ((*yyvaluep).func_fields)); }
-#line 1488 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1493 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 77: /* func_body  */
-#line 162 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 167 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_func_fields(parser->allocator, ((*yyvaluep).func_fields)); }
-#line 1494 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1499 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 79: /* func_info  */
-#line 163 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 168 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_func(parser->allocator, ((*yyvaluep).func)); wasm_free(parser->allocator, ((*yyvaluep).func)); }
-#line 1500 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1505 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 80: /* func  */
-#line 171 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 176 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_exported_func(parser->allocator, &((*yyvaluep).exported_func)); }
-#line 1506 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1511 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 84: /* segment  */
-#line 164 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 169 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_segment(parser->allocator, &((*yyvaluep).segment)); }
-#line 1512 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1517 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 85: /* segment_list  */
-#line 165 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 170 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_segment_vector_and_elements(parser->allocator, &((*yyvaluep).segments)); }
-#line 1518 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1523 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 88: /* memory  */
-#line 166 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 171 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_memory(parser->allocator, &((*yyvaluep).memory)); }
-#line 1524 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1529 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 89: /* type_def  */
-#line 168 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 173 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_func_type(parser->allocator, &((*yyvaluep).func_type)); }
-#line 1530 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1535 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 90: /* table  */
-#line 159 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 164 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_var_vector_and_elements(parser->allocator, &((*yyvaluep).vars)); }
-#line 1536 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1541 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 91: /* import  */
-#line 169 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 174 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_import(parser->allocator, ((*yyvaluep).import)); wasm_free(parser->allocator, ((*yyvaluep).import)); }
-#line 1542 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1547 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 92: /* export  */
-#line 170 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 175 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_export(parser->allocator, &((*yyvaluep).export_)); }
-#line 1548 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1553 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 94: /* module_fields  */
-#line 172 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 177 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_module(parser->allocator, ((*yyvaluep).module)); wasm_free(parser->allocator, ((*yyvaluep).module)); }
-#line 1554 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1559 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 95: /* raw_module  */
-#line 173 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 178 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_raw_module(parser->allocator, &((*yyvaluep).raw_module)); }
-#line 1560 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1565 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 96: /* module  */
-#line 172 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 177 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_module(parser->allocator, ((*yyvaluep).module)); wasm_free(parser->allocator, ((*yyvaluep).module)); }
-#line 1566 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1571 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 97: /* cmd  */
-#line 175 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 180 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_command(parser->allocator, ((*yyvaluep).command)); wasm_free(parser->allocator, ((*yyvaluep).command)); }
-#line 1572 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1577 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 98: /* cmd_list  */
-#line 176 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 181 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_command_vector_and_elements(parser->allocator, &((*yyvaluep).commands)); }
-#line 1578 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1583 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 101: /* const_list  */
-#line 174 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 179 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_const_vector(parser->allocator, &((*yyvaluep).consts)); }
-#line 1584 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1589 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
     case 102: /* script  */
-#line 177 "src/wasm-ast-parser.y" /* yacc.c:1257  */
+#line 182 "src/wasm-ast-parser.y" /* yacc.c:1257  */
       { wasm_destroy_script(&((*yyvaluep).script)); }
-#line 1590 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
+#line 1595 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1257  */
         break;
 
 
@@ -1878,18 +1883,18 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 187 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 192 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       WasmTextListNode* node = new_text_list_node(parser->allocator);
       DUPTEXT(node->text, (yyvsp[0].text));
       node->next = NULL;
       (yyval.text_list).first = (yyval.text_list).last = node;
     }
-#line 1889 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1894 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 193 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 198 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.text_list) = (yyvsp[-1].text_list);
       WasmTextListNode* node = new_text_list_node(parser->allocator);
@@ -1898,83 +1903,83 @@ yyreduce:
       (yyval.text_list).last->next = node;
       (yyval.text_list).last = node;
     }
-#line 1902 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1907 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 206 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 211 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.types)); }
-#line 1908 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1913 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 207 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 212 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.types) = (yyvsp[-1].types);
       wasm_append_type_value(parser->allocator, &(yyval.types), &(yyvsp[0].type));
     }
-#line 1917 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1922 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 213 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 218 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.func_sig)); }
-#line 1923 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1928 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 214 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 219 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig).result_type = WASM_TYPE_VOID;
       (yyval.func_sig).param_types = (yyvsp[-1].types);
     }
-#line 1932 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1937 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 218 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 223 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig).result_type = (yyvsp[-1].type);
       (yyval.func_sig).param_types = (yyvsp[-5].types);
     }
-#line 1941 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1946 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 222 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 227 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.func_sig)); (yyval.func_sig).result_type = (yyvsp[-1].type); }
-#line 1947 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1952 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 229 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 234 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 1956 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1961 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 233 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 238 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 1965 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1970 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 237 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 242 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 1974 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1979 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 244 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 249 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var).loc = (yylsp[0]);
       (yyval.var).type = WASM_VAR_TYPE_INDEX;
@@ -1987,42 +1992,42 @@ yyreduce:
       }
       (yyval.var).index = index;
     }
-#line 1991 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 1996 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 256 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 261 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var).loc = (yylsp[0]);
       (yyval.var).type = WASM_VAR_TYPE_NAME;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 2001 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2006 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 263 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 268 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.vars)); }
-#line 2007 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2012 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 264 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 269 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.vars) = (yyvsp[-1].vars);
       wasm_append_var_value(parser->allocator, &(yyval.vars), &(yyvsp[0].var));
     }
-#line 2016 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2021 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 270 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 275 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { DUPTEXT((yyval.text), (yyvsp[0].text)); }
-#line 2022 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2027 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 274 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 279 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       WasmTextListNode node;
       node.text = (yyvsp[0].text);
@@ -2036,38 +2041,38 @@ yyreduce:
       (yyval.text).start = data;
       (yyval.text).length = size;
     }
-#line 2040 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2045 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 290 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 295 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       dup_text_list(parser->allocator, &(yyvsp[0].text_list), &(yyval.segment).data, &(yyval.segment).size);
       wasm_destroy_text_list(parser->allocator, &(yyvsp[0].text_list));
     }
-#line 2049 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2054 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 297 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 302 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.text)); }
-#line 2055 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2060 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 298 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 303 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.text) = (yyvsp[0].text); }
-#line 2061 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2066 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 302 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 307 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.u64) = 0; }
-#line 2067 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2072 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 303 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 308 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
     if (WASM_FAILED(wasm_parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u64),
                                      WASM_PARSE_SIGNED_AND_UNSIGNED))) {
@@ -2076,17 +2081,17 @@ yyreduce:
                             WASM_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
       }
     }
-#line 2080 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2085 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 313 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 318 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.u32) = USE_NATURAL_ALIGNMENT; }
-#line 2086 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2091 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 314 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 319 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       if (WASM_FAILED(wasm_parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
                                        WASM_PARSE_UNSIGNED_ONLY))) {
@@ -2095,67 +2100,67 @@ yyreduce:
                               WASM_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
       }
     }
-#line 2099 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2104 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 325 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 330 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.expr) = (yyvsp[-1].expr); (yyval.expr)->loc = (yylsp[-2]); }
-#line 2105 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2110 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 328 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 333 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_empty_expr(parser->allocator, WASM_EXPR_TYPE_NOP);
     }
-#line 2113 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2118 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 331 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 336 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_block_expr(parser->allocator);
       (yyval.expr)->block.label = (yyvsp[-1].text);
       (yyval.expr)->block.first = (yyvsp[0].expr_list).first;
     }
-#line 2123 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2128 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 336 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 341 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_if_expr(parser->allocator);
       (yyval.expr)->if_.cond = (yyvsp[-1].expr);
       (yyval.expr)->if_.true_.first = (yyvsp[0].expr);
     }
-#line 2133 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2138 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 341 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 346 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_if_expr(parser->allocator);
       (yyval.expr)->if_.cond = (yyvsp[-5].expr);
       (yyval.expr)->if_.true_.label = (yyvsp[-2].text);
       (yyval.expr)->if_.true_.first = (yyvsp[-1].expr_list).first;
     }
-#line 2144 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2149 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 347 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 352 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_if_else_expr(parser->allocator);
       (yyval.expr)->if_else.cond = (yyvsp[-2].expr);
       (yyval.expr)->if_else.true_.first = (yyvsp[-1].expr);
       (yyval.expr)->if_else.false_.first = (yyvsp[0].expr);
     }
-#line 2155 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2160 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 353 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 358 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_if_else_expr(parser->allocator);
       (yyval.expr)->if_else.cond = (yyvsp[-10].expr);
@@ -2164,73 +2169,73 @@ yyreduce:
       (yyval.expr)->if_else.false_.label = (yyvsp[-2].text);
       (yyval.expr)->if_else.false_.first = (yyvsp[-1].expr_list).first;
     }
-#line 2168 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2173 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 361 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 366 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_br_if_expr(parser->allocator);
       (yyval.expr)->br_if.var = (yyvsp[-1].var);
       (yyval.expr)->br_if.cond = (yyvsp[0].expr);
     }
-#line 2178 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2183 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 366 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 371 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_br_if_expr(parser->allocator);
       (yyval.expr)->br_if.var = (yyvsp[-2].var);
       (yyval.expr)->br_if.expr = (yyvsp[-1].expr);
       (yyval.expr)->br_if.cond = (yyvsp[0].expr);
     }
-#line 2189 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2194 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 372 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 377 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_loop_expr(parser->allocator);
       WASM_ZERO_MEMORY((yyval.expr)->loop.outer);
       (yyval.expr)->loop.inner = (yyvsp[-1].text);
       (yyval.expr)->loop.first = (yyvsp[0].expr_list).first;
     }
-#line 2200 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2205 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 378 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 383 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_loop_expr(parser->allocator);
       (yyval.expr)->loop.outer = (yyvsp[-2].text);
       (yyval.expr)->loop.inner = (yyvsp[-1].text);
       (yyval.expr)->loop.first = (yyvsp[0].expr_list).first;
     }
-#line 2211 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2216 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 384 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 389 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_br_expr(parser->allocator);
       (yyval.expr)->br.var = (yyvsp[-1].var);
       (yyval.expr)->br.expr = (yyvsp[0].expr);
     }
-#line 2221 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2226 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 389 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 394 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_return_expr(parser->allocator);
       (yyval.expr)->return_.expr = (yyvsp[0].expr);
     }
-#line 2230 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2235 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 393 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 398 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_br_table_expr(parser->allocator);
       (yyval.expr)->br_table.key = (yyvsp[0].expr);
@@ -2238,11 +2243,11 @@ yyreduce:
       (yyval.expr)->br_table.targets = (yyvsp[-2].vars);
       (yyval.expr)->br_table.default_target = (yyvsp[-1].var);
     }
-#line 2242 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2247 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 400 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 405 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_br_table_expr(parser->allocator);
       (yyval.expr)->br_table.key = (yyvsp[0].expr);
@@ -2250,33 +2255,33 @@ yyreduce:
       (yyval.expr)->br_table.targets = (yyvsp[-3].vars);
       (yyval.expr)->br_table.default_target = (yyvsp[-2].var);
     }
-#line 2254 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2259 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 407 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 412 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_call_expr(parser->allocator);
       (yyval.expr)->call.var = (yyvsp[-1].var);
       (yyval.expr)->call.first_arg = (yyvsp[0].expr_list).first;
       (yyval.expr)->call.num_args = (yyvsp[0].expr_list).size;
     }
-#line 2265 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2270 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 413 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 418 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_call_import_expr(parser->allocator);
       (yyval.expr)->call.var = (yyvsp[-1].var);
       (yyval.expr)->call.first_arg = (yyvsp[0].expr_list).first;
       (yyval.expr)->call.num_args = (yyvsp[0].expr_list).size;
     }
-#line 2276 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2281 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 419 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 424 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_call_indirect_expr(parser->allocator);
       (yyval.expr)->call_indirect.var = (yyvsp[-2].var);
@@ -2284,30 +2289,30 @@ yyreduce:
       (yyval.expr)->call_indirect.first_arg = (yyvsp[0].expr_list).first;
       (yyval.expr)->call_indirect.num_args = (yyvsp[0].expr_list).size;
     }
-#line 2288 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2293 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 426 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 431 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_get_local_expr(parser->allocator);
       (yyval.expr)->get_local.var = (yyvsp[0].var);
     }
-#line 2297 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2302 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 430 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 435 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_set_local_expr(parser->allocator);
       (yyval.expr)->set_local.var = (yyvsp[-1].var);
       (yyval.expr)->set_local.expr = (yyvsp[0].expr);
     }
-#line 2307 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2312 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 435 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 440 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_load_expr(parser->allocator);
       (yyval.expr)->load.opcode = (yyvsp[-3].opcode);
@@ -2315,11 +2320,11 @@ yyreduce:
       (yyval.expr)->load.align = (yyvsp[-1].u32);
       (yyval.expr)->load.addr = (yyvsp[0].expr);
     }
-#line 2319 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2324 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 442 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 447 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_store_expr(parser->allocator);
       (yyval.expr)->store.opcode = (yyvsp[-4].opcode);
@@ -2328,11 +2333,11 @@ yyreduce:
       (yyval.expr)->store.addr = (yyvsp[-1].expr);
       (yyval.expr)->store.value = (yyvsp[0].expr);
     }
-#line 2332 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2337 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 450 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 455 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_const_expr(parser->allocator);
       (yyval.expr)->const_.loc = (yylsp[-1]);
@@ -2345,144 +2350,144 @@ yyreduce:
       }
       wasm_free(parser->allocator, (char*)(yyvsp[0].literal).text.start);
     }
-#line 2349 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2354 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 462 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 467 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_unary_expr(parser->allocator);
       (yyval.expr)->unary.opcode = (yyvsp[-1].opcode);
       (yyval.expr)->unary.expr = (yyvsp[0].expr);
     }
-#line 2359 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2364 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 467 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 472 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_binary_expr(parser->allocator);
       (yyval.expr)->binary.opcode = (yyvsp[-2].opcode);
       (yyval.expr)->binary.left = (yyvsp[-1].expr);
       (yyval.expr)->binary.right = (yyvsp[0].expr);
     }
-#line 2370 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2375 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 473 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 478 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_select_expr(parser->allocator);
       (yyval.expr)->select.true_ = (yyvsp[-2].expr);
       (yyval.expr)->select.false_ = (yyvsp[-1].expr);
       (yyval.expr)->select.cond = (yyvsp[0].expr);
     }
-#line 2381 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2386 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 479 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 484 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_compare_expr(parser->allocator);
       (yyval.expr)->compare.opcode = (yyvsp[-2].opcode);
       (yyval.expr)->compare.left = (yyvsp[-1].expr);
       (yyval.expr)->compare.right = (yyvsp[0].expr);
     }
-#line 2392 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2397 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 485 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 490 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_convert_expr(parser->allocator);
       (yyval.expr)->convert.opcode = (yyvsp[-1].opcode);
       (yyval.expr)->convert.expr = (yyvsp[0].expr);
     }
-#line 2402 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2407 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 490 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 495 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_empty_expr(parser->allocator, WASM_EXPR_TYPE_UNREACHABLE);
     }
-#line 2410 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2415 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 493 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 498 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_empty_expr(parser->allocator,
                                WASM_EXPR_TYPE_CURRENT_MEMORY);
     }
-#line 2419 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2424 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 497 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 502 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = wasm_new_grow_memory_expr(parser->allocator);
       (yyval.expr)->grow_memory.expr = (yyvsp[0].expr);
     }
-#line 2428 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2433 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 503 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 508 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.expr) = NULL; }
-#line 2434 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2439 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 507 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 512 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyval.expr_list).last = (yyvsp[0].expr);
       (yyval.expr_list).size = 1;
     }
-#line 2443 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2448 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 511 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 516 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[-1].expr_list);
       (yyval.expr_list).last->next = (yyvsp[0].expr);
       (yyval.expr_list).last = (yyvsp[0].expr);
       (yyval.expr_list).size++;
     }
-#line 2454 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2459 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 519 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 524 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.expr_list)); }
-#line 2460 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2465 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 526 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 531 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field(parser->allocator);
       (yyval.func_fields)->type = WASM_FUNC_FIELD_TYPE_RESULT_TYPE;
       (yyval.func_fields)->result_type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 2471 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2476 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 532 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 537 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field(parser->allocator);
       (yyval.func_fields)->type = WASM_FUNC_FIELD_TYPE_PARAM_TYPES;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 2482 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2487 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 538 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 543 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field(parser->allocator);
       (yyval.func_fields)->type = WASM_FUNC_FIELD_TYPE_BOUND_PARAM;
@@ -2491,33 +2496,33 @@ yyreduce:
       (yyval.func_fields)->bound_type.type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 2495 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2500 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 548 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 553 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field(parser->allocator);
       (yyval.func_fields)->type = WASM_FUNC_FIELD_TYPE_EXPRS;
       (yyval.func_fields)->first_expr = (yyvsp[0].expr_list).first;
       (yyval.func_fields)->next = NULL;
     }
-#line 2506 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2511 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 554 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 559 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field(parser->allocator);
       (yyval.func_fields)->type = WASM_FUNC_FIELD_TYPE_LOCAL_TYPES;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 2517 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2522 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 560 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 565 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field(parser->allocator);
       (yyval.func_fields)->type = WASM_FUNC_FIELD_TYPE_BOUND_LOCAL;
@@ -2526,29 +2531,23 @@ yyreduce:
       (yyval.func_fields)->bound_type.type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 2530 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2535 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 570 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 575 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2536 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2541 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 573 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 578 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = new_func(parser->allocator);
       WasmFuncField* field = (yyvsp[0].func_fields);
+
       while (field) {
         WasmFuncField* next = field->next;
-
-        if (field->type == WASM_FUNC_FIELD_TYPE_PARAM_TYPES ||
-            field->type == WASM_FUNC_FIELD_TYPE_BOUND_PARAM ||
-            field->type == WASM_FUNC_FIELD_TYPE_RESULT_TYPE) {
-          (yyval.func)->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_SIGNATURE;
-        }
-
         switch (field->type) {
           case WASM_FUNC_FIELD_TYPE_EXPRS:
             (yyval.func)->first_expr = field->first_expr;
@@ -2596,11 +2595,11 @@ yyreduce:
         field = next;
       }
     }
-#line 2600 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2599 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 634 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 633 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->loc = (yylsp[-4]);
@@ -2610,11 +2609,11 @@ yyreduce:
       (yyval.exported_func).export_.var.type = WASM_VAR_TYPE_INDEX;
       (yyval.exported_func).export_.var.index = -1;
     }
-#line 2614 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2613 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 643 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 642 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->loc = (yylsp[-5]);
@@ -2625,50 +2624,48 @@ yyreduce:
       (yyval.exported_func).export_.var.type = WASM_VAR_TYPE_INDEX;
       (yyval.exported_func).export_.var.index = -1;
     }
-#line 2629 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2628 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 653 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 652 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->loc = (yylsp[-3]);
-      (yyval.exported_func).func->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_SIGNATURE;
       (yyval.exported_func).export_.name = (yyvsp[-2].text);
       (yyval.exported_func).export_.var.type = WASM_VAR_TYPE_INDEX;
       (yyval.exported_func).export_.var.index = -1;
     }
-#line 2642 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2640 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 661 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 659 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->loc = (yylsp[-4]);
-      (yyval.exported_func).func->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_SIGNATURE;
       (yyval.exported_func).func->name = (yyvsp[-2].text);
       (yyval.exported_func).export_.name = (yyvsp[-3].text);
       (yyval.exported_func).export_.var.type = WASM_VAR_TYPE_INDEX;
       (yyval.exported_func).export_.var.index = -1;
     }
-#line 2656 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2653 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 673 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 670 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.text)); }
-#line 2662 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2659 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 681 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 678 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2668 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2665 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 685 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 682 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       if (WASM_FAILED(wasm_parse_int32((yyvsp[0].literal).text.start,
                                        (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u32),
@@ -2679,37 +2676,37 @@ yyreduce:
                               WASM_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2683 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2680 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 698 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 695 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.segment).loc = (yylsp[-3]);
       (yyval.segment).data = (yyvsp[-1].segment).data;
       (yyval.segment).size = (yyvsp[-1].segment).size;
       (yyval.segment).addr = (yyvsp[-2].u32);
     }
-#line 2694 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2691 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 706 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 703 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.segments)); }
-#line 2700 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2697 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 707 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 704 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.segments) = (yyvsp[-1].segments);
       wasm_append_segment_value(parser->allocator, &(yyval.segments), &(yyvsp[0].segment));
     }
-#line 2709 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2706 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 714 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 711 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       if (WASM_FAILED(wasm_parse_uint64((yyvsp[0].literal).text.start,
                                         (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
@@ -2719,11 +2716,11 @@ yyreduce:
                               WASM_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2723 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2720 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 726 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 723 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       if (WASM_FAILED(wasm_parse_uint64((yyvsp[0].literal).text.start,
                                         (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
@@ -2732,57 +2729,57 @@ yyreduce:
                               WASM_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2736 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2733 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 737 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 734 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.memory).loc = (yylsp[-4]);
       (yyval.memory).initial_pages = (yyvsp[-3].u64);
       (yyval.memory).max_pages = (yyvsp[-2].u64);
       (yyval.memory).segments = (yyvsp[-1].segments);
     }
-#line 2747 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2744 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 743 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 740 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.memory).loc = (yylsp[-3]);
       (yyval.memory).initial_pages = (yyvsp[-2].u64);
       (yyval.memory).max_pages = (yyval.memory).initial_pages;
       (yyval.memory).segments = (yyvsp[-1].segments);
     }
-#line 2758 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2755 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 752 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 749 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       WASM_ZERO_MEMORY((yyval.func_type));
       (yyval.func_type).sig = (yyvsp[-2].func_sig);
     }
-#line 2767 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2764 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 756 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 753 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_type).name = (yyvsp[-5].text);
       (yyval.func_type).sig = (yyvsp[-2].func_sig);
     }
-#line 2776 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2773 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 763 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 760 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.vars) = (yyvsp[-1].vars); }
-#line 2782 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2779 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 767 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 764 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import(parser->allocator);
       (yyval.import)->module_name = (yyvsp[-3].text);
@@ -2790,11 +2787,11 @@ yyreduce:
       (yyval.import)->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
       (yyval.import)->decl.type_var = (yyvsp[-1].var);
     }
-#line 2794 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2791 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 774 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 771 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import(parser->allocator);
       (yyval.import)->name = (yyvsp[-4].text);
@@ -2803,61 +2800,59 @@ yyreduce:
       (yyval.import)->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
       (yyval.import)->decl.type_var = (yyvsp[-1].var);
     }
-#line 2807 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2804 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 782 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 779 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import(parser->allocator);
       (yyval.import)->module_name = (yyvsp[-3].text);
       (yyval.import)->func_name = (yyvsp[-2].text);
-      (yyval.import)->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_SIGNATURE;
       (yyval.import)->decl.sig = (yyvsp[-1].func_sig);
     }
-#line 2819 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2815 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 789 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 785 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import(parser->allocator);
       (yyval.import)->name = (yyvsp[-4].text);
       (yyval.import)->module_name = (yyvsp[-3].text);
       (yyval.import)->func_name = (yyvsp[-2].text);
-      (yyval.import)->decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_SIGNATURE;
       (yyval.import)->decl.sig = (yyvsp[-1].func_sig);
     }
-#line 2832 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2827 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 800 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 795 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_).name = (yyvsp[-2].text);
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 2841 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2836 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 807 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 802 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_memory).name = (yyvsp[-2].text);
     }
-#line 2849 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2844 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 813 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 808 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new_module(parser->allocator);
     }
-#line 2857 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2852 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 816 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 811 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -2865,6 +2860,9 @@ yyreduce:
       field->type = WASM_MODULE_FIELD_TYPE_FUNC;
       field->func = *(yyvsp[0].exported_func).func;
       wasm_free(parser->allocator, (yyvsp[0].exported_func).func);
+
+      append_implicit_func_declaration(parser->allocator, &(yylsp[0]), (yyval.module),
+                                       &field->func.decl);
 
       WasmFunc* func_ptr = &field->func;
       wasm_append_func_ptr_value(parser->allocator, &(yyval.module)->funcs, &func_ptr);
@@ -2894,11 +2892,11 @@ yyreduce:
         binding->index = (yyval.module)->exports.size - 1;
       }
     }
-#line 2898 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2896 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 852 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 850 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -2906,6 +2904,9 @@ yyreduce:
       field->type = WASM_MODULE_FIELD_TYPE_IMPORT;
       field->import = *(yyvsp[0].import);
       wasm_free(parser->allocator, (yyvsp[0].import));
+
+      append_implicit_func_declaration(parser->allocator, &(yylsp[0]), (yyval.module),
+                                       &field->import.decl);
 
       WasmImport* import_ptr = &field->import;
       wasm_append_import_ptr_value(parser->allocator, &(yyval.module)->imports,
@@ -2917,11 +2918,11 @@ yyreduce:
         binding->index = (yyval.module)->imports.size - 1;
       }
     }
-#line 2921 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2922 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 870 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 871 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -2939,11 +2940,11 @@ yyreduce:
         binding->index = (yyval.module)->exports.size - 1;
       }
     }
-#line 2943 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2944 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 887 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 888 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -2952,11 +2953,11 @@ yyreduce:
       field->export_memory = (yyvsp[0].export_memory);
       (yyval.module)->export_memory = &field->export_memory;
     }
-#line 2956 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2957 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 895 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 896 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -2965,11 +2966,11 @@ yyreduce:
       field->table = (yyvsp[0].vars);
       (yyval.module)->table = &field->table;
     }
-#line 2969 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2970 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 903 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 904 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -2988,11 +2989,11 @@ yyreduce:
         binding->index = (yyval.module)->func_types.size - 1;
       }
     }
-#line 2992 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 2993 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 921 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 922 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -3001,11 +3002,11 @@ yyreduce:
       field->memory = (yyvsp[0].memory);
       (yyval.module)->memory = &field->memory;
     }
-#line 3005 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3006 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 929 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 930 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       WasmModuleField* field = wasm_append_module_field(parser->allocator, (yyval.module));
@@ -3014,32 +3015,61 @@ yyreduce:
       field->start = (yyvsp[0].var);
       (yyval.module)->start = &field->start;
     }
-#line 3018 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3019 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 940 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 941 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = WASM_RAW_MODULE_TYPE_TEXT;
       (yyval.raw_module).text = (yyvsp[-1].module);
       (yyval.raw_module).loc = (yylsp[-2]);
+
+      /* resolve func type variables where the signature was not specified
+       * explicitly */
+      size_t i;
+      for (i = 0; i < (yyvsp[-1].module)->funcs.size; ++i) {
+        WasmFunc* func = (yyvsp[-1].module)->funcs.data[i];
+        if (wasm_decl_has_func_type(&func->decl) &&
+            is_empty_signature(&func->decl.sig)) {
+          WasmFuncType* func_type =
+              wasm_get_func_type_by_var((yyvsp[-1].module), &func->decl.type_var);
+          if (func_type) {
+            func->decl.sig = func_type->sig;
+            func->decl.flags |= WASM_FUNC_DECLARATION_FLAG_SHARED_SIGNATURE;
+          }
+        }
+      }
+
+      for (i = 0; i < (yyvsp[-1].module)->imports.size; ++i) {
+        WasmImport* import = (yyvsp[-1].module)->imports.data[i];
+        if (wasm_decl_has_func_type(&import->decl) &&
+            is_empty_signature(&import->decl.sig)) {
+          WasmFuncType* func_type =
+              wasm_get_func_type_by_var((yyvsp[-1].module), &import->decl.type_var);
+          if (func_type) {
+            import->decl.sig = func_type->sig;
+            import->decl.flags |= WASM_FUNC_DECLARATION_FLAG_SHARED_SIGNATURE;
+          }
+        }
+      }
     }
-#line 3028 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3058 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 945 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 975 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = WASM_RAW_MODULE_TYPE_BINARY;
       (yyval.raw_module).loc = (yylsp[-2]);
       dup_text_list(parser->allocator, &(yyvsp[-1].text_list), &(yyval.raw_module).binary.data, &(yyval.raw_module).binary.size);
       wasm_destroy_text_list(parser->allocator, &(yyvsp[-1].text_list));
     }
-#line 3039 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3069 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 954 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 984 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].raw_module).type == WASM_RAW_MODULE_TYPE_TEXT) {
         (yyval.module) = (yyvsp[0].raw_module).text;
@@ -3059,22 +3089,22 @@ yyreduce:
         wasm_free(parser->allocator, (yyvsp[0].raw_module).binary.data);
       }
     }
-#line 3063 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3093 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 978 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1008 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command(parser->allocator);
       (yyval.command)->type = WASM_COMMAND_TYPE_MODULE;
       (yyval.command)->module = *(yyvsp[0].module);
       wasm_free(parser->allocator, (yyvsp[0].module));
     }
-#line 3074 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3104 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 984 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1014 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command(parser->allocator);
       (yyval.command)->type = WASM_COMMAND_TYPE_INVOKE;
@@ -3082,22 +3112,22 @@ yyreduce:
       (yyval.command)->invoke.name = (yyvsp[-2].text);
       (yyval.command)->invoke.args = (yyvsp[-1].consts);
     }
-#line 3086 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3116 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 991 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1021 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command(parser->allocator);
       (yyval.command)->type = WASM_COMMAND_TYPE_ASSERT_INVALID;
       (yyval.command)->assert_invalid.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_invalid.text = (yyvsp[-1].text);
     }
-#line 3097 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3127 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 997 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1027 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command(parser->allocator);
       (yyval.command)->type = WASM_COMMAND_TYPE_ASSERT_RETURN;
@@ -3106,11 +3136,11 @@ yyreduce:
       (yyval.command)->assert_return.invoke.args = (yyvsp[-3].consts);
       (yyval.command)->assert_return.expected = (yyvsp[-1].const_);
     }
-#line 3110 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3140 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 1005 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1035 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command(parser->allocator);
       (yyval.command)->type = WASM_COMMAND_TYPE_ASSERT_RETURN_NAN;
@@ -3118,11 +3148,11 @@ yyreduce:
       (yyval.command)->assert_return_nan.invoke.name = (yyvsp[-3].text);
       (yyval.command)->assert_return_nan.invoke.args = (yyvsp[-2].consts);
     }
-#line 3122 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3152 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 1012 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1042 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command(parser->allocator);
       (yyval.command)->type = WASM_COMMAND_TYPE_ASSERT_TRAP;
@@ -3131,27 +3161,27 @@ yyreduce:
       (yyval.command)->assert_trap.invoke.args = (yyvsp[-3].consts);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3135 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3165 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 1022 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1052 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.commands)); }
-#line 3141 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3171 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 1023 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1053 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       wasm_append_command_value(parser->allocator, &(yyval.commands), (yyvsp[0].command));
       wasm_free(parser->allocator, (yyvsp[0].command));
     }
-#line 3151 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3181 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 1031 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1061 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WASM_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -3162,41 +3192,41 @@ yyreduce:
       }
       wasm_free(parser->allocator, (char*)(yyvsp[-1].literal).text.start);
     }
-#line 3166 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3196 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 1043 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1073 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { (yyval.const_).type = WASM_TYPE_VOID; }
-#line 3172 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3202 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 1047 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1077 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.consts)); }
-#line 3178 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3208 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 1048 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1078 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       wasm_append_const_value(parser->allocator, &(yyval.consts), &(yyvsp[0].const_));
     }
-#line 3187 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3217 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 1055 "src/wasm-ast-parser.y" /* yacc.c:1646  */
+#line 1085 "src/wasm-ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script).commands = (yyvsp[0].commands);
       parser->script = (yyval.script);
     }
-#line 3196 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3226 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
 
-#line 3200 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 3230 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -3431,7 +3461,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1067 "src/wasm-ast-parser.y" /* yacc.c:1906  */
+#line 1097 "src/wasm-ast-parser.y" /* yacc.c:1906  */
 
 
 static WasmResult parse_const(WasmType type,
@@ -3531,6 +3561,30 @@ static void dup_text_list(WasmAllocator* allocator,
   }
   *out_data = result;
   *out_size = dest - result;
+}
+
+static WasmBool is_empty_signature(WasmFuncSignature* sig) {
+  return sig->result_type == WASM_TYPE_VOID && sig->param_types.size == 0;
+}
+
+static void append_implicit_func_declaration(WasmAllocator* allocator,
+                                             WasmLocation* loc,
+                                             WasmModule* module,
+                                             WasmFuncDeclaration* decl) {
+  if (wasm_decl_has_func_type(decl))
+    return;
+
+  int sig_index = wasm_get_func_type_index_by_decl(module, decl);
+  if (sig_index == -1) {
+    wasm_append_implicit_func_type(allocator, loc, module, &decl->sig);
+  } else {
+    /* signature already exists, share that one and destroy this one */
+    wasm_destroy_func_signature(allocator, &decl->sig);
+    WasmFuncSignature* sig = &module->func_types.data[sig_index]->sig;
+    decl->sig = *sig;
+  }
+
+  decl->flags |= WASM_FUNC_DECLARATION_FLAG_SHARED_SIGNATURE;
 }
 
 WasmResult wasm_parse_ast(WasmAstLexer* lexer,

--- a/src/wasm-apply-names.c
+++ b/src/wasm-apply-names.c
@@ -274,8 +274,6 @@ static WasmResult visit_func(Context* ctx,
                                             &func->decl.type_var));
   }
 
-  assert(wasm_decl_has_signature(&func->decl));
-
   wasm_make_type_binding_reverse_mapping(
       ctx->allocator, &func->decl.sig.param_types, &func->param_bindings,
       &ctx->param_index_to_name);

--- a/src/wasm-ast-lexer.c
+++ b/src/wasm-ast-lexer.c
@@ -471,7 +471,6 @@ WasmAstLexer* wasm_new_ast_file_lexer(WasmAllocator* allocator,
   lexer->source.file = fopen(filename, "rb");
   if (!lexer->source.file) {
     wasm_destroy_ast_lexer(lexer);
-    wasm_free(allocator, lexer);
     return NULL;
   }
   return lexer;

--- a/src/wasm-ast-parser-lexer-shared.c
+++ b/src/wasm-ast-parser-lexer-shared.c
@@ -86,3 +86,34 @@ void wasm_destroy_text_list(WasmAllocator* allocator, WasmTextList* text_list) {
     node = next;
   }
 }
+
+void wasm_destroy_func_fields(struct WasmAllocator* allocator,
+                              WasmFuncField* func_field) {
+  /* destroy the entire linked-list */
+  while (func_field) {
+    WasmFuncField* next_func_field = func_field->next;
+
+    switch (func_field->type) {
+      case WASM_FUNC_FIELD_TYPE_EXPRS:
+        wasm_destroy_expr_list(allocator, func_field->first_expr);
+        break;
+
+      case WASM_FUNC_FIELD_TYPE_PARAM_TYPES:
+      case WASM_FUNC_FIELD_TYPE_LOCAL_TYPES:
+        wasm_destroy_type_vector(allocator, &func_field->types);
+        break;
+
+      case WASM_FUNC_FIELD_TYPE_BOUND_PARAM:
+      case WASM_FUNC_FIELD_TYPE_BOUND_LOCAL:
+        wasm_destroy_string_slice(allocator, &func_field->bound_type.name);
+        break;
+
+      case WASM_FUNC_FIELD_TYPE_RESULT_TYPE:
+        /* nothing to free */
+        break;
+    }
+
+    wasm_free(allocator, func_field);
+    func_field = next_func_field;
+  }
+}

--- a/src/wasm-ast-parser-lexer-shared.h
+++ b/src/wasm-ast-parser-lexer-shared.h
@@ -53,6 +53,26 @@ typedef struct WasmExportedFunc {
   WasmExport export_;
 } WasmExportedFunc;
 
+typedef enum WasmFuncFieldType {
+  WASM_FUNC_FIELD_TYPE_EXPRS,
+  WASM_FUNC_FIELD_TYPE_PARAM_TYPES,
+  WASM_FUNC_FIELD_TYPE_BOUND_PARAM,
+  WASM_FUNC_FIELD_TYPE_RESULT_TYPE,
+  WASM_FUNC_FIELD_TYPE_LOCAL_TYPES,
+  WASM_FUNC_FIELD_TYPE_BOUND_LOCAL,
+} WasmFuncFieldType;
+
+typedef struct WasmFuncField {
+  WasmFuncFieldType type;
+  union {
+    WasmExpr* first_expr;
+    WasmTypeVector types;     /* WASM_FUNC_FIELD_TYPE_{PARAM,LOCAL}_TYPES */
+    WasmBoundType bound_type; /* WASM_FUNC_FIELD_TYPE_BOUND_{LOCAL, PARAM} */
+    WasmType result_type;
+  };
+  struct WasmFuncField* next;
+} WasmFuncField;
+
 typedef union WasmToken {
   /* terminals */
   WasmStringSlice text;
@@ -122,6 +142,7 @@ void wasm_ast_format_error(WasmSourceErrorHandler*,
                            va_list);
 void wasm_destroy_exported_func(WasmAllocator*, WasmExportedFunc*);
 void wasm_destroy_text_list(WasmAllocator*, WasmTextList*);
+void wasm_destroy_func_fields(WasmAllocator*, WasmFuncField*);
 WASM_EXTERN_C_END
 
 #endif /* WASM_AST_PARSER_LEXER_SHARED_H_ */

--- a/src/wasm-ast-writer.c
+++ b/src/wasm-ast-writer.c
@@ -584,14 +584,12 @@ static void write_func(Context* ctx,
     write_var(ctx, &func->decl.type_var, NEXT_CHAR_NONE);
     write_close_space(ctx);
   }
-  if (wasm_decl_has_signature(&func->decl)) {
-    write_type_bindings(ctx, "param", func, &func->decl.sig.param_types,
-                        &func->param_bindings);
-    if (wasm_get_result_type(module, func) != WASM_TYPE_VOID) {
-      write_open_space(ctx, "result");
-      write_type(ctx, wasm_get_result_type(module, func), NEXT_CHAR_NONE);
-      write_close_space(ctx);
-    }
+  write_type_bindings(ctx, "param", func, &func->decl.sig.param_types,
+                      &func->param_bindings);
+  if (wasm_get_result_type(module, func) != WASM_TYPE_VOID) {
+    write_open_space(ctx, "result");
+    write_type(ctx, wasm_get_result_type(module, func), NEXT_CHAR_NONE);
+    write_close_space(ctx);
   }
   write_newline(ctx, NO_FORCE_NEWLINE);
   if (func->local_types.size) {

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -1,5 +1,4 @@
 ;;; FLAGS: -dv
-;; int->float reinterpret unsupported currently
 (module
   (func
     (f32.reinterpret/i32 (i32.const 0))

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -1,7 +1,5 @@
 ;;; FLAGS: -dv
 (module
-  ;; The binary encoding currently doesn't support the module name, so just use
-  ;; the func name
   (import "ignored" "test" (param i32 i64 f32 f64))
   (import "ignored" "test2" (param i32) (result i32)))
 (;; STDOUT ;;;

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -20,13 +20,13 @@
 0000013: 40                                         ; function form
 0000014: 01                                         ; num params
 0000015: 01                                         ; param type
-0000016: 01                                         ; num results
-0000017: 01                                         ; result_type
+0000016: 00                                         ; num results
 ; type 1
-0000018: 40                                         ; function form
-0000019: 01                                         ; num params
-000001a: 01                                         ; param type
-000001b: 00                                         ; num results
+0000017: 40                                         ; function form
+0000018: 01                                         ; num params
+0000019: 01                                         ; param type
+000001a: 01                                         ; num results
+000001b: 01                                         ; result_type
 ; type 2
 000001c: 40                                         ; function form
 000001d: 02                                         ; num params
@@ -40,7 +40,7 @@
 0000028: 0000 0000 00                               ; section size (guess)
 000002d: 01                                         ; num imports
 ; import header 0
-000002e: 01                                         ; import signature index
+000002e: 00                                         ; import signature index
 000002f: 05                                         ; string length
 0000030: 7374 6469 6f                             stdio  ; import module name
 0000035: 05                                         ; string length
@@ -52,8 +52,8 @@
 0000044: 0000 0000 00                               ; section size (guess)
 0000049: 03                                         ; num functions
 000004a: 02                                         ; function 0 signature index
-000004b: 01                                         ; function 1 signature index
-000004c: 01                                         ; function 2 signature index
+000004b: 00                                         ; function 1 signature index
+000004c: 00                                         ; function 2 signature index
 0000044: 8480 8080 00                               ; FIXUP section size
 ; section "table"
 000004d: 05                                         ; string length
@@ -94,7 +94,7 @@
 000008f: 01                                         ; remapped local index
 0000090: 17                                         ; OPCODE_CALL_INDIRECT
 0000091: 01                                         ; call_indirect arity
-0000092: 00                                         ; signature index
+0000092: 01                                         ; signature index
 0000086: 8880 8080 00                               ; FIXUP func body size
 ; function body 1
 0000093: 0000 0000 00                               ; func body size (guess)
@@ -117,14 +117,14 @@
 0000080: a480 8080 00                               ; FIXUP section size
 ;; dump
 0000000: 0061 736d 0b00 0000 0474 7970 658f 8080  
-0000010: 8000 0340 0101 0101 4001 0100 4002 0101  
-0000020: 0006 696d 706f 7274 8e80 8080 0001 0105  
+0000010: 8000 0340 0101 0040 0101 0101 4002 0101  
+0000020: 0006 696d 706f 7274 8e80 8080 0001 0005  
 0000030: 7374 6469 6f05 7072 696e 7408 6675 6e63  
-0000040: 7469 6f6e 8480 8080 0003 0201 0105 7461  
+0000040: 7469 6f6e 8480 8080 0003 0200 0005 7461  
 0000050: 626c 6583 8080 8000 0201 0206 6d65 6d6f  
 0000060: 7279 8380 8080 0064 6400 0665 7870 6f72  
 0000070: 7485 8080 8000 0100 0266 3104 636f 6465  
 0000080: a480 8080 0003 8880 8080 0000 1400 1401  
-0000090: 1701 0086 8080 8000 0014 0010 0140 8680  
+0000090: 1701 0186 8080 8000 0014 0010 0140 8680  
 00000a0: 8080 0000 1400 1002 42                   
 ;;; STDOUT ;;)

--- a/test/interp/spec/call_indirect.txt
+++ b/test/interp/spec/call_indirect.txt
@@ -70,11 +70,11 @@ assert_invalid error:
       (call_indirect 0 (i32.const 0) (i32.const 1) (f64.const 1))
                                                    ^
 assert_invalid error:
-  third_party/testsuite/call_indirect.wast:328:46: function type variable out of range (max 0)
+  third_party/testsuite/call_indirect.wast:328:46: function type variable out of range (max 1)
   (module (func $unbound-type (call_indirect 1 (i32.const 0))))
                                              ^
 assert_invalid error:
-  third_party/testsuite/call_indirect.wast:332:44: function type variable out of range (max 0)
+  third_party/testsuite/call_indirect.wast:332:44: function type variable out of range (max 1)
   (module (func $large-type (call_indirect 10001232130000 (i32.const 0))))
                                            ^^^^^^^^^^^^^^
 41/41 tests passed.

--- a/test/interp/spec/conversions.txt
+++ b/test/interp/spec/conversions.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/conversions.wast
 (;; STDOUT ;;;
-344/344 tests passed.
+359/359 tests passed.
 ;;; STDOUT ;;)

--- a/test/interp/spec/f32.load32.fail.txt
+++ b/test/interp/spec/f32.load32.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f32.load32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f32.load32.fail.wast:1:52: unexpected token "f32.load32"
+(module (memory 1) (func (param i32) (result f32) (f32.load32 (get_local 0))))
+                                                   ^^^^^^^^^^
+third_party/testsuite/f32.load32.fail.wast:1:63: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result f32) (f32.load32 (get_local 0))))
+                                                              ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f32.load64.fail.txt
+++ b/test/interp/spec/f32.load64.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f32.load64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f32.load64.fail.wast:1:52: unexpected token "f32.load64"
+(module (memory 1) (func (param i32) (result f32) (f32.load64 (get_local 0))))
+                                                   ^^^^^^^^^^
+third_party/testsuite/f32.load64.fail.wast:1:63: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result f32) (f32.load64 (get_local 0))))
+                                                              ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f32.store32.fail.txt
+++ b/test/interp/spec/f32.store32.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f32.store32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f32.store32.fail.wast:1:51: unexpected token "f32.store32"
+... 1) (func (param i32) (param f32) (f32.store32 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/f32.store32.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param f32) (f32.store32 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f32.store64.fail.txt
+++ b/test/interp/spec/f32.store64.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f32.store64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f32.store64.fail.wast:1:51: unexpected token "f32.store64"
+... 1) (func (param i32) (param f64) (f32.store64 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/f32.store64.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param f64) (f32.store64 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f64.load32.fail.txt
+++ b/test/interp/spec/f64.load32.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f64.load32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f64.load32.fail.wast:1:52: unexpected token "f64.load32"
+(module (memory 1) (func (param i32) (result f64) (f64.load32 (get_local 0))))
+                                                   ^^^^^^^^^^
+third_party/testsuite/f64.load32.fail.wast:1:63: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result f64) (f64.load32 (get_local 0))))
+                                                              ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f64.load64.fail.txt
+++ b/test/interp/spec/f64.load64.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f64.load64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f64.load64.fail.wast:1:52: unexpected token "f64.load64"
+(module (memory 1) (func (param i32) (result f64) (f64.load64 (get_local 0))))
+                                                   ^^^^^^^^^^
+third_party/testsuite/f64.load64.fail.wast:1:63: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result f64) (f64.load64 (get_local 0))))
+                                                              ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f64.store32.fail.txt
+++ b/test/interp/spec/f64.store32.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f64.store32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f64.store32.fail.wast:1:51: unexpected token "f64.store32"
+... 1) (func (param i32) (param f32) (f64.store32 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/f64.store32.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param f32) (f64.store32 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/f64.store64.fail.txt
+++ b/test/interp/spec/f64.store64.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/f64.store64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/f64.store64.fail.wast:1:51: unexpected token "f64.store64"
+... 1) (func (param i32) (param f64) (f64.store64 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/f64.store64.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param f64) (f64.store64 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/float_exprs.txt
+++ b/test/interp/spec/float_exprs.txt
@@ -11,5 +11,5 @@ $invoke_1()
 $invoke_2() 
 $invoke_3() 
 $invoke_8() 
-612/612 tests passed.
+694/694 tests passed.
 ;;; STDOUT ;;)

--- a/test/interp/spec/float_misc.txt
+++ b/test/interp/spec/float_misc.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/float_misc.wast
 (;; STDOUT ;;;
-354/354 tests passed.
+425/425 tests passed.
 ;;; STDOUT ;;)

--- a/test/interp/spec/func.txt
+++ b/test/interp/spec/func.txt
@@ -2,116 +2,116 @@
 ;;; STDIN_FILE: third_party/testsuite/func.wast
 (;; STDOUT ;;;
 assert_invalid error:
-  third_party/testsuite/func.wast:283:65: type mismatch of function result. got i32, expected i64
+  third_party/testsuite/func.wast:337:65: type mismatch of function result. got i32, expected i64
   (module (func $type-local-num-vs-num (result i64) (local i32) (get_local 0)))
                                                                 ^
 assert_invalid error:
-  third_party/testsuite/func.wast:287:61: type mismatch of convert op. got f32, expected i32
+  third_party/testsuite/func.wast:341:61: type mismatch of convert op. got f32, expected i32
   (module (func $type-local-num-vs-num (local f32) (i32.eqz (get_local 0))))
                                                             ^
 assert_invalid error:
-  third_party/testsuite/func.wast:291:65: type mismatch of unary op. got i64, expected f64
+  third_party/testsuite/func.wast:345:65: type mismatch of unary op. got i64, expected f64
   (module (func $type-local-num-vs-num (local f64 i64) (f64.neg (get_local 1))))
                                                                 ^
 assert_invalid error:
-  third_party/testsuite/func.wast:299:65: type mismatch of function result. got i32, expected i64
+  third_party/testsuite/func.wast:353:65: type mismatch of function result. got i32, expected i64
   (module (func $type-param-num-vs-num (param i32) (result i64) (get_local 0)))
                                                                 ^
 assert_invalid error:
-  third_party/testsuite/func.wast:303:61: type mismatch of convert op. got f32, expected i32
+  third_party/testsuite/func.wast:357:61: type mismatch of convert op. got f32, expected i32
   (module (func $type-param-num-vs-num (param f32) (i32.eqz (get_local 0))))
                                                             ^
 assert_invalid error:
-  third_party/testsuite/func.wast:307:65: type mismatch of unary op. got i64, expected f64
+  third_party/testsuite/func.wast:361:65: type mismatch of unary op. got i64, expected f64
   (module (func $type-param-num-vs-num (param f64 i64) (f64.neg (get_local 1))))
                                                                 ^
 assert_invalid error:
-  third_party/testsuite/func.wast:315:12: type mismatch of function result. got void, expected i32
+  third_party/testsuite/func.wast:369:12: type mismatch of function result. got void, expected i32
   (module (func $type-empty-i32 (result i32)))
            ^^^^
 assert_invalid error:
-  third_party/testsuite/func.wast:319:12: type mismatch of function result. got void, expected i64
+  third_party/testsuite/func.wast:373:12: type mismatch of function result. got void, expected i64
   (module (func $type-empty-i64 (result i64)))
            ^^^^
 assert_invalid error:
-  third_party/testsuite/func.wast:323:12: type mismatch of function result. got void, expected f32
+  third_party/testsuite/func.wast:377:12: type mismatch of function result. got void, expected f32
   (module (func $type-empty-f32 (result f32)))
            ^^^^
 assert_invalid error:
-  third_party/testsuite/func.wast:327:12: type mismatch of function result. got void, expected f64
+  third_party/testsuite/func.wast:381:12: type mismatch of function result. got void, expected f64
   (module (func $type-empty-f64 (result f64)))
            ^^^^
 assert_invalid error:
-  third_party/testsuite/func.wast:333:5: type mismatch in nop. got void, expected i32
+  third_party/testsuite/func.wast:387:5: type mismatch in nop. got void, expected i32
     (nop)
     ^
 assert_invalid error:
-  third_party/testsuite/func.wast:339:5: type mismatch of function result. got f32, expected i32
+  third_party/testsuite/func.wast:393:5: type mismatch of function result. got f32, expected i32
     (f32.const 0)
     ^
 assert_invalid error:
-  third_party/testsuite/func.wast:345:28: type mismatch in nop. got void, expected i32
+  third_party/testsuite/func.wast:399:28: type mismatch in nop. got void, expected i32
     (return (i32.const 1)) (nop)
                            ^
 assert_invalid error:
-  third_party/testsuite/func.wast:351:28: type mismatch of function result. got f32, expected i32
+  third_party/testsuite/func.wast:405:28: type mismatch of function result. got f32, expected i32
     (return (i32.const 1)) (f32.const 0)
                            ^
 assert_invalid error:
-  third_party/testsuite/func.wast:357:26: type mismatch in nop. got void, expected i32
+  third_party/testsuite/func.wast:411:26: type mismatch in nop. got void, expected i32
     (br 0 (i32.const 1)) (nop)
                          ^
 assert_invalid error:
-  third_party/testsuite/func.wast:363:26: type mismatch of function result. got f32, expected i32
+  third_party/testsuite/func.wast:417:26: type mismatch of function result. got f32, expected i32
     (br 0 (i32.const 1)) (f32.const 0)
                          ^
 assert_invalid error:
-  third_party/testsuite/func.wast:370:5: type mismatch of return. got void, expected i32
+  third_party/testsuite/func.wast:424:5: type mismatch of return. got void, expected i32
     (return)
     ^
 assert_invalid error:
-  third_party/testsuite/func.wast:376:5: type mismatch of return. got void, expected i32
+  third_party/testsuite/func.wast:430:5: type mismatch of return. got void, expected i32
     (return) (i32.const 1)
     ^
 assert_invalid error:
-  third_party/testsuite/func.wast:382:13: type mismatch of return. got i64, expected i32
+  third_party/testsuite/func.wast:436:13: type mismatch of return. got i64, expected i32
     (return (i64.const 1)) (i32.const 1)
             ^
 assert_invalid error:
-  third_party/testsuite/func.wast:388:13: type mismatch of return. got i64, expected i32
+  third_party/testsuite/func.wast:442:13: type mismatch of return. got i64, expected i32
     (return (i64.const 1)) (return (i32.const 1))
             ^
 assert_invalid error:
-  third_party/testsuite/func.wast:394:36: type mismatch of return. got f64, expected i32
+  third_party/testsuite/func.wast:448:36: type mismatch of return. got f64, expected i32
     (return (i32.const 1)) (return (f64.const 1))
                                    ^
 assert_invalid error:
-  third_party/testsuite/func.wast:401:5: type mismatch of br value. got void, expected i32
+  third_party/testsuite/func.wast:455:5: type mismatch of br value. got void, expected i32
     (br 0)
     ^
 assert_invalid error:
-  third_party/testsuite/func.wast:407:5: type mismatch of br value. got void, expected i32
+  third_party/testsuite/func.wast:461:5: type mismatch of br value. got void, expected i32
     (br 0) (i32.const 1)
     ^
 assert_invalid error:
-  third_party/testsuite/func.wast:413:11: type mismatch of br value. got i64, expected i32
+  third_party/testsuite/func.wast:467:11: type mismatch of br value. got i64, expected i32
     (br 0 (i64.const 1)) (i32.const 1)
           ^
 assert_invalid error:
-  third_party/testsuite/func.wast:419:11: type mismatch of br value. got i64, expected i32
+  third_party/testsuite/func.wast:473:11: type mismatch of br value. got i64, expected i32
     (br 0 (i64.const 1)) (br 0 (i32.const 1))
           ^
 assert_invalid error:
-  third_party/testsuite/func.wast:425:32: type mismatch of br value. got f64, expected i32
+  third_party/testsuite/func.wast:479:32: type mismatch of br value. got f64, expected i32
     (br 0 (i32.const 1)) (br 0 (f64.const 1))
                                ^
 assert_invalid error:
-  third_party/testsuite/func.wast:432:12: type mismatch of br value. got void, expected i32
+  third_party/testsuite/func.wast:486:12: type mismatch of br value. got void, expected i32
     (block (br 1)) (br 0 (i32.const 1))
            ^
 assert_invalid error:
-  third_party/testsuite/func.wast:438:18: type mismatch of br value. got i64, expected i32
+  third_party/testsuite/func.wast:492:18: type mismatch of br value. got i64, expected i32
     (block (br 1 (i64.const 1))) (br 0 (i32.const 1))
                  ^
-78/78 tests passed.
+82/82 tests passed.
 ;;; STDOUT ;;)

--- a/test/interp/spec/functions.txt
+++ b/test/interp/spec/functions.txt
@@ -1,5 +1,0 @@
-;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/functions.wast
-(;; STDOUT ;;;
-10/10 tests passed.
-;;; STDOUT ;;)

--- a/test/interp/spec/i32.load32_s.fail.txt
+++ b/test/interp/spec/i32.load32_s.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i32.load32_s.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i32.load32_s.fail.wast:1:52: unexpected token "i32.load32_s"
+(module (memory 1) (func (param i32) (result i32) (i32.load32_s (get_local 0))))
+                                                   ^^^^^^^^^^^^
+third_party/testsuite/i32.load32_s.fail.wast:1:65: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result i32) (i32.load32_s (get_local 0))))
+                                                                ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i32.load32_u.fail.txt
+++ b/test/interp/spec/i32.load32_u.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i32.load32_u.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i32.load32_u.fail.wast:1:52: unexpected token "i32.load32_u"
+(module (memory 1) (func (param i32) (result i32) (i32.load32_u (get_local 0))))
+                                                   ^^^^^^^^^^^^
+third_party/testsuite/i32.load32_u.fail.wast:1:65: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result i32) (i32.load32_u (get_local 0))))
+                                                                ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i32.load64_s.fail.txt
+++ b/test/interp/spec/i32.load64_s.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i32.load64_s.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i32.load64_s.fail.wast:1:52: unexpected token "i32.load64_s"
+(module (memory 1) (func (param i32) (result i32) (i32.load64_s (get_local 0))))
+                                                   ^^^^^^^^^^^^
+third_party/testsuite/i32.load64_s.fail.wast:1:65: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result i32) (i32.load64_s (get_local 0))))
+                                                                ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i32.load64_u.fail.txt
+++ b/test/interp/spec/i32.load64_u.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i32.load64_u.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i32.load64_u.fail.wast:1:52: unexpected token "i32.load64_u"
+(module (memory 1) (func (param i32) (result i32) (i32.load64_u (get_local 0))))
+                                                   ^^^^^^^^^^^^
+third_party/testsuite/i32.load64_u.fail.wast:1:65: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result i32) (i32.load64_u (get_local 0))))
+                                                                ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i32.store32.fail.txt
+++ b/test/interp/spec/i32.store32.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i32.store32.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i32.store32.fail.wast:1:51: unexpected token "i32.store32"
+... 1) (func (param i32) (param i32) (i32.store32 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/i32.store32.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param i32) (i32.store32 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i32.store64.fail.txt
+++ b/test/interp/spec/i32.store64.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i32.store64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i32.store64.fail.wast:1:51: unexpected token "i32.store64"
+... 1) (func (param i32) (param i64) (i32.store64 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/i32.store64.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param i64) (i32.store64 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i32.txt
+++ b/test/interp/spec/i32.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.wast
 (;; STDOUT ;;;
-326/326 tests passed.
+342/342 tests passed.
 ;;; STDOUT ;;)

--- a/test/interp/spec/i64.load64_s.fail.txt
+++ b/test/interp/spec/i64.load64_s.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i64.load64_s.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i64.load64_s.fail.wast:1:52: unexpected token "i64.load64_s"
+(module (memory 1) (func (param i32) (result i64) (i64.load64_s (get_local 0))))
+                                                   ^^^^^^^^^^^^
+third_party/testsuite/i64.load64_s.fail.wast:1:65: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result i64) (i64.load64_s (get_local 0))))
+                                                                ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i64.load64_u.fail.txt
+++ b/test/interp/spec/i64.load64_u.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i64.load64_u.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i64.load64_u.fail.wast:1:52: unexpected token "i64.load64_u"
+(module (memory 1) (func (param i32) (result i64) (i64.load64_u (get_local 0))))
+                                                   ^^^^^^^^^^^^
+third_party/testsuite/i64.load64_u.fail.wast:1:65: syntax error, unexpected (
+(module (memory 1) (func (param i32) (result i64) (i64.load64_u (get_local 0))))
+                                                                ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i64.store64.fail.txt
+++ b/test/interp/spec/i64.store64.fail.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/i64.store64.fail.wast
+(;; STDERR ;;;
+Error running "sexpr-wasm":
+third_party/testsuite/i64.store64.fail.wast:1:51: unexpected token "i64.store64"
+... 1) (func (param i32) (param i64) (i64.store64 (get_local 0) (get_local 1))))
+                                      ^^^^^^^^^^^
+third_party/testsuite/i64.store64.fail.wast:1:63: syntax error, unexpected (
+... 1) (func (param i32) (param i64) (i64.store64 (get_local 0) (get_local 1))))
+                                                  ^
+
+;;; STDERR ;;)

--- a/test/interp/spec/i64.txt
+++ b/test/interp/spec/i64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i64.wast
 (;; STDOUT ;;;
-328/328 tests passed.
+344/344 tests passed.
 ;;; STDOUT ;;)

--- a/test/interp/spec/runaway-recursion.txt
+++ b/test/interp/spec/runaway-recursion.txt
@@ -1,5 +1,0 @@
-;;; TOOL: run-interp-spec
-;;; STDIN_FILE: third_party/testsuite/runaway-recursion.wast
-(;; STDOUT ;;;
-2/2 tests passed.
-;;; STDOUT ;;)

--- a/test/parse/expr/cast.txt
+++ b/test/parse/expr/cast.txt
@@ -1,4 +1,3 @@
-;; int->float reinterpret unsupported currently
 (module
   (func
     (f32.reinterpret/i32 (i32.const 0))

--- a/test/parse/func/bad-sig-result-type-mismatch.txt
+++ b/test/parse/func/bad-sig-result-type-mismatch.txt
@@ -6,7 +6,7 @@
 parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch between function result and function type result. got i64, expected f32
   (func (type $t) (param i32) (result i64)))
    ^^^^
-parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch of function result. got void, expected f32
+parse/func/bad-sig-result-type-mismatch.txt:4:4: type mismatch of function result. got void, expected i64
   (func (type $t) (param i32) (result i64)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-not-void.txt
+++ b/test/parse/func/bad-sig-result-type-not-void.txt
@@ -6,4 +6,7 @@
 parse/func/bad-sig-result-type-not-void.txt:4:4: type mismatch between function result and function type result. got f32, expected void
   (func (type $t) (param i32) (result f32)))
    ^^^^
+parse/func/bad-sig-result-type-not-void.txt:4:4: type mismatch of function result. got void, expected f32
+  (func (type $t) (param i32) (result f32)))
+   ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-void.txt
+++ b/test/parse/func/bad-sig-result-type-void.txt
@@ -6,7 +6,4 @@
 parse/func/bad-sig-result-type-void.txt:4:4: type mismatch between function result and function type result. got void, expected f32
   (func (type $t) (param i32)))
    ^^^^
-parse/func/bad-sig-result-type-void.txt:4:4: type mismatch of function result. got void, expected f32
-  (func (type $t) (param i32)))
-   ^^^^
 ;;; STDERR ;;)

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 WebAssembly Community Group participants
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_DIR = SCRIPT_DIR
+REPO_ROOT_DIR = os.path.dirname(SCRIPT_DIR)
+TESTSUITE_DIR = os.path.join(REPO_ROOT_DIR, 'third_party', 'testsuite')
+SPEC_TEST_DIR = os.path.join(TEST_DIR, 'interp', 'spec')
+
+
+def GetFilesWithExtension(src_dir, want_ext):
+  result = []
+  for filename in os.listdir(src_dir):
+    name, ext = os.path.splitext(filename)
+    if ext == want_ext:
+      result.append(name)
+  return result
+
+
+def main(args):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
+                      action='store_true')
+  options = parser.parse_args(args)
+
+  testsuite_tests = set(GetFilesWithExtension(TESTSUITE_DIR, '.wast'))
+  spec_tests = set(GetFilesWithExtension(SPEC_TEST_DIR, '.txt'))
+
+  for removed_test_name in spec_tests - testsuite_tests:
+    test_filename = os.path.join(SPEC_TEST_DIR, removed_test_name + '.txt')
+    if options.verbose:
+      print 'Removing %s' % test_filename
+    os.remove(test_filename)
+
+  for added_test_name in testsuite_tests - spec_tests:
+    wast_filename = os.path.join(os.path.relpath(TESTSUITE_DIR, REPO_ROOT_DIR),
+                                 added_test_name + '.wast')
+    test_filename = os.path.join(SPEC_TEST_DIR, added_test_name + '.txt')
+    if options.verbose:
+      print 'Adding %s' % test_filename
+    with open(test_filename, 'w') as f:
+      if added_test_name.endswith('.fail'):
+        f.write(';;; ERROR: 1\n')
+      f.write(';;; TOOL: run-interp-spec\n')
+      f.write(';;; STDIN_FILE: %s\n' % wast_filename)
+
+  return 0
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Change 7c482b1a of the spec repo now requires that implicit function
types are created when creating a new func or import, but only when the
type is not explicitly specified, and the have not been specified. For
example:

```
(func (param i32))
(import "foo" "bar" (result i32)
```

This was previously done in sexpr-wasm when writing the binary, but now
these types can be referenced by `call_import`, so it has to be handled
earlier.

Since all signatures are now defined in the module, I made it so the
function signature is shared with the module function types. The tricky
part here is when a function type and an explicit signature are both
specified:

```
(func (type $t) (param f32) ...)
```

In this case, we need to keep the explicit signature around long enough
to be checked against the function type, so it must be owned by the
function. The WASM_FUNC_DECLARATION_FLAG_SHARED_SIGNATURE flag specifies
this case.

To simplify code that uses the AST, I reverted many of the
changes introduced in 73e5bc7d. Now the function declaration's signature
is always valid to access, and will have been resolved if it was
specified with a func type instead of an explicit signature.

Some other changes:

* There was a bug in the interpreter's `f32.demote/f64` rounding when
  given a value that is very close to positive or negative F32_MAX

* Added `update-spec-tests.py` to more easily update the spec tests in
  `test/interp/spec/*.txt` from the files in
  `third_party/testsuite/*.wast`. Previously I would just do it
  manually.