### PR TITLE
Fix error message in the generated invoke function

### DIFF
--- a/test/gen-spec-js.py
+++ b/test/gen-spec-js.py
@@ -117,8 +117,10 @@ function assertTrap(module, name, file, line) {
 function invoke(module, name) {
   try {
     var invokeResult = module.exports[name]();
+    passed++;
   } catch(e) {
-    print(file + ":" + line + ": " + name + " unexpectedly threw: " + e);
+    print(name + " unexpectedly threw: " + e);
+    failed++;
   }
 
   if (!quiet)


### PR DESCRIPTION
The error message wanted to print some file name and line number, but these values are not passed to invoke(). Additionally I propose to increase the passed and failed counters in invoke.