### PR TITLE
Fix broken 'run-tests' target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ add_custom_command( TARGET wasm2wast
                     COMMAND ln -sf wasm2wast wasm-wast)
 
 endif ()
-set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "wasm-wast" "sexpr-wasm")
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "wasm2wast" "wast2wasm")
 
 # wasm-interp
 add_executable(wasm-interp src/wasm-interp.c)
@@ -312,7 +312,7 @@ find_package(PythonInterp 2.7 REQUIRED)
 set(RUN_TESTS_PY ${SEXPR_WASM_SOURCE_DIR}/test/run-tests.py)
 add_custom_target(run-tests
   COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY}
-      -e $<TARGET_FILE:wast2wasm>
+      --wast2wasm $<TARGET_FILE:wast2wasm>
       --wasm2wast $<TARGET_FILE:wasm2wast>
       --wasm-interp $<TARGET_FILE:wasm-interp>
   DEPENDS wast2wasm wasm2wast wasm-interp

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -49,13 +49,13 @@ set_run_test_args() {
   RUN_TEST_ARGS=""
   local EXE_DIR=out/${COMPILER}/${BUILD_TYPE}/${CONFIG}
 
-  SEXPR_WASM=${EXE_DIR}/sexpr-wasm
-  WASM_WAST=${EXE_DIR}/wasm-wast
+  WAST2WASM=${EXE_DIR}/wast2wasm
+  WASM2WAST=${EXE_DIR}/wasm2wast
   WASM_INTERP=${EXE_DIR}/wasm-interp
 
-  check_and_add_flag "--sexpr-wasm" ${SEXPR_WASM} && \
-      check_and_add_flag "--wasm-wast" ${WASM_WAST} && \
-      check_and_add_flag "--wasm-interp" ${WASM_INTERP}
+  check_and_add_flag "--wast2wasm-executable" ${WAST2WASM} && \
+      check_and_add_flag "--wasm2wast-executable" ${WASM2WAST} && \
+      check_and_add_flag "--wasm-interp-executable" ${WASM_INTERP}
 }
 
 if [ ${CC} = "gcc" ]; then

--- a/test/binary/bad-block-end.txt
+++ b/test/binary/bad-block-end.txt
@@ -15,7 +15,7 @@ section("code") {
   }
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: popping past block label
 error: @0x0000002c: on_br_expr callback failed
 

--- a/test/binary/bad-export-func.txt
+++ b/test/binary/bad-export-func.txt
@@ -6,7 +6,7 @@ section("type") { count[1] function params[0] results[0] }
 section("function") { count[1] sig[0] }
 section("export") { count[1] func[1] str("foo") }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000028: invalid export function index
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-body-count.txt
+++ b/test/binary/bad-function-body-count.txt
@@ -9,7 +9,7 @@ section("code") {
   func { locals[0] }
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000026: function signature count != function body count
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-local-type.txt
+++ b/test/binary/bad-function-local-type.txt
@@ -12,7 +12,7 @@ section("code") {
   }
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000029: expected valid local type
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -12,7 +12,7 @@ section("name") {
   str("g") locals[0]
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x0000002f: function name count > function signature count
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-param-type.txt
+++ b/test/binary/bad-function-param-type.txt
@@ -7,7 +7,7 @@ section("type") {
   function params[1] void results[0]
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000012: expected valid param type
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-result-type.txt
+++ b/test/binary/bad-function-result-type.txt
@@ -7,7 +7,7 @@ section("type") {
   function params[1] i32 results[1] void
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000014: expected valid result type
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-sig.txt
+++ b/test/binary/bad-function-sig.txt
@@ -5,7 +5,7 @@ version
 section("type") { count[1] function params[1] i32 results[1] i32 }
 section("function") { count[1] type[1] }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000020: invalid function signature index
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-too-many-results.txt
+++ b/test/binary/bad-function-too-many-results.txt
@@ -4,7 +4,7 @@ magic
 version
 section("type") { count[1] function params[0] results[2] i32 i32 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000012: result count must be 0 or 1
 
 ;;; STDERR ;;)

--- a/test/binary/bad-import-sig.txt
+++ b/test/binary/bad-import-sig.txt
@@ -5,7 +5,7 @@ version
 section("type") { count[1] function params[0] results[1] i32 }
 section("import") { count[1] type[1] str("module") str("func") }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x0000001d: invalid import signature index
 
 ;;; STDERR ;;)

--- a/test/binary/bad-magic.txt
+++ b/test/binary/bad-magic.txt
@@ -3,7 +3,7 @@
 0 "ASM"
 version
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000004: bad magic value
 
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-export-flag.txt
+++ b/test/binary/bad-memory-export-flag.txt
@@ -4,7 +4,7 @@ magic
 version
 section("memory") { initial[0] max[1] export[2] }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000013: expected valid mem export flag
 
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-init-max-size.txt
+++ b/test/binary/bad-memory-init-max-size.txt
@@ -4,7 +4,7 @@ magic
 version
 section("memory") { initial[2] max[1] export[0] }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000012: memory initial size must be <= max size
 
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-init-size.txt
+++ b/test/binary/bad-memory-init-size.txt
@@ -8,7 +8,7 @@ section("memory") {
   export[0]
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000013: invalid memory initial size
 
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-max-size.txt
+++ b/test/binary/bad-memory-max-size.txt
@@ -8,7 +8,7 @@ section("memory") {
   export[0]
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000014: invalid memory max size
 
 ;;; STDERR ;;)

--- a/test/binary/bad-segment-no-memory.txt
+++ b/test/binary/bad-segment-no-memory.txt
@@ -4,7 +4,7 @@ magic
 version
 section("data") { count[1] addr[0] data[str("hi")] }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x0000000e: data segment section without memory section
 
 ;;; STDERR ;;)

--- a/test/binary/bad-start-func.txt
+++ b/test/binary/bad-start-func.txt
@@ -6,7 +6,7 @@ section("type") { count[1] function params[0] results[0] }
 section("function") { count[1] sig[0] }
 section("start") { func[1] }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000026: invalid start function index
 
 ;;; STDERR ;;)

--- a/test/binary/bad-table-func.txt
+++ b/test/binary/bad-table-func.txt
@@ -6,7 +6,7 @@ section("type") { count[1] function params[0] results[0] }
 section("function") { count[1] type[0] }
 section("table") { count[1] func[1] }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000027: invalid function table function index
 
 ;;; STDERR ;;)

--- a/test/binary/bad-type-form.txt
+++ b/test/binary/bad-type-form.txt
@@ -7,7 +7,7 @@ section("type") {
   0x20
 }
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000010: unexpected type form
 
 ;;; STDERR ;;)

--- a/test/binary/bad-version.txt
+++ b/test/binary/bad-version.txt
@@ -3,7 +3,7 @@
 magic
 0xc 0 0 0
 (;; STDERR ;;;
-Error running "wasm-wast":
+Error running "wasm2wast":
 error: @0x00000008: bad wasm file version: 0xc (expected 0xb)
 
 ;;; STDERR ;;)

--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -23,14 +23,14 @@ from utils import Error
 IS_WINDOWS = sys.platform == 'win32'
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT_DIR = os.path.dirname(SCRIPT_DIR)
-DEFAULT_SEXPR_WASM_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'sexpr-wasm')
-DEFAULT_WASM_WAST_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'wasm-wast')
+DEFAULT_WAST2WASM_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'wast2wasm')
+DEFAULT_WASM2WAST_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'wasm2wast')
 DEFAULT_WASM_INTERP_EXE = os.path.join(REPO_ROOT_DIR, 'out', 'wasm-interp')
 
 
 if IS_WINDOWS:
-  DEFAULT_SEXPR_WASM_EXE += '.exe'
-  DEFAULT_WASM_WAST_EXE += '.exe'
+  DEFAULT_WAST2WASM_EXE += '.exe'
+  DEFAULT_WASM2WAST_EXE += '.exe'
   DEFAULT_WASM_INTERP_EXE += '.exe'
 
 
@@ -53,11 +53,11 @@ def FindExeWithFallback(name, default_exe_list, override_exe=None):
 
 
 def GetSexprWasmExecutable(override=None):
-  return FindExeWithFallback('sexpr-wasm', [DEFAULT_SEXPR_WASM_EXE], override)
+  return FindExeWithFallback('wast2wasm', [DEFAULT_WAST2WASM_EXE], override)
 
 
 def GetWasmWastExecutable(override=None):
-  return FindExeWithFallback('wasm-wast', [DEFAULT_WASM_WAST_EXE], override)
+  return FindExeWithFallback('wasm2wast', [DEFAULT_WASM2WAST_EXE], override)
 
 
 def GetWasmInterpExecutable(override=None):

--- a/test/help/sexpr-wasm.txt
+++ b/test/help/sexpr-wasm.txt
@@ -1,4 +1,4 @@
-;;; EXE: %(sexpr-wasm)s
+;;; EXE: %(wast2wasm)s
 ;;; FLAGS: --help
 (;; STDOUT ;;;
 usage: wast2wasm [options] filename

--- a/test/help/wasm-wast.txt
+++ b/test/help/wasm-wast.txt
@@ -1,4 +1,4 @@
-;;; EXE: %(wasm-wast)s
+;;; EXE: %(wasm2wast)s
 ;;; FLAGS: --help
 (;; STDOUT ;;;
 usage: wasm2wast [options] filename

--- a/test/interp/spec/f32.load32.fail.txt
+++ b/test/interp/spec/f32.load32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f32.load32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f32.load32.fail.wast:1:52: unexpected token "f32.load32"
 (module (memory 1) (func (param i32) (result f32) (f32.load32 (get_local 0))))
                                                    ^^^^^^^^^^

--- a/test/interp/spec/f32.load64.fail.txt
+++ b/test/interp/spec/f32.load64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f32.load64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f32.load64.fail.wast:1:52: unexpected token "f32.load64"
 (module (memory 1) (func (param i32) (result f32) (f32.load64 (get_local 0))))
                                                    ^^^^^^^^^^

--- a/test/interp/spec/f32.store32.fail.txt
+++ b/test/interp/spec/f32.store32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f32.store32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f32.store32.fail.wast:1:51: unexpected token "f32.store32"
 ... 1) (func (param i32) (param f32) (f32.store32 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/f32.store64.fail.txt
+++ b/test/interp/spec/f32.store64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f32.store64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f32.store64.fail.wast:1:51: unexpected token "f32.store64"
 ... 1) (func (param i32) (param f64) (f32.store64 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/f64.load32.fail.txt
+++ b/test/interp/spec/f64.load32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f64.load32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f64.load32.fail.wast:1:52: unexpected token "f64.load32"
 (module (memory 1) (func (param i32) (result f64) (f64.load32 (get_local 0))))
                                                    ^^^^^^^^^^

--- a/test/interp/spec/f64.load64.fail.txt
+++ b/test/interp/spec/f64.load64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f64.load64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f64.load64.fail.wast:1:52: unexpected token "f64.load64"
 (module (memory 1) (func (param i32) (result f64) (f64.load64 (get_local 0))))
                                                    ^^^^^^^^^^

--- a/test/interp/spec/f64.store32.fail.txt
+++ b/test/interp/spec/f64.store32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f64.store32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f64.store32.fail.wast:1:51: unexpected token "f64.store32"
 ... 1) (func (param i32) (param f32) (f64.store32 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/f64.store64.fail.txt
+++ b/test/interp/spec/f64.store64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/f64.store64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/f64.store64.fail.wast:1:51: unexpected token "f64.store64"
 ... 1) (func (param i32) (param f64) (f64.store64 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/func-local-after-body.fail.txt
+++ b/test/interp/spec/func-local-after-body.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func-local-after-body.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/func-local-after-body.fail.wast:1:22: syntax error, unexpected LOCAL
 (module (func (nop) (local i32)))
                      ^^^^^

--- a/test/interp/spec/func-local-before-param.fail.txt
+++ b/test/interp/spec/func-local-before-param.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func-local-before-param.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/func-local-before-param.fail.wast:1:28: syntax error, unexpected PARAM
 (module (func (local i32) (param i32)))
                            ^^^^^

--- a/test/interp/spec/func-local-before-result.fail.txt
+++ b/test/interp/spec/func-local-before-result.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func-local-before-result.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/func-local-before-result.fail.wast:1:28: syntax error, unexpected RESULT
 (module (func (local i32) (result i32) (get_local 0)))
                            ^^^^^^

--- a/test/interp/spec/func-param-after-body.fail.txt
+++ b/test/interp/spec/func-param-after-body.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func-param-after-body.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/func-param-after-body.fail.wast:1:22: syntax error, unexpected PARAM
 (module (func (nop) (param i32)))
                      ^^^^^

--- a/test/interp/spec/func-result-after-body.fail.txt
+++ b/test/interp/spec/func-result-after-body.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func-result-after-body.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/func-result-after-body.fail.wast:1:22: syntax error, unexpected RESULT
 (module (func (nop) (result i32)))
                      ^^^^^^

--- a/test/interp/spec/func-result-before-param.fail.txt
+++ b/test/interp/spec/func-result-before-param.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func-result-before-param.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/func-result-before-param.fail.wast:1:29: syntax error, unexpected PARAM
 (module (func (result i32) (param i32) (get_local 0)))
                             ^^^^^

--- a/test/interp/spec/i32.load32_s.fail.txt
+++ b/test/interp/spec/i32.load32_s.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.load32_s.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i32.load32_s.fail.wast:1:52: unexpected token "i32.load32_s"
 (module (memory 1) (func (param i32) (result i32) (i32.load32_s (get_local 0))))
                                                    ^^^^^^^^^^^^

--- a/test/interp/spec/i32.load32_u.fail.txt
+++ b/test/interp/spec/i32.load32_u.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.load32_u.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i32.load32_u.fail.wast:1:52: unexpected token "i32.load32_u"
 (module (memory 1) (func (param i32) (result i32) (i32.load32_u (get_local 0))))
                                                    ^^^^^^^^^^^^

--- a/test/interp/spec/i32.load64_s.fail.txt
+++ b/test/interp/spec/i32.load64_s.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.load64_s.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i32.load64_s.fail.wast:1:52: unexpected token "i32.load64_s"
 (module (memory 1) (func (param i32) (result i32) (i32.load64_s (get_local 0))))
                                                    ^^^^^^^^^^^^

--- a/test/interp/spec/i32.load64_u.fail.txt
+++ b/test/interp/spec/i32.load64_u.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.load64_u.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i32.load64_u.fail.wast:1:52: unexpected token "i32.load64_u"
 (module (memory 1) (func (param i32) (result i32) (i32.load64_u (get_local 0))))
                                                    ^^^^^^^^^^^^

--- a/test/interp/spec/i32.store32.fail.txt
+++ b/test/interp/spec/i32.store32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.store32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i32.store32.fail.wast:1:51: unexpected token "i32.store32"
 ... 1) (func (param i32) (param i32) (i32.store32 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/i32.store64.fail.txt
+++ b/test/interp/spec/i32.store64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.store64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i32.store64.fail.wast:1:51: unexpected token "i32.store64"
 ... 1) (func (param i32) (param i64) (i32.store64 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/i64.load64_s.fail.txt
+++ b/test/interp/spec/i64.load64_s.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i64.load64_s.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i64.load64_s.fail.wast:1:52: unexpected token "i64.load64_s"
 (module (memory 1) (func (param i32) (result i64) (i64.load64_s (get_local 0))))
                                                    ^^^^^^^^^^^^

--- a/test/interp/spec/i64.load64_u.fail.txt
+++ b/test/interp/spec/i64.load64_u.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i64.load64_u.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i64.load64_u.fail.wast:1:52: unexpected token "i64.load64_u"
 (module (memory 1) (func (param i32) (result i64) (i64.load64_u (get_local 0))))
                                                    ^^^^^^^^^^^^

--- a/test/interp/spec/i64.store64.fail.txt
+++ b/test/interp/spec/i64.store64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i64.store64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/i64.store64.fail.wast:1:51: unexpected token "i64.store64"
 ... 1) (func (param i32) (param i64) (i64.store64 (get_local 0) (get_local 1))))
                                       ^^^^^^^^^^^

--- a/test/interp/spec/if_label_scope.fail.txt
+++ b/test/interp/spec/if_label_scope.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/if_label_scope.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/if_label_scope.fail.wast:6:19: undefined label variable "$l"
         (else (br $l (i32.const 42)))
                   ^^

--- a/test/interp/spec/of_string-overflow-hex-u32.fail.txt
+++ b/test/interp/spec/of_string-overflow-hex-u32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/of_string-overflow-hex-u32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/of_string-overflow-hex-u32.fail.wast:1:26: invalid literal "0x100000000"
 (module (func (i32.const 0x100000000)))
                          ^^^^^^^^^^^

--- a/test/interp/spec/of_string-overflow-hex-u64.fail.txt
+++ b/test/interp/spec/of_string-overflow-hex-u64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/of_string-overflow-hex-u64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/of_string-overflow-hex-u64.fail.wast:1:26: invalid literal "0x10000000000000000"
 (module (func (i64.const 0x10000000000000000)))
                          ^^^^^^^^^^^^^^^^^^^

--- a/test/interp/spec/of_string-overflow-s32.fail.txt
+++ b/test/interp/spec/of_string-overflow-s32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/of_string-overflow-s32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/of_string-overflow-s32.fail.wast:1:26: invalid literal "-2147483649"
 (module (func (i32.const -2147483649)))
                          ^^^^^^^^^^^

--- a/test/interp/spec/of_string-overflow-s64.fail.txt
+++ b/test/interp/spec/of_string-overflow-s64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/of_string-overflow-s64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/of_string-overflow-s64.fail.wast:1:26: invalid literal "-9223372036854775809"
 (module (func (i64.const -9223372036854775809)))
                          ^^^^^^^^^^^^^^^^^^^^

--- a/test/interp/spec/of_string-overflow-u32.fail.txt
+++ b/test/interp/spec/of_string-overflow-u32.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/of_string-overflow-u32.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/of_string-overflow-u32.fail.wast:1:26: invalid literal "4294967296"
 (module (func (i32.const 4294967296)))
                          ^^^^^^^^^^

--- a/test/interp/spec/of_string-overflow-u64.fail.txt
+++ b/test/interp/spec/of_string-overflow-u64.fail.txt
@@ -2,7 +2,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/of_string-overflow-u64.fail.wast
 (;; STDERR ;;;
-Error running "sexpr-wasm":
+Error running "wast2wasm":
 third_party/testsuite/of_string-overflow-u64.fail.wast:1:26: invalid literal "18446744073709551616"
 (module (func (i64.const 18446744073709551616)))
                          ^^^^^^^^^^^^^^^^^^^^

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -36,8 +36,8 @@ def main(args):
                       action='store_true')
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wasm-wast-executable', metavar='PATH',
-                      help='set the wasm-wast executable to use.')
+  parser.add_argument('--wasm2wast-executable', metavar='PATH',
+                      help='set the wasm2wast executable to use.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
@@ -53,22 +53,22 @@ def main(args):
   gen_wasm = utils.Executable(
       sys.executable, GEN_WASM_PY, error_cmdline=options.error_cmdline)
 
-  wasm_wast = utils.Executable(
-      find_exe.GetWasmWastExecutable(options.wasm_wast_executable),
+  wasm2wast = utils.Executable(
+      find_exe.GetWasmWastExecutable(options.wasm2wast_executable),
       error_cmdline=options.error_cmdline)
-  wasm_wast.AppendOptionalArgs({
+  wasm2wast.AppendOptionalArgs({
     '--debug-names': options.debug_names,
     '--generate-names': options.generate_names,
     '--use-libc-allocator': options.use_libc_allocator
   })
 
   gen_wasm.verbose = options.print_cmd
-  wasm_wast.verbose = options.print_cmd
+  wasm2wast.verbose = options.print_cmd
 
   with utils.TempDirectory(options.out_dir, 'run-gen-wasm-') as out_dir:
     out_file = utils.ChangeDir(utils.ChangeExt(options.file, '.wasm'), out_dir)
     gen_wasm.RunWithArgs(options.file, '-o', out_file)
-    wasm_wast.RunWithArgs(out_file)
+    wasm2wast.RunWithArgs(out_file)
 
 if __name__ == '__main__':
   try:

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -31,8 +31,8 @@ def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('-e', '--executable', metavar='PATH',
-                      help='override sexpr-wasm executable.')
+  parser.add_argument('--wast2wasm-executable', metavar='PATH',
+                      help='override wast2wasm executable.')
   parser.add_argument('--wasm-interp-executable', metavar='PATH',
                       help='override wasm-interp executable.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
@@ -49,10 +49,10 @@ def main(args):
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
 
-  sexpr_wasm = utils.Executable(
-      find_exe.GetSexprWasmExecutable(options.executable),
+  wast2wasm = utils.Executable(
+      find_exe.GetSexprWasmExecutable(options.wast2wasm_executable),
       error_cmdline=options.error_cmdline)
-  sexpr_wasm.AppendOptionalArgs({
+  wast2wasm.AppendOptionalArgs({
     '-v': options.verbose,
     '--spec': options.spec,
     '--use-libc-allocator': options.use_libc_allocator
@@ -68,13 +68,13 @@ def main(args):
     '--use-libc-allocator': options.use_libc_allocator
   })
 
-  sexpr_wasm.verbose = options.print_cmd
+  wast2wasm.verbose = options.print_cmd
   wasm_interp.verbose = options.print_cmd
 
   with utils.TempDirectory(options.out_dir, 'run-interp-') as out_dir:
     new_ext = '.json' if options.spec else '.wasm'
     out_file = utils.ChangeDir(utils.ChangeExt(options.file, new_ext), out_dir)
-    sexpr_wasm.RunWithArgs(options.file, '-o', out_file)
+    wast2wasm.RunWithArgs(options.file, '-o', out_file)
     wasm_interp.RunWithArgs(out_file)
 
   return 0

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -50,16 +50,16 @@ SLOW_TIMEOUT_MULTIPLIER = 2
 
 # default configurations for tests
 TOOLS = {
-  'sexpr-wasm': {
-    'EXE': '%(sexpr-wasm)s',
+  'wast2wasm': {
+    'EXE': '%(wast2wasm)s',
     'VERBOSE-FLAGS': ['-v']
   },
   'run-roundtrip': {
     'EXE': 'test/run-roundtrip.py',
     'FLAGS': ' '.join([
       '-v',
-      '-e', '%(sexpr-wasm)s',
-      '--wasm-wast-executable=%(wasm-wast)s',
+      '--wast2wasm-executable=%(wast2wasm)s',
+      '--wasm2wast-executable=%(wasm2wast)s',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
     ]),
@@ -73,7 +73,7 @@ TOOLS = {
   'run-interp': {
     'EXE': 'test/run-interp.py',
     'FLAGS': ' '.join([
-      '-e', '%(sexpr-wasm)s',
+      '--wast2wasm-executable', '%(wast2wasm)s',
       '--wasm-interp-executable=%(wasm-interp)s',
       '--run-all-exports',
       '--no-error-cmdline',
@@ -89,7 +89,7 @@ TOOLS = {
   'run-interp-spec': {
     'EXE': 'test/run-interp.py',
     'FLAGS': ' '.join([
-      '-e', '%(sexpr-wasm)s',
+      '--wast2wasm-executable', '%(wast2wasm)s',
       '--wasm-interp-executable=%(wasm-interp)s',
       '--spec',
       '--no-error-cmdline',
@@ -105,7 +105,7 @@ TOOLS = {
   'run-gen-wasm': {
     'EXE': 'test/run-gen-wasm.py',
     'FLAGS': ' '.join([
-      '--wasm-wast-executable=%(wasm-wast)s',
+      '--wasm2wast-executable=%(wasm2wast)s',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
     ]),
@@ -133,7 +133,7 @@ TOOLS = {
   }
 }
 
-ROUNDTRIP_TOOLS = ('sexpr-wasm',)
+ROUNDTRIP_TOOLS = ('wast2wasm',)
 
 
 def Indent(s, spaces):
@@ -213,8 +213,8 @@ class TestInfo(object):
     self.input_ = []
     self.expected_stdout = ''
     self.expected_stderr = ''
-    self.tool = 'sexpr-wasm'
-    self.exe = '%(sexpr-wasm)s'
+    self.tool = 'wast2wasm'
+    self.exe = '%(wast2wasm)s'
     self.flags = []
     self.last_cmd = ''
     self.expected_error = 0
@@ -234,7 +234,7 @@ class TestInfo(object):
     result.expected_stderr = ''
     result.tool = 'run-roundtrip'
     result.exe = ROUNDTRIP_PY
-    result.flags = ['-e', '%(sexpr-wasm)s', '--wasm-wast', '%(wasm-wast)s',
+    result.flags = ['--wast2wasm', '%(wast2wasm)s', '--wasm2wast', '%(wasm2wast)s',
                     '-v']
     result.expected_error = 0
     result.slow = self.slow
@@ -663,10 +663,10 @@ def main(args):
                       help='directory to search for all executables. '
                           'This can be overridden by the other executable '
                           'flags.')
-  parser.add_argument('-e', '--sexpr-wasm-executable', metavar='PATH',
+  parser.add_argument('--wast2wasm-executable', metavar='PATH',
                       help='override executable.')
-  parser.add_argument('--wasm-wast-executable', metavar='PATH',
-                      help='override wasm-wast executable.')
+  parser.add_argument('--wasm2wast-executable', metavar='PATH',
+                      help='override wasm2wast executable.')
   parser.add_argument('--wasm-interp-executable', metavar='PATH',
                       help='override wasm-interp executable.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
@@ -708,20 +708,17 @@ def main(args):
     return 1
 
   if options.exe_dir:
-    if not options.sexpr_wasm_executable:
-      options.sexpr_wasm_executable = os.path.join(options.exe_dir,
-                                                   'sexpr-wasm')
-    if not options.wasm_wast_executable:
-      options.wasm_wast_executable = os.path.join(options.exe_dir,
-                                                  'wasm-wast')
+    if not options.wast2wasm_executable:
+      options.wast2wasm_executable = os.path.join(options.exe_dir, 'wast2wasm')
+    if not options.wasm2wast_executable:
+      options.wasm2wast_executable = os.path.join(options.exe_dir, 'wasm2wast')
     if not options.wasm_interp_executable:
       options.wasm_interp_executable = os.path.join(options.exe_dir,
                                                     'wasm-interp')
 
   variables = {
-    'sexpr-wasm':
-        find_exe.GetSexprWasmExecutable(options.sexpr_wasm_executable),
-    'wasm-wast': find_exe.GetWasmWastExecutable(options.wasm_wast_executable),
+    'wast2wasm': find_exe.GetSexprWasmExecutable(options.wast2wasm_executable),
+    'wasm2wast': find_exe.GetWasmWastExecutable(options.wasm2wast_executable),
     'wasm-interp':
         find_exe.GetWasmInterpExecutable(options.wasm_interp_executable),
   }


### PR DESCRIPTION
This is followup to (#102) which renamed the executable
files.  It propagated the rename the tools and test
runner.

It also fixes the 'run-tests' target which was passing
the wrong argument name to the run_tests.py script.