### PR TITLE
Improve error message on bad file version

### DIFF
--- a/src/wasm-binary-reader.c
+++ b/src/wasm-binary-reader.c
@@ -1135,10 +1135,12 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
 
   uint32_t magic;
   in_u32(ctx, &magic, "magic");
-  RAISE_ERROR_UNLESS(magic == WASM_BINARY_MAGIC, "magic value mismatch");
+  RAISE_ERROR_UNLESS(magic == WASM_BINARY_MAGIC, "bad magic value");
   uint32_t version;
   in_u32(ctx, &version, "version");
-  RAISE_ERROR_UNLESS(version == WASM_BINARY_VERSION, "version mismatch");
+  RAISE_ERROR_UNLESS(version == WASM_BINARY_VERSION,
+                     "bad wasm file version: %#x (expected %#x)",
+                     version, WASM_BINARY_VERSION);
 
   /* type */
   uint32_t num_signatures = 0;

--- a/test/binary/bad-magic.txt
+++ b/test/binary/bad-magic.txt
@@ -4,6 +4,6 @@
 version
 (;; STDERR ;;;
 Error running "wasm-wast":
-error: @0x00000004: magic value mismatch
+error: @0x00000004: bad magic value
 
 ;;; STDERR ;;)

--- a/test/binary/bad-version.txt
+++ b/test/binary/bad-version.txt
@@ -4,6 +4,6 @@ magic
 0xc 0 0 0
 (;; STDERR ;;;
 Error running "wasm-wast":
-error: @0x00000008: version mismatch
+error: @0x00000008: bad wasm file version: 0xc (expected 0xb)
 
 ;;; STDERR ;;)

--- a/test/interp/spec/binary.txt
+++ b/test/interp/spec/binary.txt
@@ -18,7 +18,7 @@ assert_invalid error:
 (assert_invalid (module "\01") "unexpected end")
                  ^^^^^^
 assert_invalid error:
-  third_party/testsuite/binary.wast:8:18: error in binary module: @0x00000004: magic value mismatch
+  third_party/testsuite/binary.wast:8:18: error in binary module: @0x00000004: bad magic value
 (assert_invalid (module "asm\00") "magic header not detected")
                  ^^^^^^
 assert_invalid error:
@@ -34,7 +34,7 @@ assert_invalid error:
 (assert_invalid (module "\00asm\0b\00\00") "unexpected end")
                  ^^^^^^
 assert_invalid error:
-  third_party/testsuite/binary.wast:13:18: error in binary module: @0x00000008: version mismatch
+  third_party/testsuite/binary.wast:13:18: error in binary module: @0x00000008: bad wasm file version: 0x10 (expected 0xb)
 (assert_invalid (module "\00asm\10\00\00\00") "unknown binary version")
                  ^^^^^^
 0/0 tests passed.

--- a/test/parse/assert/assertinvalid-binary-module.txt
+++ b/test/parse/assert/assertinvalid-binary-module.txt
@@ -1,7 +1,7 @@
 (assert_invalid (module "\00ASM") "bad magic")
 (;; STDOUT ;;;
 assert_invalid error:
-  parse/assert/assertinvalid-binary-module.txt:1:18: error in binary module: @0x00000004: magic value mismatch
+  parse/assert/assertinvalid-binary-module.txt:1:18: error in binary module: @0x00000004: bad magic value
 (assert_invalid (module "\00ASM") "bad magic")
                  ^^^^^^
 ;;; STDOUT ;;)

--- a/test/parse/module/bad-binary-module-magic.txt
+++ b/test/parse/module/bad-binary-module-magic.txt
@@ -3,7 +3,7 @@
   "\00ASM"
   "\0b\00\00\00")
 (;; STDERR ;;;
-parse/module/bad-binary-module-magic.txt:2:2: error in binary module: @0x00000004: magic value mismatch
+parse/module/bad-binary-module-magic.txt:2:2: error in binary module: @0x00000004: bad magic value
 (module
  ^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
As a newcomer it was not obvious what version wasm-interp
was expecting and what I had provided.